### PR TITLE
Ensure the rooms list is always freshly updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "ab_glyph_rasterizer",
  "makepad-platform",
@@ -1895,17 +1895,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1913,12 +1913,12 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1954,17 +1954,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-micro-serde-derive",
 ]
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1980,12 +1980,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-futures",
  "makepad-futures-legacy",
@@ -2000,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "ttf-parser",
 ]
@@ -2016,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2037,16 +2037,16 @@ dependencies = [
 [[package]]
 name = "makepad-windows"
 version = "0.51.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
- "windows-core 0.51.1 (git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api)",
+ "windows-core 0.51.1 (git+https://github.com/makepad/makepad?branch=rik)",
  "windows-targets",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "bitflags 2.4.1",
 ]
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "simd-adler32",
 ]
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4838,7 +4838,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.51.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=extend_portal_list_item_api#6f0a560e9958d514b69fd9d83510d80a8ed1ea0a"
+source = "git+https://github.com/makepad/makepad?branch=rik#7f04a544373ea401c43e46c1713120c1cfebf649"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "extend_portal_list_item_api" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
 
 
 anyhow = "1.0"

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -204,10 +204,8 @@ pub struct RoomsList {
 
 impl Widget for RoomsList {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        // Currently, a Signal event is only used to tell this widget
-        // that the rooms list has been updated in the background.
-        if let Event::Signal = event {
-            // Process all pending updates to the list of all rooms, and then redraw it.
+        // Process all pending updates to the list of all rooms, and then redraw it.
+        {
             let mut num_updates: usize = 0;
             while let Some(update) = PENDING_ROOM_UPDATES.pop() {
                 num_updates += 1;

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -701,6 +701,7 @@ async fn timeline_subscriber_handler(
 ) {
     log!("Starting timeline subscriber for room {room_id}...");
     let (mut timeline_items, mut subscriber) = timeline.subscribe_batched().await;
+    log!("Received initial timeline update for room {room_id}.");
 
     sender.send(TimelineUpdate::NewItems {
         items: timeline_items.clone(),


### PR DESCRIPTION
Sometimes an `Event::Signal` gets lost (applied to a different event generation), so we were missing them in the rooms_list event handler. This manifested as some rooms failing to be displayed if they were discovered after a user had clicked away from the rooms_list screen and then navigated back to the screen.

Now, we check for updates to the rooms on every event handler, which ensures we never miss any updates even if an `Event::Signal` was missed.