### PR TITLE
Use stack navigation actions to show/hide a room timeline

### DIFF
--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -32,6 +32,7 @@ live_design! {
                 width: Fill, height: Fit
                 draw_text:{
                     color: #000,
+                    wrap: Ellipsis,
                     text_style: <REGULAR_TEXT>{}
                 }
                 text: "[Room name unknown]"


### PR DESCRIPTION
This is strictly better than showing/hiding a room upon the `set_displayed_room()`, which might be too early in the event flow.

There are still some minor issues with the StackNavigation widget not delivering all show/hide actions if you navigate *very quickly* back and forth between a stacknav view and the root_view, but that requires a separate fix.