### PR TITLE
 Properly handle matrix.to links for Rooms #87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,3 +196,5 @@ appdata_paths = [
     "$APPDATA/$PUBLISHER/$PRODUCTNAME",
     "$LOCALAPPDATA/$PRODUCTNAME",
 ]
+[profile.dev]
+debug = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,5 +196,3 @@ appdata_paths = [
     "$APPDATA/$PUBLISHER/$PRODUCTNAME",
     "$LOCALAPPDATA/$PRODUCTNAME",
 ]
-[profile.dev]
-debug = 0

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1187,7 +1187,8 @@ impl Widget for RoomScreen {
                                 if self.room_id.as_ref() == Some(room_id) {
                                     return true;
                                 }
-                                if let Some(_known_room) = get_client().and_then(|c| c.get_room(room_id)) {
+                                if let Some(known_room) = get_client().and_then(|c| c.get_room(room_id)) {
+                                    self.set_displayed_room(cx, known_room.name().unwrap_or(String::from("NoNameRoom")), room_id.clone());
                                     log!("TODO: jump to known room {}", room_id);
                                 } else {
                                     log!("TODO: fetch and display room preview for room {}", room_id);


### PR DESCRIPTION
Run Robrix without entering any other rooms, only entering the room with a message that contains `OwnedRoomId` link sent by someone, click on the link to enter and this will work well.

Otherwise, robrix will panic if you enter any other rooms before that.
```
thread 'main' panicked at src/home/room_screen.rs:1804:18:
BUG: couldn't get timeline state for first-viewed room.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at src/home/room_screen.rs:1907:32:
called `Result::unwrap()` on an `Err` value: PoisonError { .. }
```
At the moment I have not dealt with `alias` links yet.

**This will work:**
[2024-11-11_14-35-47.webm](https://github.com/user-attachments/assets/85104097-b50c-472b-bf8a-66bda94cf8fa)

**This will panic:**
[2024-11-11_14-36-27.webm](https://github.com/user-attachments/assets/0b1a19f3-252c-4d1a-af07-b34149929384)