### PR TITLE
Minor UI improvements

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -719,7 +719,7 @@ live_design! {
                         align: {y: 0.5}
                         empty_message: "Write a message (in Markdown) ..."
                         draw_bg: {
-                            color: #fff
+                            color: (COLOR_PRIMARY)
                             instance radius: 2.0
                             instance border_width: 0.8
                             instance border_color: #D0D5DD
@@ -755,16 +755,8 @@ live_design! {
 
                             fn get_color(self) -> vec4 {
                                 return mix(
-                                    mix(
-                                        mix(
-                                            #xFFFFFF55,
-                                            #xFFFFFF88,
-                                            self.hover
-                                        ),
-                                        self.color,
-                                        self.focus
-                                    ),
-                                    #BBBBBB,
+                                    self.color,
+                                    #B,
                                     self.is_empty
                                 )
                             }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -149,7 +149,7 @@ live_design! {
         width: Fill
         height: Fit
         flow: Down
-        padding: {left: 5.0, bottom: 5.0, top: 5.0}
+        padding: {left: 10.0, bottom: 5.0, top: 5.0}
 
         <View> {
             width: Fill
@@ -162,7 +162,7 @@ live_design! {
                 width: 19.,
                 height: 19.,
                 text_view = { text = { draw_text: {
-                    text_style: { font_size: 7.0 }
+                    text_style: { font_size: 6.0 }
                 }}}
             }
 
@@ -307,9 +307,9 @@ live_design! {
         replied_to_message = <RepliedToMessage> {
             flow: Right
             cursor: Hand
-            margin: { bottom: 10 }
+            margin: { bottom: 5.0, top: 10.0 }
             replied_to_message_content = {
-                margin: { left: 10 }
+                margin: { left: 29 }
             }
         }
 
@@ -339,9 +339,11 @@ live_design! {
                     //     }
                     // }
                 }
-                timestamp = <Timestamp> { }
+                timestamp = <Timestamp> {
+                    padding: { top: 3.0 }
+                }
                 datestamp = <Timestamp> {
-                    padding: { top: 5.0 }
+                    padding: { top: 3.0 }
                 }
             }
             content = <View> {
@@ -352,7 +354,7 @@ live_design! {
 
                 username = <Label> {
                     width: Fill,
-                    margin: {bottom: 10.0, top: 7.5, right: 10.0,}
+                    margin: {bottom: 9.0, top: 11.0, right: 10.0,}
                     draw_text: {
                         text_style: <USERNAME_TEXT_STYLE> {},
                         color: (USERNAME_TEXT_COLOR)
@@ -374,7 +376,7 @@ live_design! {
             // once the message menu is done with overlays this wont be necessary.
             <View> {
                 width: 1,
-                height: 30
+                height: 1
             }
         }
     }
@@ -383,19 +385,27 @@ live_design! {
     // from the same sender, and thus doesn't need to display the sender's profile again.
     CondensedMessage = <Message> {
         padding: { top: 2.0, bottom: 2.0 }
+        replied_to_message = <RepliedToMessage> {
+            replied_to_message_content = {
+                margin: { left: 74, bottom: 5.0 }
+            }
+        }
         body = {
-            padding: { top: 2.5, bottom: 2.5, left: 10.0, right: 10.0 },
+            padding: { top: 0, bottom: 2.5, left: 10.0, right: 10.0 },
             profile = <View> {
                 align: {x: 0.5, y: 0.0} // centered horizontally, top aligned
                 width: 65.0,
                 height: Fit,
                 flow: Down,
-                timestamp = <Timestamp> { }
+                timestamp = <Timestamp> {
+                    margin: {top: 1.5}
+                }
             }
             content = <View> {
                 width: Fill,
                 height: Fit,
                 flow: Down,
+                padding: { left: 10.0 }
 
                 message = <HtmlOrPlaintext> { }
                 message_annotations = <MessageAnnotations> {}
@@ -408,6 +418,7 @@ live_design! {
     ImageMessage = <Message> {
         body = {
             content = {
+                padding: { left: 10.0 }
                 message = <TextOrImage> {
                     width: Fill, height: 300,
                     image_view = { image = { fit: Horizontal } }
@@ -442,13 +453,13 @@ live_design! {
         flow: Right,
         padding: { top: 1.0, bottom: 1.0 }
         spacing: 0.0
-        margin: {top: 5.0, bottom: 5.0}
+        margin: { left: 2.5, top: 4.0, bottom: 4.0}
 
         body = <View> {
             width: Fill,
             height: Fit
             flow: Right,
-            padding: { top: 2.0, bottom: 2.0 }
+            padding: { left: 7.0, top: 2.0, bottom: 2.0 }
             spacing: 5.0
             align: {y: 0.5}
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2538,7 +2538,7 @@ impl Widget for Message {
         // TODO: need vecs for apply_over(), maybe use an animator so we just set the state here
         // and the animator handles the color changes from inside the dsl.
         let default_color = vec3(1.0, 1.0, 1.0); // #ffffff
-        let hover_color = vec3(0.95, 0.95, 0.95); // #f3f3f3  (very light gray)
+        let hover_color = vec3(0.98, 0.98, 0.98); // #fafafa  (very light gray)
 
         let bg_color = if self.hovered {
             hover_color

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -71,8 +71,8 @@ live_design! {
     }
 
     COLOR_BG = #xfff8ee
-    COLOR_BRAND = #xf88
-    COLOR_BRAND_HOVER = #xf66
+    COLOR_BRAND = #x5
+    COLOR_BRAND_HOVER = #x3
     COLOR_META_TEXT = #xaaa
     COLOR_META = #xccc
     COLOR_META_INV = #xfffa

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -130,7 +130,8 @@ live_design! {
     }
 
     Timestamp = <Label> {
-        padding: { top: 10.0, bottom: 0.0, left: 0.0, right: 0.0 }
+        width: Fit, height: Fit
+        padding: { bottom: 0.0, left: 0.0, right: 0.0 }
         draw_text: {
             text_style: <TIMESTAMP_TEXT_STYLE> {},
             color: (TIMESTAMP_TEXT_COLOR)
@@ -441,6 +442,7 @@ live_design! {
         flow: Right,
         padding: { top: 1.0, bottom: 1.0 }
         spacing: 0.0
+        margin: {top: 5.0, bottom: 5.0}
 
         body = <View> {
             width: Fill,
@@ -448,15 +450,14 @@ live_design! {
             flow: Right,
             padding: { top: 2.0, bottom: 2.0 }
             spacing: 5.0
+            align: {y: 0.5}
 
             left_container = <View> {
-                align: {x: 0.5, y: 0.0} // centered horizontally, top aligned
+                align: {x: 0.5, y: 0.5}
                 width: 70.0,
                 height: Fit
-                flow: Right,
 
                 timestamp = <Timestamp> {
-                    padding: {top: 5.0}
                     draw_text: {
                         text_style: <TIMESTAMP_TEXT_STYLE> {},
                         color: (TIMESTAMP_TEXT_COLOR)
@@ -476,7 +477,7 @@ live_design! {
             content = <Label> {
                 width: Fill,
                 height: Fit
-                padding: {top: 5.0},
+                padding: { top: 0.0, bottom: 0.0, left: 0.0, right: 0.0 }
                 draw_text: {
                     wrap: Word,
                     text_style: <SMALL_STATE_TEXT_STYLE> {},

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -280,7 +280,7 @@ live_design! {
         html_content = <RobrixHtml> {
             width: Fill,
             height: Fit,
-            padding: {top: 7.5, bottom: 5.0 },
+            padding: { bottom: 5.0, top: 0.0 },
             font_size: 10.5,
             draw_normal:      { color: (REACTION_TEXT_COLOR) },
             draw_italic:      { color: (REACTION_TEXT_COLOR) },
@@ -323,7 +323,7 @@ live_design! {
                 align: {x: 0.5, y: 0.0} // centered horizontally, top aligned
                 width: 65.0,
                 height: Fit,
-                margin: {top: 7.5, right: 10}
+                margin: {top: 4.5, right: 10}
                 flow: Down,
                 avatar = <Avatar> {
                     width: 50.,
@@ -352,7 +352,7 @@ live_design! {
 
                 username = <Label> {
                     width: Fill,
-                    margin: {bottom: 10.0, top: 10.0, right: 10.0,}
+                    margin: {bottom: 10.0, top: 7.5, right: 10.0,}
                     draw_text: {
                         text_style: <USERNAME_TEXT_STYLE> {},
                         color: (USERNAME_TEXT_COLOR)
@@ -384,13 +384,13 @@ live_design! {
     CondensedMessage = <Message> {
         padding: { top: 2.0, bottom: 2.0 }
         body = {
-            padding: { top: 5.0, bottom: 5.0, left: 10.0, right: 10.0 },
+            padding: { top: 2.5, bottom: 2.5, left: 10.0, right: 10.0 },
             profile = <View> {
                 align: {x: 0.5, y: 0.0} // centered horizontally, top aligned
                 width: 65.0,
                 height: Fit,
                 flow: Down,
-                timestamp = <Timestamp> { padding: {top: 3.0} }
+                timestamp = <Timestamp> { }
             }
             content = <View> {
                 width: Fill,
@@ -668,11 +668,12 @@ live_design! {
                     width: Fill
                     height: Fit
                     flow: Down
-                    padding: {top: 0.0, right: 12.0, bottom: 0.0, left: 12.0}
+                    padding: 0.0
             
                     // Displays a "Replying to" label and a cancel button
                     // above the preview of the message being replied to.
                     <View> {
+                        padding: {right: 12.0, left: 12.0}
                         width: Fill
                         height: Fit
                         flow: Right

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -124,7 +124,7 @@ live_design! {
                     draw_italic:      { color: (COLOR_PRIMARY) },
                     draw_bold:        { color: (COLOR_PRIMARY) },
                     draw_bold_italic: { color: (COLOR_PRIMARY) },
-                    draw_fixed:       { color: (COLOR_PRIMARY) },
+                    draw_fixed:       { color: (MESSAGE_TEXT_COLOR) },
                     a = { draw_text:  { color: (COLOR_PRIMARY) }, },
                 } }
                 plaintext_view = { pt_label = {

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -6,7 +6,7 @@ use crate::shared::adaptive_layout_view::AdaptiveLayoutViewAction;
 use crate::shared::avatar::AvatarWidgetRefExt;
 use crate::shared::clickable_view::*;
 use crate::shared::html_or_plaintext::HtmlOrPlaintextWidgetRefExt;
-use crate::utils::{unix_time_millis_to_datetime, self};
+use crate::utils::{self, relative_format};
 
 const MIN_DESKTOP_WIDTH: f64 = 860.0;
 
@@ -63,46 +63,53 @@ live_design! {
 
         preview = <View> {
             width: Fill, height: Fit
-            flow: Down, spacing: 7.
+            flow: Down, spacing: 5.
 
-            room_name = <Label> {
+            header = <View> {
                 width: Fill, height: Fit
-                draw_text:{
-                    color: #000,
-                    wrap: Ellipsis,
-                    text_style: <REGULAR_TEXT>{ font_size: 12.0 }
+                flow: Right
+                spacing: 10.
+                align: {y: 0.5}
+
+                room_name = <Label> {
+                    width: Fill, height: Fit
+                    draw_text:{
+                        color: #000,
+                        wrap: Ellipsis,
+                        text_style: <REGULAR_TEXT>{ font_size: 10.5 }
+                    }
+                    text: "[Room name unknown]"
                 }
-                text: "[Room name unknown]"
+
+                timestamp = <Label> {
+                    width: Fit, height: Fit
+                    draw_text:{
+                        color: (TIMESTAMP_TEXT_COLOR)
+                        text_style: <TIMESTAMP_TEXT_STYLE>{
+                            font_size: 7.5
+                        },
+                    }
+                    text: "[Timestamp unknown]"
+                }
             }
 
             latest_message = <HtmlOrPlaintext> {
                 html_view = { html = {
-                    font_size: 10.5,
-                    draw_normal:      { text_style: { font_size: 10.5 } },
-                    draw_italic:      { text_style: { font_size: 10.5 } },
-                    draw_bold:        { text_style: { font_size: 10.5 } },
-                    draw_bold_italic: { text_style: { font_size: 10.5 } },
-                    draw_fixed:       { text_style: { font_size: 10.5 } },
-                    a = { draw_text:  { text_style: { font_size: 10.5 } } },
+                    font_size: 9.3, line_spacing: 1.,
+                    draw_normal:      { text_style: { font_size: 9.3, line_spacing: 1. } },
+                    draw_italic:      { text_style: { font_size: 9.3, line_spacing: 1. } },
+                    draw_bold:        { text_style: { font_size: 9.3, line_spacing: 1. } },
+                    draw_bold_italic: { text_style: { font_size: 9.3, line_spacing: 1. } },
+                    draw_fixed:       { text_style: { font_size: 9.3, line_spacing: 1. } },
+                    a = { draw_text:  { text_style: { font_size: 9.3, line_spacing: 1. } } },
                 } }
                 plaintext_view = { pt_label = {
                     draw_text: {
-                        text_style: { font_size: 10.5 },
+                        text_style: { font_size: 9.5, line_spacing: 1. },
                     }
                     text: "[Latest message unknown]"
                 } }
             }
-        }
-
-        timestamp = <Label> {
-            width: Fit, height: Fit
-            draw_text:{
-                color: (TIMESTAMP_TEXT_COLOR)
-                text_style: <TIMESTAMP_TEXT_STYLE>{
-                    font_size: 8.
-                },
-            }
-            text: "[Timestamp unknown]"
         }
     }
 
@@ -112,9 +119,17 @@ live_design! {
         }
 
         preview = {
-            room_name = {
-                draw_text: {
-                    color: (COLOR_PRIMARY)
+            header = {
+                room_name = {
+                    draw_text: {
+                        color: (COLOR_PRIMARY)
+                    }
+                }
+
+                timestamp = {
+                    draw_text: {
+                        color: (COLOR_PRIMARY)
+                    }
                 }
             }
 
@@ -132,12 +147,6 @@ live_design! {
                         color: (COLOR_PRIMARY)
                     }
                 } }
-            }
-        }
-
-        timestamp = {
-            draw_text: {
-                color: (COLOR_PRIMARY)
             }
         }
     }
@@ -425,10 +434,9 @@ impl Widget for RoomsList {
                         item.label(id!(preview.room_name)).set_text(name);
                     }
                     if let Some((ts, msg)) = room_info.latest.as_ref() {
-                        if let Some(dt) = unix_time_millis_to_datetime(ts) {
-                            let text = format!("{} {}", dt.date_naive(), dt.time().format("%l:%M %P"));
-                            item.label(id!(timestamp)).set_text(&text);
-                        }
+                        if let Some(human_readable_date) = relative_format(ts) {
+                            item.label(id!(timestamp)).set_text(&human_readable_date);
+                        }                        
                         item.html_or_plaintext(id!(preview.latest_message)).show_html(msg);
                     }
                     match room_info.avatar {

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -32,7 +32,7 @@ live_design! {
             instance border_width: 0.0
             instance border_color: #0000
             instance inset: vec4(0.0, 0.0, 0.0, 0.0)
-            instance radius: 2.5
+            instance radius: 4.0
             
             fn get_color(self) -> vec4 {
                 return self.color
@@ -76,7 +76,7 @@ live_design! {
                     draw_text:{
                         color: #000,
                         wrap: Ellipsis,
-                        text_style: <REGULAR_TEXT>{ font_size: 10.5 }
+                        text_style: <USERNAME_TEXT_STYLE>{ font_size: 10. }
                     }
                     text: "[Room name unknown]"
                 }

--- a/src/home/rooms_sidebar.rs
+++ b/src/home/rooms_sidebar.rs
@@ -91,9 +91,9 @@ live_design! {
     RoomsSideBar = <AdaptiveLayoutView> {
         composition: {
             desktop: {
-                padding: {top: 20., left: 20., right: 20.}
+                padding: {top: 20., left: 10., right: 10.}
                 flow: Down, spacing: 10
-                width: 400, height: Fill
+                width: 280, height: Fill
                 visibility: Visible
             },
             mobile: {

--- a/src/home/spaces_dock.rs
+++ b/src/home/spaces_dock.rs
@@ -59,7 +59,7 @@ live_design! {
                 show_bg: true,
 
                 draw_bg: {
-                    instance background_color: #b8e5cc,
+                    instance background_color: (COLOR_AVATAR_BG),
                     fn pixel(self) -> vec4 {
                         let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                         let c = self.rect_size * 0.5;

--- a/src/home/spaces_dock.rs
+++ b/src/home/spaces_dock.rs
@@ -133,7 +133,14 @@ live_design! {
             // within its parent
             padding: {top: 8, left: 8, right: 12, bottom: 8}
             align: {x: 0.5, y: 0.5}
-            <Icon> {
+            <Button> {
+                enabled: false
+                draw_bg: {
+                    fn pixel(self) -> vec4 {
+                        let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                        return sdf.result
+                    }
+                }
                 draw_icon: {
                     svg_file: (ICON_SETTINGS),
                     fn get_color(self) -> vec4 {

--- a/src/home/spaces_dock.rs
+++ b/src/home/spaces_dock.rs
@@ -144,7 +144,7 @@ live_design! {
                 draw_icon: {
                     svg_file: (ICON_SETTINGS),
                     fn get_color(self) -> vec4 {
-                        return #1C274C;
+                        return #x566287; // grayed-out #1C274C until enabled
                     }
                 }
                 icon_walk: {width: 25, height: Fit}

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -226,19 +226,23 @@ live_design! {
             width: Fill, height: Fit
             align: {x: 0.5, y: 0.0}
             padding: {left: 10, right: 10}
+            spacing: 10
             flow: Down
             avatar = <Avatar> {
                 width: 150,
                 height: 150,
                 margin: 10.0,
+                text_view = { text = { draw_text: {
+                    text_style: { font_size: 40.0 }
+                }}}
             }
 
             user_name = <Label> {
                 width: Fit, height: Fit
                 draw_text: {
-                    wrap: Line,
+                    wrap: Word,
                     color: #000,
-                    text_style: <USERNAME_TEXT_STYLE>{ },
+                    text_style: <USERNAME_TEXT_STYLE>{ font_size: 12 },
                 }
                 text: "User Name"
             }
@@ -248,7 +252,7 @@ live_design! {
                 draw_text: {
                     wrap: Line,
                     color: (MESSAGE_TEXT_COLOR),
-                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 10 },
+                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 11 },
                 }
                 text: "User ID"
             }
@@ -260,7 +264,7 @@ live_design! {
             width: Fill,
             height: Fit,
             flow: Down,
-            spacing: 8,
+            spacing: 10,
             align: {x: 0.0, y: 0.0}
             padding: {left: 10, right: 10}
 
@@ -268,28 +272,30 @@ live_design! {
                 width: Fill, height: Fit
                 draw_text: {
                     wrap: Word,
-                    text_style: <USERNAME_TEXT_STYLE>{},
+                    text_style: <USERNAME_TEXT_STYLE>{ font_size: 11.5 },
                     color: #000
                 }
                 text: "Membership in this room"
             }
 
             membership_status_label = <Label> {
+                margin: { left: 7 }
                 width: Fill, height: Fit
                 draw_text: {
                     wrap: Line,
                     color: (MESSAGE_TEXT_COLOR),
-                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 10.},
+                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 11 },
                 }
                 text: "Unknown"
             }
 
             role_info_label = <Label> {
+                margin: { left: 7 }
                 width: Fill, height: Fit
                 draw_text: {
                     wrap: Line,
                     color: (MESSAGE_TEXT_COLOR),
-                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 10.},
+                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 11 },
                 }
                 text: "Unknown"
             }
@@ -300,13 +306,13 @@ live_design! {
         actions = <View> {
             width: Fill, height: Fit
             flow: Down,
-            spacing: 10
+            spacing: 7
             padding: {left: 10., right: 10, bottom: 50}
             <Label> {
                 width: Fill, height: Fit
                 draw_text: {
                     wrap: Line,
-                    text_style: <USERNAME_TEXT_STYLE>{},
+                    text_style: <USERNAME_TEXT_STYLE>{ font_size: 11.5 },
                     color: #000
                 }
                 text: "Actions"

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -120,22 +120,17 @@ live_design! {
         width: Fit,
         height: Fit,
         spacing: 10,
-        padding: {top: 10, bottom: 10, left: 15, right: 15}
+        padding: {top: 10, bottom: 10, left: 8, right: 15}
 
         draw_bg: {
-            instance color: #EDFCF2
-            instance color_hover: #fff
-            instance border_width: 1.2
+            instance color: (COLOR_PRIMARY)
+            instance color_hover: #A
+            instance border_width: 0.0
             instance border_color: #D0D5DD
-            instance border_color_hover: #fff
             instance radius: 3.0
 
             fn get_color(self) -> vec4 {
                 return mix(self.color, mix(self.color, self.color_hover, 0.2), self.hover)
-            }
-
-            fn get_border_color(self) -> vec4 {
-                return mix(self.border_color, mix(self.border_color, self.border_color_hover, 0.2), self.hover)
             }
 
             fn pixel(self) -> vec4 {
@@ -149,7 +144,7 @@ live_design! {
                 )
                 sdf.fill_keep(self.get_color())
                 if self.border_width > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_width)
+                    sdf.stroke(self.border_color, self.border_width)
                 }
                 return sdf.result;
             }
@@ -224,8 +219,7 @@ live_design! {
 
         show_bg: true,
         draw_bg: {
-            color: #f3f3fa
-            // 241, 244, 251
+            color: (COLOR_PRIMARY)
         }
 
         personal_info = <View> {
@@ -307,8 +301,7 @@ live_design! {
             width: Fill, height: Fit
             flow: Down,
             spacing: 10
-            padding: {left: 10, right: 10, bottom: 50}
-
+            padding: {left: 10., right: 10, bottom: 50}
             <Label> {
                 width: Fill, height: Fit
                 draw_text: {
@@ -397,19 +390,15 @@ live_design! {
                 height: Fit,
                 align: {x: 0.0, y: 0.0},
                 margin: 7,
-                padding: 10,
+                padding: 15,
 
                 draw_icon: {
                     svg_file: (ICON_CLOSE),
                     fn get_color(self) -> vec4 {
-                        return #fff;
+                        return #x0;
                     }
                 }
-                draw_bg: {
-                    color: #777,
-                    color_hover: #fff,
-                }
-                icon_walk: {width: 16, height: 16}
+                icon_walk: {width: 14, height: 14}
             }
         }
 

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -218,7 +218,8 @@ live_design! {
         width: Fill,
         height: Fill,
         align: {x: 0.5, y: 0},
-        spacing: 15,
+        padding: {left: 15., right: 15., top: 15.}
+        spacing: 20,
         flow: Down,
 
         show_bg: true,
@@ -227,44 +228,50 @@ live_design! {
             // 241, 244, 251
         }
 
-        avatar = <Avatar> {
-            width: 150,
-            height: 150,
-            margin: 10.0,
-        }
-
-        user_name = <Label> {
+        personal_info = <View> {
             width: Fill, height: Fit
-            draw_text: {
-                wrap: Line,
-                color: #000,
-                text_style: <USERNAME_TEXT_STYLE>{ },
+            align: {x: 0.5, y: 0.0}
+            padding: {left: 10, right: 10}
+            flow: Down
+            avatar = <Avatar> {
+                width: 150,
+                height: 150,
+                margin: 10.0,
             }
-            text: "User Name"
-        }
 
-        user_id = <Label> {
-            width: Fill, height: Fit
-            draw_text: {
-                wrap: Line,
-                color: (MESSAGE_TEXT_COLOR),
-                text_style: <MESSAGE_TEXT_STYLE>{ font_size: 10 },
+            user_name = <Label> {
+                width: Fit, height: Fit
+                draw_text: {
+                    wrap: Line,
+                    color: #000,
+                    text_style: <USERNAME_TEXT_STYLE>{ },
+                }
+                text: "User Name"
             }
-            text: "User ID"
+
+            user_id = <Label> {
+                width: Fit, height: Fit
+                draw_text: {
+                    wrap: Line,
+                    color: (MESSAGE_TEXT_COLOR),
+                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 10 },
+                }
+                text: "User ID"
+            }
         }
 
         <LineH> { padding: 15 }
 
-        <View> {
+        membership = <View> {
             width: Fill,
             height: Fit,
             flow: Down,
-            spacing: 15,
+            spacing: 8,
             align: {x: 0.0, y: 0.0}
+            padding: {left: 10, right: 10}
 
             membership_title_label = <Label> {
                 width: Fill, height: Fit
-                padding: {left: 15}
                 draw_text: {
                     wrap: Word,
                     text_style: <USERNAME_TEXT_STYLE>{},
@@ -275,31 +282,35 @@ live_design! {
 
             membership_status_label = <Label> {
                 width: Fill, height: Fit
-                padding: {left: 30}
                 draw_text: {
                     wrap: Line,
                     color: (MESSAGE_TEXT_COLOR),
-                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 11.5},
+                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 10.},
                 }
                 text: "Unknown"
             }
 
             role_info_label = <Label> {
                 width: Fill, height: Fit
-                padding: {left: 30}
                 draw_text: {
                     wrap: Line,
                     color: (MESSAGE_TEXT_COLOR),
-                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 11.5},
+                    text_style: <MESSAGE_TEXT_STYLE>{ font_size: 10.},
                 }
                 text: "Unknown"
             }
+        }
 
-            <LineH> { padding: 15 }
+        <LineH> { padding: 15 }
+
+        actions = <View> {
+            width: Fill, height: Fit
+            flow: Down,
+            spacing: 10
+            padding: {left: 10, right: 10, bottom: 50}
 
             <Label> {
                 width: Fill, height: Fit
-                padding: {left: 15}
                 draw_text: {
                     wrap: Line,
                     text_style: <USERNAME_TEXT_STYLE>{},
@@ -307,14 +318,6 @@ live_design! {
                 }
                 text: "Actions"
             }
-        }
-
-        actions = <View> {
-            width: Fill, height: Fit
-            flow: Down,
-            spacing: 10
-            padding: {left: 25, bottom: 50 }
-
 
             direct_message_button = <UserProfileActionButton> {
                 // TODO: support this button. Once this is implemented, uncomment the line in draw_walk()

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -44,7 +44,8 @@ live_design! {
             align: { x: 0.5, y: 0.5 }
             show_bg: true,
             draw_bg: {
-                instance background_color: #bfb,
+                instance background_color: (COLOR_AVATAR_BG)
+                
                 fn pixel(self) -> vec4 {
                     let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                     let c = self.rect_size * 0.5;
@@ -59,7 +60,7 @@ live_design! {
                 padding: { top: 1.0 } // for better vertical alignment
                 draw_text: {
                     text_style: <TITLE_TEXT>{ font_size: 15. }
-                    color: #777,
+                    color: #f,
                 }
                 text: "?"
             }
@@ -125,8 +126,8 @@ impl Widget for Avatar {
 
     fn set_text(&mut self, v: &str) {
         let f = utils::user_name_first_letter(v)
-            .unwrap_or("?");
-        self.label(id!(text_view.text)).set_text(f);
+            .unwrap_or("?").to_uppercase();
+        self.label(id!(text_view.text)).set_text(&f);
         self.view(id!(img_view)).set_visible(false);
         self.view(id!(text_view)).set_visible(true);
     }

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -57,7 +57,7 @@ live_design! {
             
             text = <Label> {
                 width: Fit, height: Fit,
-                padding: { top: 1.0 } // for better vertical alignment
+                padding: { top: 0.5 } // for better vertical alignment
                 draw_text: {
                     text_style: <TITLE_TEXT>{ font_size: 15. }
                     color: #f,

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -11,8 +11,8 @@ live_design! {
 
     // These match the `MESSAGE_*` styles defined in `styles.rs`.
     // For some reason, they're not the same. That's TBD.
-    HTML_LINE_SPACING = 8.0
-    HTML_TEXT_HEIGHT_FACTOR = 1.2
+    HTML_LINE_SPACING = 6.0
+    HTML_TEXT_HEIGHT_FACTOR = 1.1
     HTML_BLOCK_LINE_SPACING = 5.0
 
 
@@ -51,8 +51,9 @@ live_design! {
             quote_fg_color: (MESSAGE_TEXT_COLOR)
         }
         list_item_layout: { line_spacing: (HTML_BLOCK_LINE_SPACING), padding: {left: 5.0, top: 1.0, bottom: 1.0}, }
-        code_layout: { line_spacing: (HTML_BLOCK_LINE_SPACING), padding: {top: 4.0, bottom: 4.0}, }
-        quote_layout: { line_spacing: (HTML_BLOCK_LINE_SPACING), padding: {top: 0.0, bottom: 8.0}, }
+        code_layout: { line_spacing: (HTML_BLOCK_LINE_SPACING), padding: {left: 7.0, right: 7.0, top: 8.0, bottom: 0.0}, }
+        quote_layout: { line_spacing: (HTML_BLOCK_LINE_SPACING), padding: {top: 0.0, bottom: 0.0}, }
+        inline_code_padding: { left: 5.0, right: 5.0, top: 7.0, bottom: 0.0 }
 
         font = <MatrixHtmlSpan> { }
         span = <MatrixHtmlSpan> { }

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -17,7 +17,7 @@ live_design! {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
     }
 
-    USERNAME_FONT_SIZE = 10.5
+    USERNAME_FONT_SIZE = 11
     USERNAME_TEXT_COLOR = #x2
     USERNAME_TEXT_STYLE = {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Bold.ttf")}
@@ -26,8 +26,8 @@ live_design! {
     }
 
 
-    MESSAGE_FONT_SIZE = 10.0
-    MESSAGE_TEXT_COLOR = #x555
+    MESSAGE_FONT_SIZE = 11
+    MESSAGE_TEXT_COLOR = #x444
     MESSAGE_TEXT_LINE_SPACING = 1.35
     MESSAGE_TEXT_HEIGHT_FACTOR = 1.55
     // This font should only be used for plaintext labels. Don't use this for Html content,
@@ -39,10 +39,10 @@ live_design! {
         line_spacing: (MESSAGE_TEXT_LINE_SPACING),
     }
 
-    MESSAGE_REPLY_PREVIEW_FONT_SIZE = 9.0
+    MESSAGE_REPLY_PREVIEW_FONT_SIZE = 9.5
 
     SMALL_STATE_FONT_SIZE = 9.0
-    SMALL_STATE_TEXT_COLOR = #x999
+    SMALL_STATE_TEXT_COLOR = #x888
     SMALL_STATE_TEXT_STYLE = {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
         font_size: (SMALL_STATE_FONT_SIZE),

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -17,10 +17,10 @@ live_design! {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
     }
 
-    USERNAME_FONT_SIZE = 11.0
-    USERNAME_TEXT_COLOR = #x060 // dark green
+    USERNAME_FONT_SIZE = 10.5
+    USERNAME_TEXT_COLOR = #x2
     USERNAME_TEXT_STYLE = {
-        font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
+        font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Bold.ttf")}
         font_size: (USERNAME_FONT_SIZE),
         // height_factor: 1.5,
     }
@@ -67,4 +67,7 @@ live_design! {
     COLOR_SECONDARY = #eef2f4
 
     COLOR_SELECTED_PRIMARY = #0f88fe
+    COLOR_SELECTED_PRIMARY_DARKER = #106fcc
+
+    COLOR_AVATAR_BG = #52b2ac
 }

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -17,7 +17,7 @@ live_design! {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
     }
 
-    USERNAME_FONT_SIZE = 12.0
+    USERNAME_FONT_SIZE = 11.0
     USERNAME_TEXT_COLOR = #x060 // dark green
     USERNAME_TEXT_STYLE = {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}
@@ -26,7 +26,7 @@ live_design! {
     }
 
 
-    MESSAGE_FONT_SIZE = 11.0
+    MESSAGE_FONT_SIZE = 10.0
     MESSAGE_TEXT_COLOR = #x555
     MESSAGE_TEXT_LINE_SPACING = 1.35
     MESSAGE_TEXT_HEIGHT_FACTOR = 1.55
@@ -39,9 +39,9 @@ live_design! {
         line_spacing: (MESSAGE_TEXT_LINE_SPACING),
     }
 
-    MESSAGE_REPLY_PREVIEW_FONT_SIZE = 9.5
+    MESSAGE_REPLY_PREVIEW_FONT_SIZE = 9.0
 
-    SMALL_STATE_FONT_SIZE = 9.5
+    SMALL_STATE_FONT_SIZE = 9.0
     SMALL_STATE_TEXT_COLOR = #x999
     SMALL_STATE_TEXT_STYLE = {
         font: {path: dep("crate://makepad-widgets/resources/GoNotoKurrent-Regular.ttf")}


### PR DESCRIPTION
Addresses the tasks in #137

- [x] Gray out icons of not yet implemented features
- [x] Minor vertical mis-alignment on small state items
- [x] Missing/squashed left padding on user profile sliding pane 
- [x] Change the hover bg color for Message to have starker contrast with background color of Html blocks (`draw_block: { quote_bg_color: ... }`)
- [x] Text input's text is invisible due to color matching the background
- [x] Change text color in html block bg in RoomPreviewSelected, to `MESSAGE_TEXT_COLOR`
- [x] Make rooms list sidebar narrower
- [x] Update user profile colors to match the general UI theme
- [x] [Kevin] Misaligned code block background, miscellaneous vertical spacing issues
- [ ] Make the border between the "replying preview" and the bottom of the timeline view more distinct, either via a shadow or different bg colors

- [ ] Display the message timestamp next to username (Edit: will do in a separate PR)