### PR TITLE
Remove native dependencies in favor of rustls and sqlite-bundled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,21 +1078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,19 +1449,6 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -2547,24 +2519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,58 +2635,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "300.2.2+3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfad0063610ac26ee79f7484739e2b07555a75c42453b89263830b5c8103bc"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -3321,21 +3227,22 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -3343,6 +3250,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3409,9 +3317,7 @@ dependencies = [
  "makepad-widgets",
  "matrix-sdk",
  "matrix-sdk-ui",
- "openssl",
  "rangemap",
- "rusqlite",
  "tokio",
  "tracing-subscriber",
  "unicode-segmentation",
@@ -4270,16 +4176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4797,6 +4693,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "wildmatch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,21 @@ eyeball-im = "0.4.2"
 futures-util = "0.3"
 imbl = { version = "2.0.0", features = ["serde"] }  # same as matrix-sdk-ui
 imghdr = "0.7.0"
-matrix-sdk = { git = "https://github.com/matrix-org/matrix-rust-sdk", features = [ "experimental-sliding-sync" ] }
-matrix-sdk-ui = { git = "https://github.com/matrix-org/matrix-rust-sdk" }
+matrix-sdk = { git = "https://github.com/matrix-org/matrix-rust-sdk", default-features = false, features = [ "experimental-sliding-sync", "e2e-encryption", "automatic-room-key-forwarding", "sqlite", "rustls-tls", "bundled-sqlite" ] }
+matrix-sdk-ui = { git = "https://github.com/matrix-org/matrix-rust-sdk", default-features = false, features = [ "e2e-encryption", "rustls-tls" ] }
 rangemap = "1.5.0"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.17"
 unicode-segmentation = "1.10.1"
 url = "2.2.2"
 
+
+###################################################################################################
+#### Note: we now enable the usage of `rustls-tls` and the `bundled-sqlite` features in the 2  ####
+####       matrix crate dependencies, so the below android- and windows-specific dependencies  ####
+####       are no longer needed. However, if you wish to disable those features, you would     ####
+####       need to re-enable the below target-specific dependencies.                           ####
+###################################################################################################
 
 ## On Android, we currently build OpenSSL and SQLite from
 ## the vendored source code, because on macOS hosts there aren't yet
@@ -54,9 +61,10 @@ url = "2.2.2"
 ## but there's no way to specify that in Cargo.toml, so we just always include them.
 ## Plus, this makes builds more reproducible across host systems,
 ## and avoids the issue of needing to set up pkg-config sysroots on Linux.
-[target.'cfg(target_os = "android")'.dependencies]
-openssl = { version = "*", features = ["vendored"] }
-rusqlite = { version = "*", features = ["bundled"] }
+##
+# [target.'cfg(target_os = "android")'.dependencies]
+# openssl = { version = "*", features = ["vendored"] }
+# rusqlite = { version = "*", features = ["bundled"] }
 
 ## On Windows, there are prebuilt versions of sqlite3 available,
 ## but building it from bundled source is just easier and works out of the box.
@@ -68,8 +76,9 @@ rusqlite = { version = "*", features = ["bundled"] }
 ## directly from the sqlite website: <https://www.sqlite.org/download.html>,
 ## where you'll want the 64-bit DLL (x64) under "Precompiled Binaries for Windows".
 ## You'll need to add the directory of that prebuilt sqlite DLL to your path env variable.
-[target.'cfg(target_os = "windows")'.dependencies]
-rusqlite = { version = "*", features = ["bundled"] }
+##
+# [target.'cfg(target_os = "windows")'.dependencies]
+# rusqlite = { version = "*", features = ["bundled"] }
 
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This VASTLY simplifies building for Android and Windows targets.