### PR TITLE
Pre-paginate each visible room in the rooms list once

### DIFF
--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -31,6 +31,7 @@ impl AvatarState {
     }
 
     /// Returns the avatar URI, if in the `Known` state and it exists.
+    #[allow(unused)]
     pub fn uri(&self) -> Option<&OwnedMxcUri> {
         if let AvatarState::Known(Some(uri)) = self {
             Some(uri)

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1093,6 +1093,7 @@ async fn add_new_room(room: &room_list_service::Room) -> Result<()> {
         // start with a basic text avatar; the avatar image will be fetched asynchronously below.
         avatar: avatar_from_room_name(room_name.as_deref().unwrap_or_default()),
         room_name,
+        has_been_paginated: false,
         is_selected: false,
     }));
 


### PR DESCRIPTION
This ensures that the room preview will have a latest message to display and that we'll be able to display some room history immediately upon a user opening a room timeline for the first time.

Also, use more Rusty and non-panic-ing code to access the rooms list while drawing room previews.