### PR TITLE
Move timeline item management into a background async task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1869,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-platform",
  "makepad-vector",
@@ -1880,22 +1880,22 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1913,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1931,17 +1931,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-micro-serde-derive",
 ]
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1957,12 +1957,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-futures",
  "makepad-futures-legacy",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "ttf-parser",
 ]
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2002,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "makepad-windows"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "windows-core 0.51.1 (git+https://github.com/makepad/makepad?branch=rik)",
  "windows-targets",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "bitflags 2.4.1",
 ]
@@ -2030,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "simd-adler32",
 ]
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4788,7 +4788,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#1e5cc06507da6180374262b8b85bcb84011b17eb"
+source = "git+https://github.com/makepad/makepad?branch=rik#be75272c2087aa441557a580c83ca668268cb6dc"
 dependencies = [
  "windows-targets",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -284,7 +284,7 @@ impl MatchEvent for App {
             ),
         );
 
-        self.update_rooms_list_info(&actions);
+        self.handle_rooms_list_action(&actions);
 
         let mut navigation = self.ui.stack_navigation(id!(navigation));
         navigation.handle_stack_view_actions(
@@ -312,16 +312,16 @@ impl App {
         self.navigation_destinations.insert(StackViewAction::ShowRoom, live_id!(rooms_stack_view));
     }
 
-    fn update_rooms_list_info(&mut self, actions: &Actions) {
+    fn handle_rooms_list_action(&mut self, actions: &Actions) {
         for action in actions {
-            // Handle the user selecting a RoomPreview to view.
+            // Handle the user selecting a room to view (a RoomPreview in the RoomsList).
             if let RoomListAction::Selected { room_index: _, room_id, room_name } = action.as_widget_action().cast() {
                 let stack_navigation = self.ui.stack_navigation(id!(navigation));
                 
-                // Update the title of the room screen
+                // Set the title of the RoomScreen's header to the room name.
                 stack_navigation.set_title(
                     live_id!(rooms_stack_view),
-                    room_name.unwrap_or_else(|| format!("Room {}", room_id)),
+                    room_name.unwrap_or_else(|| format!("Room {}", &room_id)),
                 );
 
                 // Get a reference to the Timeline within the new RoomScreen to be displayed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub use makepad_widgets;
 pub mod app;
 mod contacts;
 mod discover;
-mod home;
+pub mod home;
 mod profile;
 pub mod shared;
 

--- a/src/shared/dropdown_menu.rs
+++ b/src/shared/dropdown_menu.rs
@@ -40,7 +40,7 @@ live_design! {
                     self.pressed
                 )
             }
-         }
+        }
 
         icon_walk: { width: 20., height: Fit}
 
@@ -124,8 +124,8 @@ pub struct WechatDropDown {
 }
 
 impl LiveHook for WechatDropDown {
-    fn after_apply(&mut self, cx: &mut Cx, from: ApplyFrom, _index: usize, _nodes: &[LiveNode]) {
-        if self.popup_menu.is_none() || !from.is_from_doc() {
+    fn after_apply_from(&mut self, cx: &mut Cx, apply: &mut Apply) {
+        if self.popup_menu.is_none() || !apply.from.is_from_doc() {
             return;
         }
         let global = cx.global::<PopupMenuGlobal>().clone();

--- a/src/shared/popup_menu.rs
+++ b/src/shared/popup_menu.rs
@@ -196,10 +196,10 @@ pub struct PopupMenu {
 }
 
 impl LiveHook for PopupMenu {
-    fn after_apply(&mut self, cx: &mut Cx, from: ApplyFrom, index: usize, nodes: &[LiveNode]) {
+    fn after_apply(&mut self, cx: &mut Cx, apply: &mut Apply, index: usize, nodes: &[LiveNode]) {
         if let Some(index) = nodes.child_by_name(index, live_id!(list_node).as_field()) {
             for (_, node) in self.menu_items.iter_mut() {
-                node.apply(cx, from, index, nodes);
+                node.apply(cx, apply, index, nodes);
             }
         }
         self.draw_list.redraw(cx);


### PR DESCRIPTION
* There's no need to have the Timeline UI widget do this as part of a UI action handler. Instead, we now apply the incoming timeline diffs to the timeline items list within a background async task, and then just send a reference to the update items list to the UI threads using the existing `TimelineUpdate` sender.

* Also, update to latest Makepad version.