### PR TITLE
sliding pane: set the default animation state to "hide"

### DIFF
--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -312,7 +312,7 @@ live_design! {
 
         animator: {
             panel = {
-                default: show,
+                default: hide,
                 show = {
                     redraw: true,
                     from: {all: Forward {duration: 0.4}}


### PR DESCRIPTION
This fixes a jitter issue when the sliding pane is shown for the very first time, as the state of it being "shown" without it actually having been shown previously is wrong.
Now the animation is always smooth, even on the first sequence.