### PR TITLE
Post-`ignore_user` pagination does work to refill the cleared timeline.

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -995,6 +995,7 @@ impl Widget for Timeline {
                         if clear_cache {
                             tl.content_drawn_since_last_update.clear();
                             tl.profile_drawn_since_last_update.clear();
+                            tl.fully_paginated = false;
                         } else {
                             tl.content_drawn_since_last_update.remove(changed_indices.clone());
                             tl.profile_drawn_since_last_update.remove(changed_indices.clone());


### PR DESCRIPTION
But, there are still a couple of things we need to fix up:
* saving which event ID is currently shown on each timeline, such that we can jump back to displaying that event after the timelines get cleared and then refilled.
* subscribing to an ignored user stream, such that we can receive an update when the current logged-in user (un)ignores someone from a different client that we do not control.
  * See `Client::subscribe_to_ignore_user_list_changes()`: <https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk/struct.Client.html#method.subscribe_to_ignore_user_list_changes>

Ideally we also do not want to re-paginate _all_ rooms, just the ones that were already (partially) paginated.