### PR TITLE
Use new Makepad version to reduce/remove clones and mutable pre-borrows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1940,7 +1940,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1972,17 +1972,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2001,7 +2001,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2019,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2045,17 +2045,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-micro-serde-derive",
 ]
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2071,12 +2071,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-android-state",
  "makepad-futures",
@@ -2094,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "ttf-parser",
 ]
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "makepad-windows"
 version = "0.51.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "windows-core 0.51.1 (git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack)",
  "windows-targets 0.48.5",
@@ -2156,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "bitflags 2.4.1",
 ]
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "simd-adler32",
 ]
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4584,7 +4584,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "ttf-parser"
 version = "0.19.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 
 [[package]]
 name = "typenum"
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.51.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#13eed69ec1f987cbf9ec80d0d1fa4aed5d7e8242"
+source = "git+https://github.com/kevinaboos/makepad?branch=rik_with_old_font_stack#c3075a9cbc4a7362966e396ac2ab274ef9d51936"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/src/shared/modal.rs
+++ b/src/shared/modal.rs
@@ -71,7 +71,7 @@ impl WidgetNode for Modal {
         self.view.redraw(cx);
     }
 
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
         self.view.find_widgets(path, cached, results);
     }
 }

--- a/src/shared/portal.rs
+++ b/src/shared/portal.rs
@@ -48,7 +48,7 @@ impl WidgetNode for PortalView {
         self.view.redraw(cx);
     }
 
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
         self.view.find_widgets(path, cached, results);
     }
 }
@@ -147,7 +147,7 @@ impl WidgetNode for Portal {
         }
     }
 
-    fn find_widgets(&mut self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
+    fn find_widgets(&self, path: &[LiveId], cached: WidgetCache, results: &mut WidgetSet) {
         self.view.find_widgets(path, cached, results);
     }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -837,7 +837,7 @@ async fn timeline_subscriber_handler(
 
     let send_update = |timeline_items: Vector<Arc<TimelineItem>>, changed_indices: Range<usize>, clear_cache: bool, num_updates: usize| {
         if num_updates > 0 {
-            log!("timeline_subscriber: applied {num_updates} updates for room {room_id}, timeline now has {} items. Clear cache? {clear_cache}. Changes: {changed_indices:?}.", timeline_items.len());
+            // log!("timeline_subscriber: applied {num_updates} updates for room {room_id}, timeline now has {} items. Clear cache? {clear_cache}. Changes: {changed_indices:?}.", timeline_items.len());
             sender.send(TimelineUpdate::NewItems {
                 items: timeline_items,
                 changed_indices,
@@ -849,7 +849,7 @@ async fn timeline_subscriber_handler(
         }
     };
 
-    const LOG_DIFFS: bool = true;
+    const LOG_DIFFS: bool = false;
 
     while let Some(batch) = subscriber.next().await {
         let mut num_updates = 0;


### PR DESCRIPTION
See this: <https://github.com/makepad/makepad/pull/497>

Also, clean up extraneous logging from prior PRs.