### PR TITLE
Use the user profile cache as a fallback for usernames/avatars

### DIFF
--- a/src/avatar_cache.rs
+++ b/src/avatar_cache.rs
@@ -1,0 +1,101 @@
+use std::{cell::RefCell, collections::{btree_map::Entry, BTreeMap}, sync::Arc};
+use crossbeam_queue::SegQueue;
+use makepad_widgets::{Cx, SignalToUI};
+use matrix_sdk::ruma::{MxcUri, OwnedMxcUri};
+
+use crate::sliding_sync::{submit_async_request, MatrixRequest};
+
+
+thread_local! {
+    /// A cache of Avatar images, indexed by Matrix URI.
+    ///
+    /// To be of any use, this cache must only be accessed by the main UI thread.
+    static AVATAR_NEW_CACHE: RefCell<BTreeMap<OwnedMxcUri, AvatarCacheEntry>> = RefCell::new(BTreeMap::new());
+}
+
+/// An entry in the avatar cache.
+#[derive(Clone)]
+pub enum AvatarCacheEntry {
+    Loaded(Arc<[u8]>),
+    Requested,
+    Failed,
+}
+
+pub struct AvatarUpdate {
+    pub mxc_uri: OwnedMxcUri,
+    pub avatar_data: Result<Arc<[u8]>, matrix_sdk::Error>,
+}
+
+/// The queue of avatar updates waiting to be processed by the UI thread's event handler.
+static PENDING_AVATAR_UPDATES: SegQueue<AvatarUpdate> = SegQueue::new();
+
+/// Enqueues a new avatar update and signals the UI
+/// such that the new update will be handled by the avatar sliding pane widget.
+fn enqueue_avatar_update(update: AvatarUpdate) {
+    PENDING_AVATAR_UPDATES.push(update);
+    SignalToUI::set_ui_signal();
+}
+
+/// Processes all pending avatar updates in the queue.
+///
+/// This function requires passing in a reference to `Cx`,
+/// which isn't used, but acts as a guarantee that this function
+/// must only be called by the main UI thread.
+pub fn process_avatar_updates(_cx: &mut Cx) {
+    AVATAR_NEW_CACHE.with_borrow_mut(|cache| {
+        while let Some(update) = PENDING_AVATAR_UPDATES.pop() {
+            cache.insert(
+                update.mxc_uri,
+                match update.avatar_data {
+                    Ok(data) => AvatarCacheEntry::Loaded(data),
+                    Err(_e) => AvatarCacheEntry::Failed,
+                },
+            );
+        }
+    });
+}
+
+/// Returns the cached avatar for the given Matrix URI if it exists,
+/// or submits a request to fetch it from the server if it isn't already cached.
+///
+/// This function requires passing in a reference to `Cx`,
+/// which isn't used, but acts as a guarantee that this function
+/// must only be called by the main UI thread.
+pub fn get_or_fetch_avatar(
+    _cx: &mut Cx,
+    mxc_uri: OwnedMxcUri,
+) -> AvatarCacheEntry {
+    AVATAR_NEW_CACHE.with_borrow_mut(|cache| {
+        match cache.entry(mxc_uri.clone()) {
+            Entry::Vacant(vacant) => {
+                vacant.insert(AvatarCacheEntry::Requested);
+            },
+            Entry::Occupied(occupied) => match occupied.get() {
+                entry @ AvatarCacheEntry::Loaded(_) => return entry.clone(),
+                AvatarCacheEntry::Failed => return AvatarCacheEntry::Failed,
+                AvatarCacheEntry::Requested => { }
+            },
+        }
+        
+        submit_async_request(MatrixRequest::FetchAvatar {
+            mxc_uri,
+            on_fetched: enqueue_avatar_update,
+        });
+        AvatarCacheEntry::Requested
+    })
+}
+
+/// Returns the avatar for the given user ID, if it exists.
+///
+/// This function requires passing in a reference to `Cx`,
+/// which isn't used, but acts as a guarantee that this function
+/// must only be called by the main UI thread.
+#[allow(unused)]
+pub fn get_avatar(_cx: &mut Cx, mxc_uri: &MxcUri) -> Option<Arc<[u8]>> {
+    AVATAR_NEW_CACHE.with_borrow(|cache|
+        match cache.get(mxc_uri) {
+            Some(AvatarCacheEntry::Loaded(data)) => Some(data.clone()),
+            _ => None,
+        }
+    )
+}

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -8,9 +8,7 @@ use makepad_widgets::*;
 use matrix_sdk::{ruma::{
     events::{
         room::{
-            guest_access::GuestAccess,
-            history_visibility::HistoryVisibility,
-            join_rules::JoinRule, message::{MessageFormat, MessageType, RoomMessageEventContent}, MediaSource,
+            avatar, guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule, message::{MessageFormat, MessageType, RoomMessageEventContent}, MediaSource
         },
         AnySyncMessageLikeEvent, AnySyncTimelineEvent, FullStateEventContent, SyncMessageLikeEvent,
     }, matrix_uri::MatrixId, uint, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId,
@@ -558,6 +556,7 @@ impl Widget for RoomScreen {
         // so we first check to see if it was a user profile update.
         if let Event::Signal = event {
             user_profile_cache::process_user_profile_updates(cx);
+            avatar_cache::process_avatar_updates(cx);
         }
 
         let pane = self.user_profile_sliding_pane(id!(user_profile_sliding_pane));

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -21,11 +21,7 @@ use matrix_sdk_ui::timeline::{
 
 use rangemap::RangeSet;
 use crate::{
-    media_cache::{MediaCache, MediaCacheEntry, AVATAR_CACHE},
-    profile::{user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt}, user_profile_cache},
-    shared::{avatar::{AvatarRef, AvatarWidgetRefExt}, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, text_or_image::TextOrImageWidgetRefExt},
-    sliding_sync::{get_client, submit_async_request, take_timeline_update_receiver, MatrixRequest},
-    utils::{self, unix_time_millis_to_datetime, MediaFormatConst},
+    avatar_cache::{self, AvatarCacheEntry}, media_cache::{MediaCache, MediaCacheEntry}, profile::{user_profile::{AvatarState, ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt}, user_profile_cache}, shared::{avatar::{AvatarRef, AvatarWidgetRefExt}, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, text_or_image::TextOrImageWidgetRefExt}, sliding_sync::{get_client, submit_async_request, take_timeline_update_receiver, MatrixRequest}, utils::{self, unix_time_millis_to_datetime, MediaFormatConst}
 };
 
 live_design! {
@@ -601,12 +597,12 @@ impl Widget for RoomScreen {
 
             for action in actions {
                 // Handle the action that requests to show the user profile sliding pane.
-                if let ShowUserProfileAction::ShowUserProfile(avatar_info) = action.as_widget_action().cast() {
+                if let ShowUserProfileAction::ShowUserProfile(profile_and_room_id) = action.as_widget_action().cast() {
                     timeline.show_user_profile(
                         cx,
                         &pane,
                         UserProfilePaneInfo {
-                            avatar_info,
+                            profile_and_room_id,
                             room_name: self.room_name.clone(),
                             room_member: None,
                         },
@@ -651,11 +647,11 @@ impl Widget for RoomScreen {
                                     cx,
                                     &pane,
                                     UserProfilePaneInfo {
-                                        avatar_info: UserProfileAndRoomId {
+                                        profile_and_room_id: UserProfileAndRoomId {
                                             user_profile: UserProfile {
                                                 user_id: user_id.to_owned(),
                                                 username: None,
-                                                avatar_img_data: None,
+                                                avatar_state: AvatarState::Unknown,
                                             },
                                             room_id: self.room_id.clone().unwrap(),
                                         },
@@ -1774,12 +1770,14 @@ fn set_timestamp(
 /// The specific behavior is as follows:
 /// * If the timeline event's sender profile *is* ready, then the `username` and `avatar`
 ///   will be the user's display name and avatar image, if available.
+///   * If it's not ready, we attempt to fetch the user info from the user profile cache.
 /// * If no avatar image is available, then the `avatar` will be set to the first character
 ///   of the user's display name, if available.
 /// * If the user's display name is not available or has not been set, the user ID
 ///   will be used for the `username`, and the first character of the user ID for the `avatar`.
-/// * If the timeline event's sender profile is not yet ready, then the `username` and `avatar`
-///   will be the user ID and the first character of that user ID, respectively.
+/// * If the timeline event's sender profile isn't ready and the user ID isn't found in
+///   our user profile cache , then the `username` and `avatar`  will be the user ID
+///   and the first character of that user ID, respectively.
 ///
 /// ## Return
 /// Returns a tuple of:
@@ -1792,66 +1790,54 @@ fn set_avatar_and_get_username(
     room_id: &RoomId,
     event_tl_item: &EventTimelineItem,
 ) -> (String, bool) {
-    let username: String;
-    let mut profile_drawn = false;
-
     let user_id = event_tl_item.sender();
 
-    // Set sender to the display name if available, otherwise the user id.
-    match event_tl_item.sender_profile() {
+    // Get the display name and avatar URL from the sender's profile, if available,
+    // or if the profile isn't ready, fall back to qeurying our user profile cache.
+    let (username_opt, avatar_state) = match event_tl_item.sender_profile() {
         TimelineDetails::Ready(profile) => {
-            // Set the sender's avatar image, or use a text character if no image is available.
-            let avatar_img = match profile.avatar_url.as_ref() {
-                Some(uri) => match AVATAR_CACHE.lock().unwrap().try_get_media_or_fetch(uri.clone(), None) {
-                    MediaCacheEntry::Loaded(data) => {
-                        profile_drawn = true;
-                        Some(data)
-                    }
-                    MediaCacheEntry::Failed => {
-                        profile_drawn = true;
-                        None
-                    }
-                    MediaCacheEntry::Requested => None,
-                }
-                None => {
-                    profile_drawn = true;
-                    None
-                }
-            };
-            
-            // Set the username to the display name if available, otherwise the user ID after the '@'.
-            let username_opt = profile.display_name.clone();
-            username = username_opt.clone().unwrap_or_else(|| user_id.to_string());
-
-            // Draw the avatar image if available, otherwise set the avatar to text.
-            let drew_avatar_img = avatar_img.map(|data|
-                avatar.show_image(
-                    Some((user_id.to_owned(), username_opt.clone(), room_id.to_owned(), data.clone())),
-                    |img| utils::load_png_or_jpg(&img, cx, &data)
-                ).is_ok()
-            ).unwrap_or(false);
-            
-            if !drew_avatar_img {
-                avatar.show_text(
-                    Some((user_id.to_owned(), username_opt, room_id.to_owned())),
-                    &username,
-                );
-            }
+            (profile.display_name.clone(), AvatarState::Known(profile.avatar_url.clone()))
         }
-
-        // If the profile is not ready, use the user ID for both the username and the avatar.
-        not_ready => {
-            // log!("populate_message_view(): sender profile not ready yet for event {not_ready:?}");
-            username = user_id.to_string();
-            avatar.show_text(
-                    Some((user_id.to_owned(), None, room_id.to_owned())),
-                &username,
-            );
-            // If there was an error fetching the profile, treat that condition as fully drawn,
-            // since we don't yet have a good way to re-request profile information.
-            profile_drawn = matches!(not_ready, TimelineDetails::Error(_));
+        _not_ready => {
+            // log!("populate_message_view(): sender profile not ready yet for event {_not_ready:?}");
+            user_profile_cache::with_user_profile(cx, user_id, |profile, room_members| {
+                room_members.get(room_id)
+                    .map(|rm| (
+                        rm.display_name().map(|n| n.to_owned()),
+                        AvatarState::Known(rm.avatar_url().map(|u| u.to_owned()))
+                    ))
+                    .unwrap_or_else(|| (
+                        profile.username.clone(),
+                        profile.avatar_state.clone(),
+                    ))
+                })
+                .unwrap_or((None, AvatarState::Unknown))
         }
-    }
+    };
+
+    let (avatar_img_data_opt, profile_drawn) = match avatar_state {
+        AvatarState::Loaded(data) => (Some(data), true),
+        AvatarState::Known(Some(uri)) => match avatar_cache::get_or_fetch_avatar(cx, uri) {
+            AvatarCacheEntry::Loaded(data) => (Some(data), true),
+            AvatarCacheEntry::Failed => (None, true),
+            AvatarCacheEntry::Requested => (None, false),
+        }
+        AvatarState::Known(None) | AvatarState::Failed => (None, true),
+        AvatarState::Unknown => (None, false),
+    };
+
+    // Set sender to the display name if available, otherwise the user id.
+    let username = username_opt.clone().unwrap_or_else(|| user_id.to_string());
+
+    // Set the sender's avatar image, or use the username if no image is available.
+    avatar_img_data_opt.and_then(|data| avatar.show_image(
+        Some((user_id.to_owned(), username_opt.clone(), room_id.to_owned(), data.clone())),
+        |img| utils::load_png_or_jpg(&img, cx, &data)
+    ).ok())
+    .unwrap_or_else(|| avatar.show_text(
+        Some((user_id.to_owned(), username_opt, room_id.to_owned())),
+        &username,
+    ));
 
     (username, profile_drawn)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod shared;
 
 // Matrix stuff
 pub mod sliding_sync;
+pub mod avatar_cache;
 pub mod media_cache;
 
 // UI stuff

--- a/src/media_cache.rs
+++ b/src/media_cache.rs
@@ -1,74 +1,9 @@
 use std::{sync::{Mutex, Arc}, collections::{BTreeMap, btree_map::Entry}, time::SystemTime, ops::{Deref, DerefMut}};
 use makepad_widgets::{error, log, SignalToUI};
 use matrix_sdk::{ruma::{OwnedMxcUri, events::room::MediaSource}, media::{MediaRequest, MediaFormat}};
-use crate::{home::room_screen::TimelineUpdate, sliding_sync::{self, MatrixRequest}, utils::{MediaFormatConst, MEDIA_THUMBNAIL_FORMAT}};
+use crate::{home::room_screen::TimelineUpdate, sliding_sync::{self, MatrixRequest}, utils::MediaFormatConst};
 
 pub type MediaCacheEntryRef = Arc<Mutex<MediaCacheEntry>>;
-
-pub static AVATAR_CACHE: MediaCacheLocked = MediaCacheLocked(Mutex::new(MediaCache::new(MEDIA_THUMBNAIL_FORMAT, None)));
-
-pub struct MediaCacheLocked(Mutex<MediaCache>);
-impl Deref for MediaCacheLocked {
-    type Target = Mutex<MediaCache>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl MediaCacheLocked {
-    /// Similar to [`Self::try_get_media_or_fetch()`], but immediately fires off an async request
-    /// on the current task to fetch the media, blocking until the request completes.
-    ///
-    /// Unlike other functions, this is intended for use in background tasks or other async contexts
-    /// where it is not latency-sensitive, and safe to block on the async request.
-    /// Thus, it must be implemented on the `MediaCacheLocked` type, which is safe to hold a reference to
-    /// across an await point, whereas a mutable reference to a locked `MediaCache` is not (i.e., a `MutexGuard`).
-    pub async fn get_media_or_fetch_async(
-        &self,
-        client: &matrix_sdk::Client,
-        mxc_uri: OwnedMxcUri,
-        media_format: Option<MediaFormat>,
-    ) -> Option<Arc<[u8]>> {
-        let destination = {
-            match self.lock().unwrap().entry(mxc_uri.clone()) {
-                Entry::Vacant(vacant) => vacant
-                    .insert(Arc::new(Mutex::new(MediaCacheEntry::Requested)))
-                    .clone(),
-                Entry::Occupied(occupied) => match occupied.get().lock().unwrap().deref() {
-                    MediaCacheEntry::Loaded(data) => return Some(data.clone()),
-                    MediaCacheEntry::Failed => return None,
-                    // If already requested (a fetch is in process),
-                    // we return None for now and allow the `insert_into_cache` function
-                    // emit a UI Signal when the fetch completes,
-                    // which will trigger a re-draw of the UI,
-                    // and thus a re-fetch of any visible avatars.
-                    MediaCacheEntry::Requested => return None,
-                }
-            }
-        };
-
-        let media_request = MediaRequest {
-            source: MediaSource::Plain(mxc_uri),
-            format: media_format.unwrap_or_else(|| self.lock().unwrap().default_format.clone().into()),
-        };
-
-        let res = client
-            .media()
-            .get_media_content(&media_request, true)
-            .await;
-        let res: matrix_sdk::Result<Arc<[u8]>> = res.map(|d| d.into());
-        let retval = res
-            .as_ref()
-            .ok()
-            .cloned();
-        insert_into_cache(
-            &destination,
-            media_request,
-            res,
-            None,
-        );
-        retval
-    }
-}
 
 /// An entry in the media cache. 
 #[derive(Debug, Clone)]

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -524,6 +524,7 @@ impl Widget for UserProfileSlidingPane {
         // A UI Signal indicates this user profile was updated by a background task.
         if let Event::Signal = event {
             user_profile_cache::process_user_profile_updates(cx);
+            avatar_cache::process_avatar_updates(cx);
 
             // Re-fetch the currently-displayed user profile info from the cache in case it was updated.
             let mut redraw_this_pane = false;

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -12,7 +12,7 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId};
 
 use crate::{
-    profile::user_profile::{UserProfileAndRoomId, ShowUserProfileAction, UserProfile},
+    profile::user_profile::{AvatarState, ShowUserProfileAction, UserProfile, UserProfileAndRoomId},
     utils,
 };
 
@@ -153,7 +153,7 @@ impl Avatar {
                 user_profile: UserProfile {
                     user_id,
                     username,
-                    avatar_img_data: None,
+                    avatar_state: AvatarState::Unknown,
                 },
                 room_id,
             }
@@ -191,7 +191,7 @@ impl Avatar {
                     user_profile: UserProfile {
                         user_id,
                         username,
-                        avatar_img_data: Some(img_data),
+                        avatar_state: AvatarState::Loaded(img_data),
                     },
                     room_id,
                 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -431,6 +431,7 @@ async fn async_worker(mut receiver: UnboundedReceiver<MatrixRequest>) -> Result<
                         format: MEDIA_THUMBNAIL_FORMAT.into(),
                     };
                     let res = client.media().get_media_content(&media_request, true).await;
+                    log!("Fetched avatar for {mxc_uri:?}, succeeded? {}", res.is_ok());
                     on_fetched(AvatarUpdate { mxc_uri, avatar_data: res.map(|v| v.into()) });
                 });
             }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -6,7 +6,7 @@ use imbl::Vector;
 use makepad_widgets::{error, log, SignalToUI};
 use matrix_sdk::{
     config::RequestConfig, media::MediaRequest, room::RoomMember, ruma::{
-        api::client::session::get_login_types::v3::LoginType, assign, events::{room::message::RoomMessageEventContent, FullStateEventContent, StateEventType}, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UInt, UserId
+        api::client::session::get_login_types::v3::LoginType, assign, events::{room::{message::RoomMessageEventContent, MediaSource}, FullStateEventContent, StateEventType}, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, UInt, UserId
     }, sliding_sync::http::request::{AccountData, ListFilters, ToDevice, E2EE}, Client, Room, SlidingSyncList, SlidingSyncMode
 };
 use matrix_sdk_ui::{timeline::{AnyOtherFullStateEventContent, LiveBackPaginationStatus, TimelineItem, TimelineItemContent}, Timeline};
@@ -18,7 +18,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use std::{cmp::{max, min}, collections::{BTreeMap, BTreeSet}, ops::Range, sync::{Arc, Mutex, OnceLock}};
 use url::Url;
 
-use crate::{home::{room_screen::TimelineUpdate, rooms_list::{self, enqueue_rooms_list_update, RoomPreviewAvatar, RoomPreviewEntry, RoomsListUpdate}}, media_cache::{MediaCacheEntry, AVATAR_CACHE}, profile::{user_profile::UserProfile, user_profile_cache::{enqueue_user_profile_update, UserProfileUpdate}}, utils::MEDIA_THUMBNAIL_FORMAT};
+use crate::{avatar_cache::AvatarUpdate, home::{room_screen::TimelineUpdate, rooms_list::{self, enqueue_rooms_list_update, RoomPreviewAvatar, RoomPreviewEntry, RoomsListUpdate}}, media_cache::MediaCacheEntry, profile::{user_profile::{AvatarState, UserProfile}, user_profile_cache::{enqueue_user_profile_update, UserProfileUpdate}}, utils::MEDIA_THUMBNAIL_FORMAT};
 use crate::message_display::DisplayerExt;
 
 
@@ -151,6 +151,13 @@ pub enum MatrixRequest {
     },
     /// Request to resolve a room alias into a room ID and the servers that know about that room.
     ResolveRoomAlias(OwnedRoomAliasId),
+    /// Request to fetch an Avatar image from the server.
+    /// Upon completion of the async media request, the `on_fetched` function
+    /// will be invoked with the content of an `AvatarUpdate`.
+    FetchAvatar {
+        mxc_uri: OwnedMxcUri,
+        on_fetched: fn(AvatarUpdate),
+    },
     /// Request to fetch media from the server.
     /// Upon completion of the async media request, the `on_fetched` function
     /// will be invoked with four arguments: the `destination`, the `media_request`,
@@ -289,7 +296,7 @@ async fn async_worker(mut receiver: UnboundedReceiver<MatrixRequest>) -> Result<
                     log!("Sending get user profile request: user: {user_id}, \
                         room: {room_id:?}, local_only: {local_only}...",
                     );
-                    let mut avatar_url: Option<OwnedMxcUri> = None;
+
                     let mut update = None;
 
                     if let Some(room_id) = room_id.as_ref() {
@@ -300,12 +307,11 @@ async fn async_worker(mut receiver: UnboundedReceiver<MatrixRequest>) -> Result<
                                 room.get_member(&user_id).await
                             };
                             if let Ok(Some(room_member)) = member {
-                                avatar_url = room_member.avatar_url().map(|u| u.to_owned());
                                 update = Some(UserProfileUpdate::Full {
                                     new_profile: UserProfile {
                                         username: room_member.display_name().map(|u| u.to_owned()),
                                         user_id: user_id.clone(),
-                                        avatar_img_data: None, // will be fetched below
+                                        avatar_state: AvatarState::Known(room_member.avatar_url().map(|u| u.to_owned())),
                                     },
                                     room_id: room_id.to_owned(),
                                     room_member,
@@ -320,12 +326,11 @@ async fn async_worker(mut receiver: UnboundedReceiver<MatrixRequest>) -> Result<
 
                     if update.is_none() && !local_only {
                         if let Ok(response) = client.account().fetch_user_profile_of(&user_id).await {
-                            avatar_url = response.avatar_url;
                             update = Some(UserProfileUpdate::UserProfileOnly(
                                 UserProfile {
                                     username: response.displayname,
                                     user_id: user_id.clone(),
-                                    avatar_img_data: None, // will be fetched below
+                                    avatar_state: AvatarState::Known(response.avatar_url),
                                 }
                             ));
                         } else {
@@ -333,19 +338,8 @@ async fn async_worker(mut receiver: UnboundedReceiver<MatrixRequest>) -> Result<
                         }
                     }
 
-                    if let Some(mut upd) = update {
+                    if let Some(upd) = update {
                         log!("Successfully completed get user profile request: user: {user_id}, room: {room_id:?}, local_only: {local_only}.");
-                        if let Some(uri) = avatar_url {
-                            match upd {
-                                UserProfileUpdate::UserProfileOnly(ref mut new_profile)
-                                | UserProfileUpdate::Full { ref mut new_profile, .. } => {
-                                    new_profile.avatar_img_data = AVATAR_CACHE
-                                        .get_media_or_fetch_async(client, uri, None)
-                                        .await;
-                                }
-                                _ => { }
-                            }
-                        }
                         enqueue_user_profile_update(upd);
                     } else {
                         log!("Failed to get user profile: user: {user_id}, room: {room_id:?}, local_only: {local_only}.");
@@ -374,7 +368,7 @@ async fn async_worker(mut receiver: UnboundedReceiver<MatrixRequest>) -> Result<
                     }
 
                     // We need to re-acquire the `RoomMember` object now that its state
-                    // has changed, i.e., the user has been (un)ignored).
+                    // has changed, i.e., the user has been (un)ignored.
                     // We then need to send an update to replace the cached `RoomMember`
                     // with the now-stale ignored state.
                     if let Some(room) = client.get_room(&room_id) {
@@ -425,6 +419,19 @@ async fn async_worker(mut receiver: UnboundedReceiver<MatrixRequest>) -> Result<
                     let res = client.resolve_room_alias(&room_alias).await;
                     log!("Resolved room alias {room_alias} to: {res:?}");
                     todo!("Send the resolved room alias back to the UI thread somehow.");
+                });
+            }
+
+            MatrixRequest::FetchAvatar { mxc_uri, on_fetched } => {
+                let Some(client) = CLIENT.get() else { continue };
+                let _fetch_task = Handle::current().spawn(async move {
+                    log!("Sending fetch avatar request for {mxc_uri:?}...");
+                    let media_request = MediaRequest {
+                        source: MediaSource::Plain(mxc_uri.clone()),
+                        format: MEDIA_THUMBNAIL_FORMAT.into(),
+                    };
+                    let res = client.media().get_media_content(&media_request, true).await;
+                    on_fetched(AvatarUpdate { mxc_uri, avatar_data: res.map(|v| v.into()) });
                 });
             }
 


### PR DESCRIPTION
Currently this commit only adds the usage of the user profile cache for the drawing of a profile (user name + avatar) for each timeline event.

Rewrite the avatar_cache to use a thread-local cache only accessible by the main UI thread (just like the user_profile_cache) instead of being based on the media cache.

Addresses #96 