### PR TITLE
Enable lazy loading of user profiles for only the room members that have sent events

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -535,8 +535,10 @@ impl TimelineRef {
             println!("Note: skipping pagination request for room {} because it is already fully paginated.", room_id);
         }
 
-        // if this is the first time showing this room, then kick off a request to fetch the room's members.
-        if first_time_showing_room {
+        // Note: this isn't required any more because we now specify that room member profiles
+        //       (of any users that sent messages in the room) should be lazy-loaded ("$LAZY" required state)
+        //       by the initial sliding sync request.
+        if false && first_time_showing_room {
             submit_async_request(MatrixRequest::FetchRoomMembers { room_id });
         }
     }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -371,6 +371,7 @@ async fn async_main_loop() -> Result<()> {
         .required_state(vec![ // we want to know immediately:
             (StateEventType::RoomEncryption, "".to_owned()),  // is it encrypted
             (StateEventType::RoomMember, "$LAZY".to_owned()), // lazily fetch room member profiles for users that have sent events
+            // (StateEventType::RoomMember, "$ME".to_owned()),   // fetch profile for "me", the currently logged-in user (optiona, not yet needed)
             (StateEventType::RoomCreate, "".to_owned()),      // room creation type
             (StateEventType::RoomName,   "".to_owned()),      // the room's displayable name
             (StateEventType::RoomTopic,  "".to_owned()),      // any topic if known


### PR DESCRIPTION
Thus, there is no need to do a full room member fetch/sync upon viewing a room for the first time, which is good because that is *incredibly* slow for large rooms.