### PR TITLE
Restructure the `RoomsList` to separate the storage of all rooms from the filtered display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1767,7 +1767,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1784,17 +1784,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1813,7 +1813,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1857,17 +1857,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1884,12 +1884,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -1912,7 +1912,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -1967,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "simd-adler32",
 ]
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4029,7 +4029,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#c6b972e9244efbdf3adfbd727e7feb51a2a0f961"
+source = "git+https://github.com/kevinaboos/makepad?branch=widget_uid_hashable#9c5439bf6c5a20c540212c2375edee03274c6a11"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ version = "0.0.1-pre-alpha"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
-
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "widget_uid_hashable" }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.0"

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref};
 use crossbeam_queue::SegQueue;
 use makepad_widgets::*;
 use matrix_sdk::ruma::{MilliSecondsSinceUnixEpoch, OwnedRoomId};
@@ -161,22 +161,63 @@ impl Default for RoomPreviewAvatar {
     }
 }
 
+/// A filter function that is called for each room to determine whether it should be displayed.
+///
+/// If the function returns `true`, the room is displayed; otherwise, it is not shown.
+/// The default value is a filter function that always returns `true`.
+///
+/// ## Example
+/// The following example shows how to create and apply a filter function
+/// that only displays rooms that have a displayable name starting with the letter "M":
+/// ```rust,norun
+/// rooms_list.display_filter = RoomDisplayFilter(Box::new(
+///     |room| room.room_name.as_ref().is_some_and(|n| n.starts_with("M"))
+/// ));
+/// rooms_list.displayed_rooms = rooms_list.all_rooms.iter()
+///    .filter(|(_, room)| (rooms_list.display_filter)(room))
+///    .collect();
+/// // Then redraw the rooms_list widget.
+/// ```
+pub struct RoomDisplayFilter(Box<dyn Fn(&RoomPreviewEntry) -> bool>);
+impl Default for RoomDisplayFilter {
+    fn default() -> Self {
+        RoomDisplayFilter(Box::new(|_| true))
+    }
+}
+impl Deref for RoomDisplayFilter {
+    type Target = Box<dyn Fn(&RoomPreviewEntry) -> bool>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Live, LiveHook, Widget)]
 pub struct RoomsList {
     #[deref] view: View,
 
-    /// The list of all known rooms and their cached preview info.
-    //
-    // TODO: change this into a hashmap keyed by room ID.
-    #[rust] all_rooms: Vec<RoomPreviewEntry>,
-    /// Maps the WidgetUid of a `RoomPreview` to that room's index in the `all_rooms` vector.
-    #[rust] rooms_list_map: HashMap<u64, usize>,
-    /// Maps the OwnedRoomId to the index of the room in the `all_rooms` vector.
-    #[rust] rooms_list_owned_room_id_map: HashMap<OwnedRoomId, usize>,
+    /// The single set of all known rooms and their cached preview info.
+    #[rust] all_rooms: HashMap<OwnedRoomId, RoomPreviewEntry>,
+
+    /// The currently-active filter function for the list of rooms.
+    ///
+    /// Note: for performance reasons, this does not get automatically applied
+    /// when its value changes. Instead, you must manually invoke it on the set of `all_rooms`
+    /// in order to update the set of `displayed_rooms` accordingly.
+    #[rust] display_filter: RoomDisplayFilter,
+    
+    /// The list of rooms currently displayed in the UI, in order from top to bottom.
+    /// This must be a strict subset of the rooms present in `all_rooms`, and should be determined
+    /// by applying the `display_filter` to the set of `all_rooms``.
+    #[rust] displayed_rooms: Vec<OwnedRoomId>,
+
+    /// Maps the WidgetUid of a `RoomPreview` to that room's index in the `displayed_rooms` vector.
+    ///
+    /// NOTE: this should only be modified by the draw routine, not anything else.
+    #[rust] displayed_rooms_map: HashMap<WidgetUid, usize>,
+
     /// The latest status message that should be displayed in the bottom status label.
     #[rust] status: String,
-    /// The index of the currently selected room
+    /// The index of the currently-selected room.
     #[rust] current_active_room_index: Option<usize>,
     /// The maximum number of rooms that will ever be loaded.
     #[rust] max_known_rooms: Option<u32>,
@@ -201,40 +242,70 @@ impl Widget for RoomsList {
                 num_updates += 1;
                 match update {
                     RoomsListUpdate::AddRoom(room) => {
-                        let room_index = self.all_rooms.len();
-                        self.rooms_list_owned_room_id_map.insert(room.room_id.clone(), room_index);
-                        self.all_rooms.push(room);
+                        let room_id = room.room_id.clone();
+                        let should_display = (self.display_filter)(&room);
+                        let _replaced = self.all_rooms.insert(room_id.clone(), room);
+                        if let Some(_old_room) = _replaced {
+                            // TODO: handle tombstoned rooms, and treat this case as a bug/error.
+                            warning!("Added room {room_id} that already exists in the list of all rooms");
+                        } else {
+                            if should_display {
+                                self.displayed_rooms.push(room_id);
+                            }
+                        }
                     }
                     RoomsListUpdate::UpdateRoomAvatar { room_id, avatar } => {
-                        if let Some(room) = self.all_rooms.iter_mut().find(|r| &r.room_id == &room_id) {
+                        if let Some(room) = self.all_rooms.get_mut(&room_id) {
                             room.avatar = avatar;
                         } else {
                             error!("Error: couldn't find room {room_id} to update avatar");
                         }
                     }
                     RoomsListUpdate::UpdateLatestEvent { room_id, timestamp, latest_message_text } => {
-                        if let Some(room) = self.all_rooms.iter_mut().find(|r| &r.room_id == &room_id) {
+                        if let Some(room) = self.all_rooms.get_mut(&room_id) {
                             room.latest = Some((timestamp, latest_message_text));
                         } else {
                             error!("Error: couldn't find room {room_id} to update latest event");
                         }
                     }
                     RoomsListUpdate::UpdateRoomName { room_id, new_room_name } => {
-                        if let Some(room) = self.all_rooms.iter_mut().find(|r| &r.room_id == &room_id) {
+                        if let Some(room) = self.all_rooms.get_mut(&room_id) {
+                            let was_displayed = (self.display_filter)(&room);
                             room.room_name = Some(new_room_name);
+                            let should_display = (self.display_filter)(&room);
+                            match (was_displayed, should_display) {
+                                (true, true) | (false, false) => {
+                                    // No need to update the displayed rooms list.
+                                }
+                                (true, false) => {
+                                    // Room was displayed but should no longer be displayed.
+                                    self.displayed_rooms.retain(|r| r != &room_id);
+                                }
+                                (false, true) => {
+                                    // Room was not displayed but should now be displayed.
+                                    self.displayed_rooms.push(room_id);
+                                }
+                            }
                         } else {
                             error!("Error: couldn't find room {room_id} to update room name");
                         }
                     }
                     RoomsListUpdate::RemoveRoom(room_id) => {
-                        if let Some(idx) = self.all_rooms.iter().position(|r| &r.room_id == &room_id) {
-                            self.all_rooms.remove(idx);
-                        } else {
-                            error!("Error: couldn't find room {room_id} to remove room");
-                        }
+                        self.all_rooms.remove(&room_id)
+                            .and_then(|_removed|
+                                self.displayed_rooms.iter().position(|r| r == &room_id)
+                            )
+                            .map(|index_to_remove| {
+                                // Remove the room from the list of displayed rooms.
+                                self.displayed_rooms.remove(index_to_remove);
+                            })
+                            .unwrap_or_else(|| {
+                                error!("Error: couldn't find room {room_id} to remove room");
+                            });
                     }
                     RoomsListUpdate::ClearRooms => {
                         self.all_rooms.clear();
+                        self.displayed_rooms.clear();
                     }
                     RoomsListUpdate::NotLoaded => {
                         self.status = "Loading rooms (waiting for homeserver)...".to_string();
@@ -260,43 +331,50 @@ impl Widget for RoomsList {
             if let RoomPreviewAction::Click = list_action.as_widget_action().cast() {
                 let widget_action = list_action.as_widget_action();
 
-                if let Some(room_index) = self.rooms_list_map
+                let Some(displayed_room_index) = self.displayed_rooms_map
                     .iter()
-                    .find(|&(&room_widget_uid, _)| widget_action.widget_uid_eq(WidgetUid(room_widget_uid)).is_some())
+                    .find(|&(&room_widget_uid, _)| widget_action.widget_uid_eq(room_widget_uid).is_some())
                     .map(|(_, &room_index)| room_index)
-                {
-                    let room_details = &self.all_rooms[room_index];
-                    self.current_active_room_index = Some(room_index);
-                    cx.widget_action(
-                        widget_uid,
-                        &scope.path,
-                        RoomListAction::Selected {
-                            room_index,
-                            room_id: room_details.room_id.to_owned(),
-                            room_name: room_details.room_name.clone(),
-                        }
-                    );
-                    self.redraw(cx);
-                }
+                else {
+                    error!("BUG: couldn't find displayed index of clicked room for widget action {widget_action:?}");
+                    continue;
+                };
+                let Some(room_details) = self.displayed_rooms
+                    .get(displayed_room_index)
+                    .and_then(|room_id| self.all_rooms.get(room_id))
+                else {
+                    error!("BUG: couldn't get room details for room at displayed index {displayed_room_index}");
+                    continue;
+                };
+
+                self.current_active_room_index = Some(displayed_room_index);
+                cx.widget_action(
+                    widget_uid,
+                    &scope.path,
+                    RoomListAction::Selected {
+                        room_index: displayed_room_index,
+                        room_id: room_details.room_id.to_owned(),
+                        room_name: room_details.room_name.clone(),
+                    }
+                );
+                self.redraw(cx);
             }
         }
     }
 
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-
-        // TODO: sort list of `all_rooms` by alphabetic, most recent message, grouped by spaces, etc
         let app_state = scope.data.get_mut::<AppState>().unwrap();
         // Override the current active room index if the app state has a different selected room
         if let Some(room) = app_state.rooms_panel.selected_room.as_ref() {
-            if let Some(room_index) = self.rooms_list_owned_room_id_map.get(&room.id) {
-                self.current_active_room_index = Some(*room_index);
+            if let Some(room_index) = self.displayed_rooms.iter().position(|r| r == &room.id) {
+                self.current_active_room_index = Some(room_index);
             }
         } else {
             self.current_active_room_index = None;
         }
 
-        let count = self.all_rooms.len();
+        let count = self.displayed_rooms.len();
         let status_label_id = count;
 
         // Start the actual drawing procedure.
@@ -312,9 +390,10 @@ impl Widget for RoomsList {
                 let mut scope = Scope::empty();
 
                 // Draw the room preview for each room.
-                let item = if let Some(room_info) = self.all_rooms.get_mut(item_id) {
+                let room_to_draw = self.displayed_rooms.get(item_id).and_then(|room_id| self.all_rooms.get_mut(room_id));
+                let item = if let Some(room_info) = room_to_draw {
                     let item = list.item(cx, item_id, live_id!(room_preview));
-                    self.rooms_list_map.insert(item.widget_uid().0, item_id);
+                    self.displayed_rooms_map.insert(item.widget_uid(), item_id);
                     room_info.is_selected = self.current_active_room_index == Some(item_id);
 
                     // Paginate the room if it hasn't been paginated yet.

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -409,9 +409,8 @@ impl Widget for RoomsList {
                         });
                     }
 
-                    // Pass the room info through Scope down to the RoomPreview widget.
+                    // Pass the room info down to the RoomPreview widget via Scope.
                     scope = Scope::with_props(&*room_info);
-
                     item
                 }
                 // Draw the status label as the bottom entry.

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -291,7 +291,8 @@ impl Widget for RoomsList {
                         }
                     }
                     RoomsListUpdate::RemoveRoom(room_id) => {
-                        self.all_rooms.remove(&room_id)
+                        self.all_rooms
+                            .remove(&room_id)
                             .and_then(|_removed|
                                 self.displayed_rooms.iter().position(|r| r == &room_id)
                             )
@@ -389,8 +390,10 @@ impl Widget for RoomsList {
             while let Some(item_id) = list.next_visible_item(cx) {
                 let mut scope = Scope::empty();
 
-                // Draw the room preview for each room.
-                let room_to_draw = self.displayed_rooms.get(item_id).and_then(|room_id| self.all_rooms.get_mut(room_id));
+                // Draw the room preview for each room in the `displayed_rooms` list.
+                let room_to_draw = self.displayed_rooms
+                    .get(item_id)
+                    .and_then(|room_id| self.all_rooms.get_mut(room_id));
                 let item = if let Some(room_info) = room_to_draw {
                     let item = list.item(cx, item_id, live_id!(room_preview));
                     self.displayed_rooms_map.insert(item.widget_uid(), item_id);


### PR DESCRIPTION
Closes #185.

Basically, this lays the groundwork for implementing a proper room search bar.

* `RoomsList::all_rooms` is now a HashMap that maps an `OwnedRoomId` key to a `RoomPreviewEntry` value. This being a hashmap implies that it has no ordering and is not used for determining display sort order or filtering.
* The list of `displayed_rooms` is stored separately as an ordered list of room IDs, which correspond to the specific order in which we want to display the list of rooms to the user.
* Introduced a `RoomDisplayFilter` function/closure type, which can be applied to all or part of the `all_rooms` map in order to produce the `displayed_rooms` ordered list above. This must be done manually since we don't want to have to recalculate it on every draw pass, but rather only occasionally when the user wishes to change what rooms are shown per their custom filter.
* Sorting isn't yet implemented but should be easy enough to layer atop this.