### PR TITLE
Use `robius-directories` crate to support persistence on Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,15 +827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,6 +3068,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312584c40c0d996c96a0c8498c6e556c38ca5785eda670ae11ba12fe2e556c4f"
 dependencies = [
  "jni",
+ "makepad-android-state",
+]
+
+[[package]]
+name = "robius-directories"
+version = "5.0.1"
+source = "git+https://github.com/project-robius/robius-directories?branch=robius#a7ac6b7b137232f5a835b4d4946a07f9dda05c3d"
+dependencies = [
+ "dirs-sys",
+ "jni",
+ "robius-android-env",
 ]
 
 [[package]]
@@ -3093,6 +3095,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "robius-use-makepad"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dc404c4111c88cd9f8a409b2831d13fe93e5242c95939a3852e7e7d675f89c4"
+dependencies = [
+ "robius-android-env",
+]
+
+[[package]]
 name = "robrix"
 version = "0.0.1-pre-alpha"
 dependencies = [
@@ -3101,7 +3112,6 @@ dependencies = [
  "clap",
  "crossbeam-channel",
  "crossbeam-queue",
- "directories",
  "emojis",
  "eyeball",
  "eyeball-im",
@@ -3114,7 +3124,9 @@ dependencies = [
  "matrix-sdk-ui",
  "rand",
  "rangemap",
+ "robius-directories",
  "robius-open",
+ "robius-use-makepad",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
 makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
-directories = "5.0.1"
+## Including this crate automatically configures all `robius-*` crates to work with Makepad.
+robius-use-makepad = "0.1.0"
 robius-open = "0.1.0"
+## A fork of the `directories` crate that adds support for Android by using our `robius-android-env` crate.
+robius-directories = { git = "https://github.com/project-robius/robius-directories", branch = "robius"}
 
 anyhow = "1.0"
 chrono = "0.4"

--- a/login.toml
+++ b/login.toml
@@ -1,7 +1,9 @@
 username = " "
 password = " "
+homeserver = " "
 
 ### Please fill in your username and password above.
+### The homeserver name/URL field is optional, but defaults to "matrix.org".
 ###
 ### Robrix does not yet have a login splash screen.
 ### Thus, on desktop platforms, we allow the user to
@@ -12,7 +14,7 @@ password = " "
 ### Instead, we enable the mobile apps to read them from a copy
 ### of this file that is included in the app package files.
 ###
-### Only the two username and password fields are supported.
+### Only the username, password, and homeserver fields are supported.
 ###
 ### Note that for obvious reasons you should not commit this file
 ### or upload it to a public repo with your actual username and password in it.

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,6 +137,11 @@ impl LiveHook for App { }
 
 impl MatchEvent for App {
     fn handle_startup(&mut self, _cx: &mut Cx) {
+        // Initialize the project directory here from the main UI thread
+        // such that background threads/tasks will be able to can access it.
+        let _app_data_dir = crate::app_data_dir();
+        log!("App::handle_startup(): app_data_dir: {:?}", _app_data_dir);
+
         log!("App::handle_startup(): starting matrix sdk loop");
         crate::sliding_sync::start_matrix_tokio().unwrap();
     }

--- a/src/event_preview.rs
+++ b/src/event_preview.rs
@@ -281,7 +281,7 @@ pub fn text_preview_of_other_state(
                 HistoryVisibility::Shared => "joined users, for all of time.",
                 HistoryVisibility::WorldReadable | _ => "anyone for all time.",
             };
-            Some(format!("set this room's history to be visible by {}.", visibility))
+            Some(format!("set this room's history to be visible by {}", visibility))
         }
         AnyOtherFullStateEventContent::RoomJoinRules(FullStateEventContent::Original { content, .. }) => {
             Some(match content.join_rule {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, sync::OnceLock};
 
-use directories::ProjectDirs;
+use robius_directories::ProjectDirs;
 
 pub use makepad_widgets;
 pub mod app;

--- a/src/persistent_state.rs
+++ b/src/persistent_state.rs
@@ -1,7 +1,7 @@
 //! Handles app persistence by saving and restoring client session data to/from the filesystem.
 
 use std::{
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 use anyhow::{anyhow, bail};
 use makepad_widgets::log;
@@ -110,7 +110,7 @@ pub async fn restore_session(
 
     // Build the client with the previous settings from the session.
     let client = Client::builder()
-        .homeserver_url(client_session.homeserver)
+        .server_name_or_homeserver_url(client_session.homeserver)
         .sqlite_store(client_session.db_path, Some(&client_session.passphrase))
         .simplified_sliding_sync(false)
         .build()


### PR DESCRIPTION
Fix CLI to accept server names instead of only fully-formed URLs.

Allow specifying the homserver on both the CLI and in `login.toml`.