### PR TITLE
Fix empty space below room screen input

### DIFF
--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -37,11 +37,11 @@ live_design! {
             }
             width: Fill, height: Fill
             flow: Down
-            padding: {top: 40.}
 
             <NavigationWrapper> {
                 view_stack = <StackNavigation> {
                     root_view = {
+                        padding: {top: 40.}
                         flow: Down
                         width: Fill, height: Fill
                         sidebar = <RoomsSideBar> {}


### PR DESCRIPTION
Removes unnecessary padding at the global level and sets it specifically on the rooms lists. 
(There's already padding in the NavigationStackView)