### PR TITLE
Apply a yellow background highlight to messages that mention the current logged-in user

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2449,10 +2449,8 @@ fn check_if_message_mentions_current_user(
 
     //  Matrix SDK offers an API to obtain the users mentioned by a given message,
     // also cover the use case of a replied-to message.
-    match message.mentions() {
-        Some(mentions) => mentions.user_ids.contains(current_user_id),
-        None => false,
-    }
+    message.mentions()
+        .map_or(false, |mentions| mentions.user_ids.contains(current_user_id))
 }
 
 /// Draws the Html or plaintext body of the given Text or Notice message into the `message_content_widget`.
@@ -3259,7 +3257,7 @@ impl Widget for Message {
             self.view.apply_over(
                 cx, live!(
                     draw_bg: {
-                        color: (vec4(0.96, 0.95, 0.90, 1.0))
+                        color: (vec4(0.96, 0.95, 0.90, 0.95))
                     }
                 )
             )

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -310,6 +310,9 @@ live_design! {
             instance hover: 0.0
             color: #ffffff  // default color
 
+            instance mentions_bar_color: #ffffff
+            instance mentions_bar_width: 4.0
+
             fn pixel(self) -> vec4 {
                 let base_color = mix(
                     self.color,
@@ -323,7 +326,17 @@ live_design! {
                     self.highlight
                 );
 
-                return with_highlight;
+                let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+
+                // draw bg
+                sdf.rect(0., 0., self.rect_size.x, self.rect_size.y);
+                sdf.fill(with_highlight);
+
+                // draw the left vertical line
+                sdf.rect(0., 0., self.mentions_bar_width, self.rect_size.y);
+                sdf.fill(self.mentions_bar_color);
+
+                return sdf.result;
             }
         }
 
@@ -3257,7 +3270,8 @@ impl Widget for Message {
             self.view.apply_over(
                 cx, live!(
                     draw_bg: {
-                        color: (vec4(0.96, 0.95, 0.90, 0.95))
+                        color: (vec4(1.0, 1.0, 0.82, 1.0))
+                        mentions_bar_color: #ffd54f
                     }
                 )
             )

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2447,7 +2447,7 @@ fn check_if_message_mentions_current_user(
         return false;
     };
 
-    //  Matrix SDK offers an API to obtain the users mentioned by a given message,
+    // Matrix SDK offers an API to obtain the users mentioned by a given message,
     // also cover the use case of a replied-to message.
     message.mentions()
         .map_or(false, |mentions| mentions.user_ids.contains(current_user_id))

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2464,6 +2464,21 @@ fn check_if_message_mentions_current_user(
                     }
                 }
             }
+            // Check if it is a reply to the current user’s message
+            if let Some(in_reply_to) = message.in_reply_to() {
+                match &in_reply_to.event {
+                    TimelineDetails::Ready(replied_to_event) => {
+                        let replied_user = replied_to_event.sender().to_string();
+                        // log!("current user : {}", current_user_id.to_string());
+                        // log!("reply to current user : {}", replied_user);
+                        if replied_user == current_user_id.to_string() {
+                            log!("Is reply to current user's message");
+                            return true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
 
             false
         }


### PR DESCRIPTION
Fixed issue [#299](https://github.com/project-robius/robrix/issues/229)  . Apply a yellow background highlight to messages that mention the current user. 

<img width="905" alt="Screenshot 2024-11-07 at 00 36 21" src="https://github.com/user-attachments/assets/f000ef4a-350b-4783-9094-15e47db3d433">

<img width="895" alt="Screenshot 2024-11-07 at 01 01 46" src="https://github.com/user-attachments/assets/fc05db22-af50-4a4d-ae7a-41f574c43f59">
