### PR TITLE
Fully update list of all rooms for any event that affects a room preview

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod contacts;
 mod discover;
 mod home;
 mod profile;
-mod shared;
+pub mod shared;
 
 // Matrix stuff
 pub mod sliding_sync;


### PR DESCRIPTION
* The RoomsList widget now handles these updates:
  * adding a new room
  * updating the room's name
  * updating the room's avatar
  * any event occurring (which becomes the "latest" event)

* We now spawn a separate async task to fetch room avatar images, which speeds up handling large batches of updates in the main sync loop.

* The RoomsList now handles updates in the `handle_event()` callback
  instead of in the draw function, which is better, faster, easier to understand,
  and more similar to how timeline widgets handle their updates.

* Address all compiler warnings, just to assuage the worrisome :)