### PR TITLE
Backward Paginate timeline by scroll #109

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1268,8 +1268,9 @@ impl Widget for RoomScreen {
                 }
             }
 
-            // Handle sending any read receipts for the current logged-in user.
+            // Set visibility of loading message banner based of pagination logic
             self.send_pagination_request_based_on_scroll_pos(cx, actions);
+            // Handle sending any read receipts for the current logged-in user.
             self.send_user_read_receipts_based_on_scroll_pos(cx, actions);
 
             // Handle the cancel reply button being clicked.


### PR DESCRIPTION
https://github.com/project-robius/robrix/issues/109


https://github.com/user-attachments/assets/4ca3a953-eb76-4f8a-8a65-f237682a9ef8

1. Set visibility for top_space when pagination is idle to true
2. Clear it when done_loading is true
3. Added send_pagination_request_based_on_scroll_pos function