### PR TITLE
Add Makepad feature to determine if a primary modifier key is pressed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1962,17 +1962,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1991,7 +1991,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2009,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2017,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2035,17 +2035,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2062,12 +2062,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2113,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "simd-adler32",
 ]
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4195,7 +4195,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#bf99ab0175285818c3ec3c7e655636de572c9598"
+source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "typenum"

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1196,21 +1196,14 @@ impl Widget for RoomScreen {
                 }
             }
 
-            let msg_input_widget = self.text_input(id!(message_input));
-
-            let mut send_message_with_shortcut_key = false;
-            if let Some(key_event) = msg_input_widget.key_down_unhandled(&actions) {
-
-                // Windows and linux use control key, mac uses logo key
-                if key_event.key_code == KeyCode::ReturnKey
-                && (key_event.modifiers.control || key_event.modifiers.logo)
-                {
-                    send_message_with_shortcut_key = true;
-                }
-            }
-
             // Handle the send message button being clicked and enter key being pressed.
-            if self.button(id!(send_message_button)).clicked(&actions) || send_message_with_shortcut_key {
+            let msg_input_widget = self.text_input(id!(message_input));
+            let send_message_shortcut_pressed = msg_input_widget
+                .key_down_unhandled(&actions)
+                .is_some_and(|ke| ke.key_code == KeyCode::ReturnKey && ke.modifiers.is_primary());
+            if send_message_shortcut_pressed
+                || self.button(id!(send_message_button)).clicked(&actions)
+            {
                 let entered_text = msg_input_widget.text().trim().to_string();
                 if !entered_text.is_empty() {
                     let room_id = self.room_id.clone().unwrap();


### PR DESCRIPTION
The primary modifier key is Command on macOs and Ctrl on all other platforms. We now use this to add a shortcut that sends a message when you press `PrimaryModifier` + `Return`/`Enter` in the message input box.