### PR TITLE
Properly handle events when the user profile pane is shown

### DIFF
--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -180,7 +180,7 @@ live_design! {
                 width: Fill, height: Fit
                 padding: {left: 15}
                 draw_text: {
-                    wrap: Line,
+                    wrap: Word,
                     text_style: <USERNAME_TEXT_STYLE>{},
                     color: #000
                 }
@@ -427,6 +427,14 @@ impl Widget for UserProfileSlidingPane {
 }
 
 impl UserProfileSlidingPaneRef {
+    /// Returns `true` if the pane is both currently visible *and*
+    /// animator is in the `show` state.
+    pub fn is_currently_shown(&self, cx: &mut Cx) -> bool {
+        self.borrow().map_or(false, |inner|
+            inner.visible && inner.animator_in_state(cx, id!(panel.show))
+        )
+    }
+
     pub fn set_info(&self, info: UserProfileInfo) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.info = Some(info);
@@ -441,4 +449,6 @@ impl UserProfileSlidingPaneRef {
             inner.redraw(cx);
         }
     }
+
+
 }


### PR DESCRIPTION
Events that flow into the RoomScreen either get forwarded to the underlying timeline view or the user profile sliding pane. If the pane is currently shown, mouse/touch/tap events are forwarded to the pane *ONLY*, and not the underlying timeline. Other events (e.g., draw events) are always forwarded to the underlying timeline.
If the pane is not shown, events are also forwarded to the timeline view, as normal.

Solution suggested by @jmbejar.