### PR TITLE
Auto-refresh rooms list view upon a background room update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-platform",
  "makepad-vector",
@@ -2032,22 +2032,22 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2057,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2083,17 +2083,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-micro-serde-derive",
 ]
@@ -2101,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2109,12 +2109,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-futures",
  "makepad-futures-legacy",
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "ttf-parser",
 ]
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2154,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2165,16 +2165,16 @@ dependencies = [
 [[package]]
 name = "makepad-windows"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
- "windows-core 0.51.1 (git+https://github.com/makepad/makepad)",
+ "windows-core 0.51.1 (git+https://github.com/makepad/makepad?branch=rik)",
  "windows-targets",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "bitflags 2.4.1",
 ]
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "simd-adler32",
 ]
@@ -2190,7 +2190,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -5010,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad#a304fc2a9fcb59c49af12410fe839652a266b3bd"
+source = "git+https://github.com/makepad/makepad?branch=rik#2f63bb327e5b36fa5e879cf1a825f0ace2da04ba"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.17"
 url = "2.2.2"
 
-makepad-widgets = { git = "https://github.com/makepad/makepad" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -195,7 +195,7 @@ live_design! {
                             content = {
                                 title_container = {
                                     title = {
-                                        text: " "
+                                        text: ""
                                     }
                                 }
                             }
@@ -297,6 +297,7 @@ impl MatchEvent for App {
 
 impl AppMain for App {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
+        // Forward events to the MatchEvent trait impl, and then to the App's UI element.
         self.match_event(cx, event);
         self.ui.handle_event(cx, event, &mut Scope::empty());
     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -438,9 +438,12 @@ pub struct Timeline {
 
     // TODO: figure out how to remove the option whilst deriving `Live`.
     #[rust] room_id: Option<OwnedRoomId>,
+    /// The index in [`RoomsList::all_rooms`] where this room is located.
     #[rust] room_index: usize,
 
-    // Set to `true` once this room's timeline has been fully paginated.
+    /// Whether this room's timeline has been fully paginated, which means
+    /// that the oldest (first) event in the timeline is locally synced and available.
+    /// When `true`, further backwards pagination requests will not be sent.
     #[rust] fully_paginated: bool,
 }
 

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -160,9 +160,9 @@ pub struct RoomPreviewEntry {
 pub struct RoomsList {
     #[deref] view: View,
 
-    // The list of all known rooms and their cached preview info.
+    /// The list of all known rooms and their cached preview info.
     #[rust] all_rooms: Vec<RoomPreviewEntry>,
-    // Maps the widget uid (of a room preview) to the index in the `all_rooms` vector.
+    /// Maps the WidgetUid of a `RoomPreview` to that room's index in the `all_rooms` vector.
     #[rust] rooms_list_map: HashMap<u64, usize>,
 }
 
@@ -170,10 +170,17 @@ impl LiveHook for RoomsList {
     fn after_new_from_doc(&mut self, _cx: &mut Cx) { }
 }
 
+
 impl Widget for RoomsList {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        let widget_uid = self.widget_uid();
+        // Currently, a Signal event is only used to tell this widget
+        // that the rooms list has been updated in the background.
+        if let Event::Signal = event {
+            self.redraw(cx);
+        }
 
+        // Now, handle any actions on this widget, e.g., a user selecting a room.
+        let widget_uid = self.widget_uid();
         for list_action in cx.capture_actions(|cx| self.view.handle_event(cx, event, scope)) {
             if let ClickableViewAction::Click = list_action.as_widget_action().cast() {
                 let widget_action = list_action.as_widget_action();

--- a/src/shared/stack_navigation.rs
+++ b/src/shared/stack_navigation.rs
@@ -201,6 +201,10 @@ impl StackNavigation {
         }
     }
 
+    /// Returns the list of currently active views.
+    ///
+    /// It is possible for multiple views to be active because
+    /// one view may be animating out while another view is animating in.
     fn get_active_views(&mut self, cx: &mut Cx) -> Vec<WidgetRef> {
         match self.active_stack_view {
             ActiveStackView::None => {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, bail};
 use clap::Parser;
 use futures_util::{StreamExt, pin_mut};
 use imbl::Vector;
+use makepad_widgets::Signal;
 use matrix_sdk::{
     Client,
     ruma::{
@@ -398,6 +399,10 @@ async fn async_main_loop() -> Result<()> {
                                         timeline_items: items,
                                         pagination_status_task: None,
                                     });
+
+                                    // now that we've updated the room list, signal the UI to refresh.
+                                    Signal::set_ui_signal();
+
                                     tl_arc
                                 }
                             }


### PR DESCRIPTION
Currently we just use a basic UI signal for this, but we can definitely be smarter and more efficient about it in the future.

Upgraded to latest commit from the `rik` branch of makepad.