### PR TITLE
Use `Arc` instead of `Box` for ruma types like `OwnedRoomId`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+## Add these flags onto all target builds cumulatively.
+## <https://github.com/rust-lang/cargo/issues/5376#issuecomment-2163350032>
+[target.'cfg(all())']
+rustflags = ["--cfg", "ruma_identifiers_storage=\"Arc\""]
+


### PR DESCRIPTION
Since we use these so prolifically, this reduces overall memory usage, allocation overhead, etc.