### PR TITLE
Improve rooms list to use actual server-side room names

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use crate::home::rooms_list::RoomListAction;
-use crate::home::chat_screen::*;
+use crate::home::room_screen::*;
 use crate::shared::stack_navigation::*;
 use crate::shared::stack_view_action::StackViewAction;
 use makepad_widgets::*;
@@ -10,7 +10,7 @@ live_design! {
     import makepad_widgets::theme_desktop_dark::*;
 
     import crate::home::home_screen::HomeScreen
-    import crate::home::chat_screen::RoomScreen
+    import crate::home::room_screen::RoomScreen
     import crate::contacts::contacts_screen::ContactsScreen
     import crate::contacts::add_contact_screen::AddContactScreen
     import crate::discover::discover_screen::DiscoverScreen
@@ -236,7 +236,7 @@ impl LiveHook for App {
         // home - chats
         crate::home::home_screen::live_design(cx);
         crate::home::rooms_list::live_design(cx);
-        crate::home::chat_screen::live_design(cx);
+        crate::home::room_screen::live_design(cx);
 
         // contacts
         crate::contacts::contacts_screen::live_design(cx);
@@ -313,13 +313,13 @@ impl App {
     fn update_rooms_list_info(&mut self, actions: &WidgetActions) {
         for action in actions {
             // Handle the user selecting a RoomPreview to view.
-            if let RoomListAction::Selected { room_index, room_id } = action.action() {
+            if let RoomListAction::Selected { room_index, room_id, room_name } = action.action() {
                 let stack_navigation = self.ui.stack_navigation(id!(navigation));
                 
                 // Update the title of the room screen
                 stack_navigation.set_title(
                     live_id!(rooms_stack_view),
-                    &format!("Room {}", room_id),
+                    room_name.unwrap_or_else(|| format!("Room {}", room_id)),
                 );
 
                 // Get a reference to the Timeline within the new RoomScreen to be displayed.

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -1,3 +1,3 @@
 pub mod rooms_list;
-pub mod chat_screen;
+pub mod room_screen;
 pub mod home_screen;

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1,3 +1,6 @@
+//! A room screen is the UI page that displays a single Room's timeline of events/messages
+//! along with a message input bar at the bottom.
+
 use makepad_widgets::*;
 use matrix_sdk::ruma::{
     MilliSecondsSinceUnixEpoch,
@@ -343,6 +346,12 @@ live_design! {
         }
     }
 
+    // TODO: in the future, use this to display a loading animation while pagination status is `Paginating`.
+    TopSpace = <View> {
+        width: Fill,
+        height: 0.0
+    }
+
     Timeline = {{Timeline}} {
         width: Fill,
         height: Fill,
@@ -355,7 +364,7 @@ live_design! {
             flow: Down
     
             // Below, we must place all of the possible views that can be used in the portal list.
-            TopSpace = <View> {height: 80}
+            TopSpace = <TopSpace> {}
             Message = <Message> {}
             SmallStateEvent = <SmallStateEvent> {}
             Empty = <Empty> {}

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -137,6 +137,7 @@ pub enum RoomListAction {
         /// The index (into the `all_rooms` vector) of the selected `RoomPreviewEntry`.
         room_index: RoomIndex,
         room_id: OwnedRoomId,
+        room_name: Option<String>,
     },
     None,
 }
@@ -218,12 +219,14 @@ impl RoomsList {
         let widget_uid = self.widget_uid();
         for (room_index, action) in actions {
             if let ClickableViewAction::Click = action.action() {
+                let room_details = &self.all_rooms[room_index];
                 dispatch_action(
                     cx,
                     WidgetActionItem::new(
                         RoomListAction::Selected {
                             room_index,
-                            room_id: self.all_rooms[room_index].room_id.clone().unwrap(),
+                            room_id: room_details.room_id.clone().unwrap(),
+                            room_name: room_details.room_name.clone(),
                         }.into(),
                         widget_uid,
                     )

--- a/src/shared/stack_navigation.rs
+++ b/src/shared/stack_navigation.rs
@@ -295,10 +295,10 @@ impl StackNavigationRef {
         }
     }
 
-    pub fn set_title(&self, stack_view_id: LiveId, title: &str) {
+    pub fn set_title<S: AsRef<str>>(&self, stack_view_id: LiveId, title: S) {
         if let Some(mut inner) = self.borrow_mut() {
             let stack_view_ref = inner.stack_navigation_view(&[stack_view_id]);
-            stack_view_ref.label(id!(title)).set_text(title);
+            stack_view_ref.label(id!(title)).set_text(title.as_ref());
         }
     }
 }


### PR DESCRIPTION
Collapse `TopSpace` within the timeline view.

Properly rename `chat_screen` to `room_screen`