### PR TITLE
Clear message input box after sending message

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -57,6 +57,7 @@ live_design! {
                         padding: 0, align: {x: 0.0, y: 0.0}, spacing: 0., flow: Down
 
                         application_pages = <View> {
+                            width: Fill,
                             margin: 0.0,
                             padding: 0.0
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -497,7 +497,7 @@ live_design! {
         align: {x: 0.5, y: 0.0} // center horizontally, align to top vertically
 
         list = <PortalList> {
-            auto_tail: false, // set to `true` to lock the view to the last item.
+            auto_tail: true, // set to `true` to lock the view to the last item.
             height: Fill,
             width: Fill
             flow: Down
@@ -622,7 +622,9 @@ impl Widget for RoomScreen {
         // Handle actions on this widget, e.g., it being hidden or shown.
         if let Event::Actions(actions) = event {
             if self.button(id!(send_message_button)).clicked(&actions) {
-                let entered_text = self.text_input(id!(message_input)).text();
+                let msg_input_widget = self.text_input(id!(message_input));
+                let entered_text = msg_input_widget.text();
+                msg_input_widget.set_text_and_redraw(cx, "");
                 if !entered_text.is_empty() {
                     let room_id = self.room_id.clone().unwrap();
                     println!("Sending message to room {}: {:?}", room_id, entered_text);

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -64,14 +64,16 @@ live_design! {
     Empty = <View> { }
 
     StatusLabel = <View> {
-        width: Fill, height: 80.0,
+        width: Fill, height: Fit,
         align: { x: 0.5, y: 0.5 }
+        padding: 15.0,
         draw_bg: {
             color: #f4f4f4
         }
         show_bg: true,
 
         label = <Label> {
+            align: { x: 0.5, y: 0.5 }
             draw_text: {
                 wrap: Word,
                 text_style: <REGULAR_TEXT>{}
@@ -306,9 +308,15 @@ impl Widget for RoomsList {
                     let item = list.item(cx, item_id, live_id!(status_label)).unwrap();
                     if count > 0 {
                         let text = format!("Found {count} joined rooms.");
-                        item.label(id!(label)).set_text(&text);
+                        item.as_view().apply_over(cx, live!{
+                            height: 80.0,
+                            label = { text: (text) }
+                        });
                     } else {
-                        item.label(id!(label)).set_text(&self.status);
+                        item.as_view().apply_over(cx, live!{
+                            height: 500.0,
+                            label = { text: (&self.status) }
+                        });
                     }
                     item
                 }

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -46,7 +46,8 @@ live_design! {
             }
             
             text = <Label> {
-                width: Fit, height: Fit
+                padding: { top: 3.0 }
+                // width: Fit, height: Fit,
                 draw_text: {
                     text_style: <TITLE_TEXT>{ font_size: 15. }
                 }

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -46,8 +46,8 @@ live_design! {
             }
             
             text = <Label> {
-                padding: { top: 3.0 }
-                // width: Fit, height: Fit,
+                width: Fit, height: Fit,
+                padding: { top: 3.0 } // for better vertical alignment
                 draw_text: {
                     text_style: <TITLE_TEXT>{ font_size: 15. }
                 }


### PR DESCRIPTION
* Enable auto-tail to auto scroll to display new message if the timeline was already scrolled to the end of the list.

* Minor improvements to display of status messages, but the `apply_over()` function doesn't accept the `Fill`/`Fit` values for the `Size` enum that we actually need to use.