### PR TITLE
Save & restore replying-to preview state upon switching room timelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1722,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1739,17 +1739,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1757,7 +1757,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1768,7 +1768,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1778,7 +1778,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1812,17 +1812,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-micro-serde-derive",
 ]
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1838,12 +1838,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-android-state",
  "makepad-futures",
@@ -1861,7 +1861,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1884,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -1893,7 +1893,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1902,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "makepad-windows"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "windows-core 0.51.1 (git+https://github.com/makepad/makepad?branch=rik)",
  "windows-targets 0.48.5",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "bitflags 2.4.1",
 ]
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "simd-adler32",
 ]
@@ -1941,7 +1941,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3847,7 +3847,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 
 [[package]]
 name = "typenum"
@@ -4254,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#7be7c8d8a921f97827a757ac075e05845df83e20"
+source = "git+https://github.com/makepad/makepad?branch=rik#92ae696dfed563236af750a957112fbe6bdb2e37"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/src/home/main_content.rs
+++ b/src/home/main_content.rs
@@ -118,7 +118,7 @@ impl MatchEvent for MainContent {
                     // Get a reference to the `RoomScreen` widget and tell it which room's data to show.
                     self.view
                         .room_screen(id!(room_screen))
-                        .set_displayed_room(displayed_room_name, room_id);
+                        .set_displayed_room(cx, displayed_room_name, room_id);
                     self.redraw(cx);
                 }
                 _ => (),


### PR DESCRIPTION
Addresses a few to-do items in `RoomScreen` state management, primarily the issue of a reply preview not actually being re-drawn upon switching back to a previously-drawn room.

Also, the message input box is automatically given keyboard focus after the user clicks the reply button for a message, making it much easier for the user to start typing a reply.