### PR TITLE
Support backwards pagination until a target event is reached, with interactive user cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,7 +1919,6 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1928,7 +1927,6 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1936,7 +1934,6 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1945,7 +1942,6 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1962,17 +1958,14 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1980,7 +1973,6 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1991,7 +1983,6 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2001,7 +1992,6 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2009,7 +1999,6 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2017,7 +2006,6 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2027,7 +2015,6 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2035,17 +2022,14 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2054,7 +2038,6 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2062,12 +2045,10 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -2090,7 +2071,6 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2105,7 +2085,6 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2113,7 +2092,6 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2122,7 +2100,6 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2131,7 +2108,6 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2145,7 +2121,6 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2153,7 +2128,6 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "simd-adler32",
 ]
@@ -2161,7 +2135,6 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2169,7 +2142,6 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4195,7 +4167,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#1b5cbc0a00bb487c0e193087539e48744bc7eb73"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ version = "0.0.1-pre-alpha"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
+makepad-widgets = { path = "../makepad/widgets" }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"

--- a/src/home/loading_modal.rs
+++ b/src/home/loading_modal.rs
@@ -160,18 +160,18 @@ impl WidgetMatchEvent for LoadingModal {
             .is_some();
 
         if cancel_button.clicked(actions) || modal_dismissed {
-            log!("LoadingModal: close requested: {}", if modal_dismissed { "by modal dismiss" } else { "by cancel button" });
+            // log!("LoadingModal: close requested: {}", if modal_dismissed { "by modal dismiss" } else { "by cancel button" });
             if let LoadingModalState::BackwardsPaginateUntilEvent { target_event_id, request_sender, .. } = &self.state {
-                let did_send = request_sender.send_if_modified(|requests| {
+                let _did_send = request_sender.send_if_modified(|requests| {
                     let initial_len = requests.len();
                     requests.retain(|r| &r.target_event_id != target_event_id);
                     // if we actually cancelled this request, notify the receivers
                     // such that they can stop looking for the target event.
                     requests.len() != initial_len
                 });
-                log!("LoadingModal: {} cancel request for target_event_id: {target_event_id}",
-                    if did_send { "Sent" } else { "Did not send" },
-                );
+                // log!("LoadingModal: {} cancel request for target_event_id: {target_event_id}",
+                //     if did_send { "Sent" } else { "Did not send" },
+                // );
             }
             self.set_state(cx, LoadingModalState::None);
 

--- a/src/home/loading_modal.rs
+++ b/src/home/loading_modal.rs
@@ -1,0 +1,235 @@
+use makepad_widgets::*;
+use matrix_sdk::ruma::OwnedEventId;
+
+use crate::sliding_sync::TimelineRequestSender;
+
+live_design! {
+    import makepad_widgets::base::*;
+    import makepad_widgets::theme_desktop_dark::*;
+    import makepad_draw::shader::std::*;
+
+    import crate::shared::styles::*;
+    import crate::shared::icon_button::RobrixIconButton;
+
+    LoadingModal = {{LoadingModal}} {
+        width: Fit
+        height: Fit
+
+        <RoundedView> {
+            flow: Down
+            width: 600
+            height: Fit
+            padding: {top: 25, right: 30 bottom: 30 left: 45}
+            spacing: 10
+
+            show_bg: true
+            draw_bg: {
+                color: #fff
+                radius: 3.0
+            }
+
+            title_view = <View> {
+                width: Fill,
+                height: Fit,
+                flow: Right
+                padding: {top: 0, bottom: 40}
+                align: {x: 0.5, y: 0.0}
+
+                title = <Label> {
+                    text: "Loading content..."
+                    draw_text: {
+                        text_style: <TITLE_TEXT>{font_size: 13},
+                        color: #000
+                    }
+                }
+            }
+
+            body = <View> {
+                width: Fill,
+                height: Fit,
+                flow: Down,
+                spacing: 40,
+
+                status = <Label> {
+                    width: Fill
+                    draw_text: {
+                        text_style: <REGULAR_TEXT>{
+                            font_size: 11.5,
+                            height_factor: 1.3
+                        },
+                        color: #000
+                        wrap: Word
+                    }
+                }
+
+                <View> {
+                    width: Fill, height: Fit
+                    flow: Right,
+                    align: {x: 1.0, y: 0.5}
+                    spacing: 20
+
+                    cancel_button = <RobrixIconButton> {
+                        padding: {left: 15, right: 15}
+                        // draw_icon: {
+                        //     svg_file: (ICON_BLOCK_USER)
+                        //     color: (COLOR_DANGER_RED),
+                        // }
+                        icon_walk: {width: 0, height: 0 }
+
+                        draw_bg: {
+                            border_color: (COLOR_DANGER_RED),
+                            color: #fff0f0 // light red
+                        }
+                        text: "Cancel"
+                        draw_text:{
+                            color: (COLOR_DANGER_RED),
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct LoadingModal {
+    #[deref] view: View,
+    #[rust] state: LoadingModalState,
+}
+impl Drop for LoadingModal {
+    fn drop(&mut self) {
+        if let LoadingModalState::BackwardsPaginateUntilEvent { target_event_id, request_sender, .. } = &self.state {
+            warning!("Dropping LoadingModal with target_event_id: {}", target_event_id);
+            request_sender.send_if_modified(|requests| {
+                let initial_len = requests.len();
+                requests.retain(|r| &r.target_event_id != target_event_id);
+                // if we actually cancelled this request, notify the receivers
+                // such that they can stop looking for the target event.
+                requests.len() != initial_len
+            });
+        }
+    }
+}
+
+/// An action sent from this LoadingModal widget to its parent widget,
+/// which is currently required in order for the parent to close this modal.
+#[derive(Clone, Debug, DefaultNone)]
+pub enum LoadingModalAction {
+    Close,
+    None,
+}
+
+/// The state of a LoadingModal: the possible tasks that it may be performing.
+#[derive(Clone, DefaultNone)]
+pub enum LoadingModalState {
+    /// The room is being backwards paginated until the target event is reached.
+    BackwardsPaginateUntilEvent {
+        target_event_id: OwnedEventId,
+        /// The number of events paginated so far, which is only used to display progress.
+        events_paginated: usize,
+        /// The sender for timeline requests for the room that is showing this modal.
+        /// This is used to inform the `timeline_subscriber_handler` that the user has
+        /// cancelled the request, so that it can stop looking for the target event.
+        request_sender: TimelineRequestSender,
+    },
+    /// The loading modal is displaying an error message until the user closes it.
+    Error(String),
+    /// The LoadingModal is not doing anything and can be hidden.
+    None,
+}
+
+impl Widget for LoadingModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))
+    }
+}
+
+impl WidgetMatchEvent for LoadingModal {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+        let widget_uid = self.widget_uid();
+        let cancel_button = self.button(id!(cancel_button));
+
+        let modal_dismissed = actions
+            .iter()
+            .find(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)))
+            .is_some();
+
+        if cancel_button.clicked(actions) || modal_dismissed {
+            if let LoadingModalState::BackwardsPaginateUntilEvent { target_event_id, request_sender, .. } = &self.state {
+                request_sender.send_if_modified(|requests| {
+                    let initial_len = requests.len();
+                    requests.retain(|r| &r.target_event_id != target_event_id);
+                    // if we actually cancelled this request, notify the receivers
+                    // such that they can stop looking for the target event.
+                    requests.len() != initial_len
+                });
+            }
+            self.set_state(LoadingModalState::None);
+
+            // If the modal was dismissed by clicking outside of it, we MUST NOT emit
+            // a `LoadingModalAction::Close` action, as that would cause
+            // an infinite action feedback loop.
+            if !modal_dismissed {
+                cx.widget_action(widget_uid, &scope.path, LoadingModalAction::Close);
+            }
+        }
+    }
+}
+
+impl LoadingModal {
+    pub fn set_state(&mut self, state: LoadingModalState) {
+        let cancel_button = self.button(id!(cancel_button));
+        match &state {
+            LoadingModalState::BackwardsPaginateUntilEvent {
+                target_event_id,
+                events_paginated,
+                ..
+            } => {
+                self.set_title("Loading older messages...");
+                self.set_status(&format!(
+                    "Looking for event {target_event_id}\n\n\
+                    Loaded {events_paginated} messages so far...",
+                ));
+                cancel_button.set_text("Cancel");
+            }
+            LoadingModalState::Error(error_message) => {
+                self.set_title("Error loading content");
+                self.set_status(error_message);
+                cancel_button.set_text("Okay");
+            }
+            LoadingModalState::None => { }
+        }
+
+        self.state = state;
+    }
+
+    pub fn set_status(&mut self, status: &str) {
+        self.label(id!(status)).set_text(status);
+    }
+
+    pub fn set_title(&mut self, title: &str) {
+        self.label(id!(title)).set_text(title);
+    }
+}
+
+impl LoadingModalRef {
+    pub fn set_state(&self, state: LoadingModalState) {
+        let Some(mut inner) = self.borrow_mut() else { return }; 
+        inner.set_state(state);
+    }
+
+    pub fn set_status(&self, status: &str) {
+        let Some(mut inner) = self.borrow_mut() else { return }; 
+        inner.set_status(status);
+    }
+
+    pub fn set_title(&self, title: &str) {
+        let Some(mut inner) = self.borrow_mut() else { return }; 
+        inner.set_title(title);
+    }
+}

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -1,18 +1,20 @@
 use makepad_widgets::Cx;
 
 pub mod home_screen;
-pub mod main_mobile_ui;
+pub mod light_themed_dock;  
+pub mod loading_modal;
 pub mod main_desktop_ui;
+pub mod main_mobile_ui;
 pub mod room_preview;
 pub mod room_screen;
 pub mod rooms_list;
 pub mod rooms_sidebar;
 pub mod spaces_dock;
 pub mod welcome_screen;
-pub mod light_themed_dock;  
 
 pub fn live_design(cx: &mut Cx) {
     home_screen::live_design(cx);
+    loading_modal::live_design(cx);
     rooms_list::live_design(cx);
     room_preview::live_design(cx);
     room_screen::live_design(cx);

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1578,9 +1578,6 @@ impl RoomScreen {
                                 "Looking for event {target_event_id}\n\n\
                                 Loaded {events_paginated} messages so far...",
                             ));
-                            // redraw now to show the updated status message
-                            self.view.modal(id!(loading_modal)).redraw(cx);
-                            loading_modal_inner.redraw(cx);
                             // Here, we assume that we have not yet found the target event,
                             // so we need to continue paginating backwards.
                             // If the target event has already been found, it will be handled

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -24,14 +24,16 @@ use matrix_sdk_ui::timeline::{
 use robius_location::Coordinates;
 
 use crate::{
-    avatar_cache::{self, AvatarCacheEntry}, event_preview::{text_preview_of_member_profile_change, text_preview_of_other_state, text_preview_of_redacted_message, text_preview_of_room_membership_change, text_preview_of_timeline_item}, location::{get_latest_location, init_location_subscriber, request_location_update, LocationAction, LocationRequest, LocationUpdate}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    avatar_cache::{self, AvatarCacheEntry}, event_preview::{text_preview_of_member_profile_change, text_preview_of_other_state, text_preview_of_redacted_message, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::loading_modal::LoadingModalWidgetExt, location::{get_latest_location, init_location_subscriber, request_location_update, LocationAction, LocationRequest, LocationUpdate}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
         user_profile::{AvatarState, ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     }, shared::{
         avatar::{AvatarRef, AvatarWidgetRefExt}, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt}, jump_to_bottom_button::JumpToBottomButtonWidgetExt, text_or_image::{TextOrImageRef, TextOrImageWidgetRefExt}, typing_animation::TypingAnimationWidgetExt
-    }, sliding_sync::{get_client, submit_async_request, take_timeline_update_receiver, MatrixRequest, PaginationDirection}, utils::{self, unix_time_millis_to_datetime, MediaFormatConst}
+    }, sliding_sync::{get_client, submit_async_request, take_timeline_endpoints, BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineRequestSender}, utils::{self, unix_time_millis_to_datetime, MediaFormatConst}
 };
 use rangemap::RangeSet;
+
+use super::loading_modal::{LoadingModalAction, LoadingModalState};
 
 const GEO_URI_SCHEME: &str = "geo:";
 
@@ -50,6 +52,7 @@ live_design! {
     import crate::shared::typing_animation::TypingAnimation;
     import crate::shared::icon_button::*;
     import crate::shared::jump_to_bottom_button::*;
+    import crate::home::loading_modal::*;
 
     IMG_DEFAULT_AVATAR = dep("crate://self/resources/img/default_avatar.png")
     ICO_FAV = dep("crate://self/resources/icon_favorite.svg")
@@ -914,7 +917,8 @@ live_design! {
             // The top space should be displayed on top of the timeline
             top_space = <TopSpace> { }
 
-            // The user profile sliding pane should be displayed on top of all other subviews.
+            // The user profile sliding pane should be displayed on top of other "static" subviews
+            // (on top of all other views that are always visible).
             <View> {
                 width: Fill,
                 height: Fill,
@@ -922,6 +926,14 @@ live_design! {
                 flow: Right,
 
                 user_profile_sliding_pane = <UserProfileSlidingPane> { }
+            }
+
+            // A pop-up modal that appears while the user must wait for something
+            // in the room to finish loading, e.g., when loading an older replied-to message.
+            loading_modal = <Modal> {
+                content: {
+                    loading_modal_inner = <LoadingModal> {}
+                }
             }
         }
 
@@ -943,7 +955,7 @@ live_design! {
     }
 }
 
-/// A simple deref wrapper around the `RoomScreen` widget that enables us to handle its events.
+/// The main widget that displays a single Matrix room.
 #[derive(Live, LiveHook, Widget)]
 pub struct RoomScreen {
     #[deref] view: View,
@@ -953,8 +965,10 @@ pub struct RoomScreen {
     #[rust] room_id: Option<OwnedRoomId>,
     /// The display name of the currently-shown room.
     #[rust] room_name: String,
-    /// The UI-relevant states for the room that this widget is currently displaying.
+    /// The persistent UI-relevant states for the room that this widget is currently displaying.
     #[rust] tl_state: Option<TimelineUiState>,
+    /// The current state of the loading modal: what it is currently being used for. 
+    #[rust] loading_modal_state: LoadingModalState,
     /// 5 secs timer when scroll ends
     #[rust] fully_read_timer: Timer,
 }
@@ -986,7 +1000,7 @@ impl Widget for RoomScreen {
             for action in actions {
                 // Handle actions on a message, e.g., clicking the reply button or clicking the reply preview.
                 match action.as_widget_action().widget_uid_eq(widget_uid).cast() {
-                    MessageAction::MessageReply(item_id) => {
+                    MessageAction::MessageReplyButtonClicked(item_id) => {
                         let Some(tl) = self.tl_state.as_mut() else {
                             continue;
                         };
@@ -1001,12 +1015,14 @@ impl Widget for RoomScreen {
                         }
                     }
                     MessageAction::ReplyPreviewClicked { reply_message_item_id, replied_to_event } => {
+                        let loading_modal_inner = self.loading_modal(id!(loading_modal_inner));
+                        let loading_modal = self.modal(id!(loading_modal));
                         let Some(tl) = self.tl_state.as_mut() else {
                             continue;
                         };
                         let tl_idx = reply_message_item_id as usize;
 
-                        // Attempt to find the index of replied-to message on the timeline.
+                        // Attempt to find the index of replied-to message in the timeline.
                         // Start from the current item's index (`tl_idx`)and search backwards,
                         // since we know the replied-to message must come before the current item.
                         let replied_to_msg_tl_index = tl.items
@@ -1027,15 +1043,46 @@ impl Widget for RoomScreen {
                             // FIXME: `smooth_scroll_to` should accept a scroll offset parameter too,
                             //       so that we can scroll to the replied-to message and have it
                             //       appear beneath the top of the viewport.
-                            portal_list.smooth_scroll_to(cx, index - 1, scaled_speed);
+                            portal_list.smooth_scroll_to(cx, index.saturating_sub(1), scaled_speed);
                             // start highlight animation.
                             tl.message_highlight_animation_state = MessageHighlightAnimationState::Pending {
                                 item_id: index
                             };
-                            self.redraw(cx);
                         } else {
-                            log!("TODO: the replied-to message was not yet available in the timeline.");
+                            log!("The replied-to message {replied_to_event} was not yet available in room timeline {}, fetching it now...", tl.room_id);
+                            // Here, we set the state of the loading modal and display it to the user.
+                            // We also start the first back pagination request.
+                            // The main logic will be handled in `process_timeline_updates()`, which is the only
+                            // place where we can receive updates to the timeline from the background tasks.
+                            self.loading_modal_state = LoadingModalState::BackwardsPaginateUntilEvent {
+                                target_event_id: replied_to_event.clone(),
+                                events_paginated: 0,
+                                request_sender: tl.request_sender.clone(),
+                            };
+                            loading_modal_inner.set_state(self.loading_modal_state.clone());
+                            loading_modal.open(cx);
+
+                            tl.request_sender.send_if_modified(|requests| {
+                                if let Some(existing) = requests.iter_mut().find(|r| r.room_id == tl.room_id) {
+                                    warning!("Unexpected: room {} already had an existing timeline request in progress, event: {:?}", tl.room_id, existing.target_event_id);
+                                    // We might as well re-use this existing request...
+                                    existing.target_event_id = replied_to_event;
+                                } else {
+                                    requests.push(BackwardsPaginateUntilEventRequest {
+                                        room_id: tl.room_id.clone(),
+                                        target_event_id: replied_to_event,
+                                    });
+                                }
+                                true
+                            });
+
+                            submit_async_request(MatrixRequest::PaginateRoomTimeline {
+                                room_id: tl.room_id.clone(),
+                                num_events: 50,
+                                direction: PaginationDirection::Backwards,
+                            });
                         }
+                        self.redraw(cx);
                     }
                     _ => {}
                 }
@@ -1148,6 +1195,10 @@ impl Widget for RoomScreen {
                             error!("Failed to open URL {:?}. Error: {:?}", url, e);
                         }
                     }
+                }
+
+                if let LoadingModalAction::Close = action.as_widget_action().cast() {
+                    self.modal(id!(loading_model)).close(cx);
                 }
             }
 
@@ -1415,12 +1466,25 @@ impl RoomScreen {
         let Some(tl) = self.tl_state.as_mut() else { return };
 
         let mut done_loading = false;
+        let mut should_continue_backwards_pagination = false;
         let mut num_updates = 0;
         let mut typing_users = Vec::new();
 
         while let Ok(update) = tl.update_receiver.try_recv() {
             num_updates += 1;
             match update {
+                TimelineUpdate::FirstUpdate { initial_items } => {
+                    tl.content_drawn_since_last_update.clear();
+                    tl.profile_drawn_since_last_update.clear();
+                    tl.fully_paginated = false;
+                    // Set the portal list to the very bottom of the timeline.
+                    portal_list.set_first_id_and_scroll(initial_items.len().saturating_sub(1), 0.0);
+                    portal_list.set_tail_range(true);
+                    jump_to_bottom.update_visibility(true);
+
+                    tl.items = initial_items;
+                    done_loading = true;
+                }
                 TimelineUpdate::NewItems { new_items, changed_indices, is_append, clear_cache } => {
                     if new_items.is_empty() {
                         if !tl.items.is_empty() {
@@ -1498,6 +1562,21 @@ impl RoomScreen {
                         tl.content_drawn_since_last_update.clear();
                         tl.profile_drawn_since_last_update.clear();
                         tl.fully_paginated = false;
+
+                        // If this RoomScreen is showing the loading modal and has an ongoing backwards pagination request,
+                        // then we should update the status message in that loading modal
+                        // and then continue paginating backwards until we find the target event.
+                        // Note that we do this here because `clear_cache` will always be true if backwards pagination occurred.
+                        if let LoadingModalState::BackwardsPaginateUntilEvent {
+                            ref mut events_paginated, target_event_id, ..
+                        } = &mut self.loading_modal_state {
+                            *events_paginated += new_items.len() - tl.items.len();
+                            self.view.loading_modal(id!(loading_modal_inner)).set_status(&format!(
+                                "Looking for event {target_event_id}\n\n\
+                                Loaded {events_paginated} messages so far...",
+                            ));
+                            should_continue_backwards_pagination = true;
+                        }
                     } else {
                         tl.content_drawn_since_last_update.remove(changed_indices.clone());
                         tl.profile_drawn_since_last_update.remove(changed_indices.clone());
@@ -1506,9 +1585,63 @@ impl RoomScreen {
                     tl.items = new_items;
                     done_loading = true;
                 }
+                TimelineUpdate::TargetEventFound { target_event_id, index } => {
+                    log!("Target event found in room {}: {target_event_id}, index: {index}", tl.room_id);
+                    tl.request_sender.send_if_modified(|requests| {
+                        requests.retain(|r| r.room_id != tl.room_id);
+                        // no need to notify/wake-up all receivers for a completed request
+                        false
+                    });
+
+                    // sanity check to ensure the target event is in the timeline
+                    let item = tl.items.get(index);
+                    let is_valid = item.is_some_and(|item|
+                        item.as_event()
+                            .is_some_and(|ev| ev.event_id() == Some(&target_event_id))
+                    );
+                    log!("TargetEventFound: is_valid? {is_valid}. room {}, event {target_event_id}, index {index} of {}\n  --> item: {item:?}", tl.room_id, tl.items.len());
+                    if is_valid {
+                        // NOTE: this code was copied from the `ReplyPreviewClicked` action handler;
+                        //       we should deduplicate them at some point.
+                        let distance = (index as isize - portal_list.first_id() as isize).abs() as f64;
+                        let base_speed = 15.0;
+                        // apply a scaling based on the distance
+                        let scaled_speed = base_speed * (distance * distance);
+                        // Scroll to the message right above the replied-to message.
+                        // FIXME: `smooth_scroll_to` should accept a scroll offset parameter too,
+                        //       so that we can scroll to the replied-to message and have it
+                        //       appear beneath the top of the viewport.
+                        portal_list.smooth_scroll_to(cx, index.saturating_sub(1), scaled_speed);
+                        // start highlight animation.
+                        tl.message_highlight_animation_state = MessageHighlightAnimationState::Pending {
+                            item_id: index
+                        };
+                        // We successfully found the target event, so we can close the loading modal,
+                        // reset the loading modal state to `None`, and stop issuing backwards pagination requests.
+                        self.view.loading_modal(id!(loading_modal_inner)).set_state(LoadingModalState::None);
+                        self.view.modal(id!(loading_modal)).close(cx);
+                        self.loading_modal_state = LoadingModalState::None;
+                    }
+                    else {
+                        // Here, the target event was not found in the current timeline,
+                        // or we found it previously but it is no longer in the timeline (or has moved),
+                        // which means we encountered an error and are unable to jump to the target event.
+                        error!("Target event index {index} of {} is out of bounds for room {}", tl.items.len(), tl.room_id);
+                        // Show this error in the loading modal, which should already be open.
+                        self.view.loading_modal(id!(loading_modal_inner)).set_state(LoadingModalState::Error(
+                            format!("Unable to find replied-to message; it may have been deleted."),
+                        ));
+                    }
+
+                    should_continue_backwards_pagination = false;
+
+                    // redraw now before any other items get added to the timeline list.
+                    self.view.redraw(cx);
+                }
                 TimelineUpdate::PaginationRunning(direction) => {
                     if direction == PaginationDirection::Backwards {
                         top_space.set_visible(true);
+                        done_loading = false;
                     } else {
                         error!("Unexpected PaginationRunning update in the Forwards direction");
                     }
@@ -1519,8 +1652,12 @@ impl RoomScreen {
                 }
                 TimelineUpdate::PaginationIdle { fully_paginated, direction } => {
                     if direction == PaginationDirection::Backwards {
-                        done_loading = true;
+                        // Don't set `done_loading` to `true`` here, because we want to keep the top space visible
+                        // (with the "loading" message) until the corresponding `NewItems` update is received.
                         tl.fully_paginated = fully_paginated;
+                        if fully_paginated {
+                            done_loading = true;
+                        }
                     } else {
                         error!("Unexpected PaginationIdle update in the Forwards direction");
                     }
@@ -1552,6 +1689,14 @@ impl RoomScreen {
                     typing_users = users;
                 }
             }
+        }
+
+        if should_continue_backwards_pagination {
+            submit_async_request(MatrixRequest::PaginateRoomTimeline {
+                room_id: tl.room_id.clone(),
+                num_events: 50,
+                direction: PaginationDirection::Backwards,
+            });
         }
 
         if done_loading {
@@ -1675,7 +1820,7 @@ impl RoomScreen {
         let (mut tl_state, first_time_showing_room) = if let Some(existing) = TIMELINE_STATES.lock().unwrap().remove(&room_id) {
             (existing, false)
         } else {
-            let (update_sender, update_receiver) = take_timeline_update_receiver(&room_id)
+            let (update_sender, update_receiver, request_sender) = take_timeline_endpoints(&room_id)
                 .expect("BUG: couldn't get timeline state for first-viewed room.");
             let new_tl_state = TimelineUiState {
                 room_id: room_id.clone(),
@@ -1685,6 +1830,7 @@ impl RoomScreen {
                 content_drawn_since_last_update: RangeSet::new(),
                 profile_drawn_since_last_update: RangeSet::new(),
                 update_receiver,
+                request_sender,
                 media_cache: MediaCache::new(MediaFormatConst::File, Some(update_sender)),
                 replying_to: None,
                 saved_state: SavedState::default(),
@@ -1743,14 +1889,20 @@ impl RoomScreen {
 
     /// Invoke this when this RoomScreen/timeline is being hidden or no longer being shown.
     fn hide_timeline(&mut self) {
-        if let Some(room_id) = self.room_id.clone() {
-            self.save_state();
-            self.location_preview(id!(location_preview)).clear();
-            submit_async_request(MatrixRequest::SubscribeToTypingNotices {
-                room_id,
-                subscribe: false,
-            });
-        }
+        let Some(room_id) = self.room_id.clone() else { return };
+
+        self.save_state();
+
+        // When closing a room view, we do the following with non-persistent states:
+        // * Unsubscribe from typing notices, since we don't care about them
+        //   when a given room isn't visible.
+        // * Clear the location preview. We don't save this to the TimelineUiState
+        //   because the location might change by the next time the user opens this same room.
+        self.location_preview(id!(location_preview)).clear();
+        submit_async_request(MatrixRequest::SubscribeToTypingNotices {
+            room_id,
+            subscribe: false,
+        });
     }
 
     /// Removes the current room's visual UI state from this widget
@@ -1822,6 +1974,11 @@ impl RoomScreen {
         }
 
         self.hide_timeline();
+        let loading_modal = self.modal(id!(loading_modal));
+        if loading_modal.is_open() {
+            // this will also reset the state of the inner loading modal
+            loading_modal.close(cx);
+        }
         self.room_name = room_name;
         self.room_id = Some(room_id);
         self.show_timeline(cx);
@@ -1935,6 +2092,11 @@ impl RoomScreenRef {
 /// A message that is sent from a background async task to a room's timeline view
 /// for the purpose of update the Timeline UI contents or metadata.
 pub enum TimelineUpdate {
+    /// The very first update a given room's timeline receives.
+    FirstUpdate {
+        /// The initial list of timeline items (events) for a room.
+        initial_items: Vector<Arc<TimelineItem>>,
+    },
     /// The content of a room's timeline was updated in the background.
     NewItems {
         /// The entire list of timeline items (events) for a room.
@@ -1949,6 +2111,14 @@ pub enum TimelineUpdate {
         /// Whether to clear the entire cache of drawn items in the timeline.
         /// This supercedes `index_of_first_change` and is used when the entire timeline is being redrawn.
         clear_cache: bool,
+    },
+    /// The target event ID was found at the given `index` in the timeline items vector.
+    ///
+    /// This means that the RoomScreen widget can scroll the timeline up to this event,
+    /// and the background `timeline_subscriber_handler` async task can stop looking for this event.
+    TargetEventFound {
+        target_event_id: OwnedEventId,
+        index: usize,
     },
     /// A notice that the background task doing pagination for this room is currently running
     /// a pagination request in the given direction, and is waiting for that request to complete.
@@ -1990,6 +2160,11 @@ pub enum TimelineUpdate {
 static TIMELINE_STATES: Mutex<BTreeMap<OwnedRoomId, TimelineUiState>> = Mutex::new(BTreeMap::new());
 
 /// The UI-side state of a single room's timeline, which is only accessed/updated by the UI thread.
+///
+/// This struct should only include states that need to be persisted for a given room
+/// across multiple `Hide`/`Show` cycles of that room's timeline within a RoomScreen.
+/// If a state is more temporary and shouldn't be persisted when the timeline is hidden,
+/// then it should be stored in the RoomScreen widget itself, not in this struct.
 struct TimelineUiState {
     /// The ID of the room that this timeline is for.
     room_id: OwnedRoomId,
@@ -2028,6 +2203,10 @@ struct TimelineUiState {
     /// in a sync context and the sender runs in an async context,
     /// which is okay because a sender on an unbounded channel never needs to block.
     update_receiver: crossbeam_channel::Receiver<TimelineUpdate>,
+
+    /// The sender for timeline requests from a RoomScreen showing this room
+    /// to the background async task that handles this room's timeline updates.
+    request_sender: TimelineRequestSender,
 
     /// The cache of media items (images, videos, etc.) that appear in this timeline.
     ///
@@ -3080,12 +3259,12 @@ impl LocationPreviewRef {
 }
 
 
-/// Actions that can be performed on a message.
+/// Actions related to a specific message within a room timeline.
 #[derive(Clone, DefaultNone, Debug)]
 pub enum MessageAction {
-    /// The user clicked the reply button on the message,
-    /// indicating that they want to reply to this message.
-    MessageReply(usize),
+    /// The user clicked a message's reply button, indicating that they want to
+    /// reply to this message (the message at the given timeline item index).
+    MessageReplyButtonClicked(usize),
     /// The user clicked the inline reply preview above a message
     /// indicating that they want to jump upwards to the replied-to message shown in the preview.
     ReplyPreviewClicked {
@@ -3095,7 +3274,7 @@ pub enum MessageAction {
         /// The event ID of the replied-to message (the target of the reply).
         replied_to_event: OwnedEventId,
     },
-    /// The message with the given item ID should be highlighted.
+    /// The message at the given item index in the timeline should be highlighted.
     MessageHighlight(usize),
     None,
 }
@@ -3133,7 +3312,7 @@ impl Widget for Message {
                 cx.widget_action(
                     widget_uid,
                     &scope.path,
-                    MessageAction::MessageReply(self.item_id),
+                    MessageAction::MessageReplyButtonClicked(self.item_id),
                 );
             }
         }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -17,12 +17,12 @@ use matrix_sdk::{
 use matrix_sdk_ui::{
     room_list_service::{self, RoomListLoadingState},
     sync_service::{self, SyncService},
-    timeline::{AnyOtherFullStateEventContent, EventTimelineItem, RepliedToInfo, TimelineDetails, TimelineItemContent},
+    timeline::{AnyOtherFullStateEventContent, EventTimelineItem, RepliedToInfo, TimelineDetails, TimelineItem, TimelineItemContent},
     Timeline,
 };
 use tokio::{
     runtime::Handle,
-    sync::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender}, task::JoinHandle,
+    sync::{mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender}, watch}, task::JoinHandle,
 };
 use unicode_segmentation::UnicodeSegmentation;
 use std::{cmp::{max, min}, collections::{BTreeMap, BTreeSet}, path:: Path, sync::{Arc, Mutex, OnceLock}};
@@ -197,7 +197,7 @@ impl std::fmt::Display for PaginationDirection {
 pub enum MatrixRequest {
     /// Request from the login screen to log in with the given credentials.
     Login(LoginRequest),
-    /// Request to paginate (backwards fetch) the older events of a room's timeline.
+    /// Request to paginate the older (or newer) events of a room's timeline.
     PaginateRoomTimeline {
         room_id: OwnedRoomId,
         /// The maximum number of timeline events to fetch in each pagination batch.
@@ -774,6 +774,11 @@ pub fn start_matrix_tokio() -> Result<()> {
 }
 
 
+/// A tokio::watch channel sender for sending requests from the RoomScreen UI widget
+/// to the corresponding background async task for that room (its `timeline_subscriber_handler`).
+pub type TimelineRequestSender = watch::Sender<Vec<BackwardsPaginateUntilEventRequest>>;
+
+
 /// Info about a room that our client currently knows about.
 struct RoomInfo {
     #[allow(unused)]
@@ -782,15 +787,20 @@ struct RoomInfo {
     timeline: Arc<Timeline>,
     /// An instance of the clone-able sender that can be used to send updates to this room's timeline.
     timeline_update_sender: crossbeam_channel::Sender<TimelineUpdate>,
-    /// The single receiver that can receive updates to this room's timeline.
+    /// A tuple of two separate channel endpoints that can only be taken *once* by the main UI thread.
     ///
-    /// When a new room is joined, an unbounded crossbeam channel will be created
-    /// and its sender given to a background task that enqueues timeline updates
-    /// as vector diffs when they are received from the server.
-    ///
-    /// The UI thread can take ownership of this receiver in order to receive updates to
-    /// this room's timeline, but only one receiver can exist at a time.
-    timeline_update_receiver: Option<crossbeam_channel::Receiver<TimelineUpdate>>,
+    /// 1. The single receiver that can receive updates to this room's timeline.
+    ///    * When a new room is joined, an unbounded crossbeam channel will be created
+    ///      and its sender given to a background task (the `timeline_subscriber_handler()`)
+    ///      that enqueues timeline updates as it receives timeline vector diffs from the server.
+    ///    * The UI thread can take ownership of this update receiver in order to receive updates
+    ///      to this room's timeline, but only one receiver can exist at a time.
+    /// 2. The sender that can send requests to the background timeline subscriber handler,
+    ///    e.g., to watch for a specific event to be prepended to the timeline (via back pagination).
+    timeline_singleton_endpoints: Option<(
+        crossbeam_channel::Receiver<TimelineUpdate>,
+        TimelineRequestSender,
+    )>,
     /// The async task that listens for timeline updates for this room and sends them to the UI thread.
     timeline_subscriber_handler_task: JoinHandle<()>,
     /// A drop guard for the event handler that represents a subscription to typing notices for this room.
@@ -852,21 +862,27 @@ pub fn is_user_ignored(user_id: &UserId) -> bool {
 }
 
 
-/// Returns the timeline update sender and receiver endpoints for the given room,
-/// if and only if the receiver exists.
+/// Returns three channel endpoints related to the timeline for the given room.
+/// 
+/// 1. A timeline update sender.
+/// 2. The timeline update receiver, which is a singleton, and can only be taken once.
+/// 3. A `tokio::watch` sender that can be used to send requests to the timeline subscriber handler.
 ///
 /// This will only succeed once per room, as only a single channel receiver can exist.
-pub fn take_timeline_update_receiver(
+pub fn take_timeline_endpoints(
     room_id: &OwnedRoomId,
 ) -> Option<(
         crossbeam_channel::Sender<TimelineUpdate>,
         crossbeam_channel::Receiver<TimelineUpdate>,
+        TimelineRequestSender,
     )>
 {
     ALL_ROOM_INFO.lock().unwrap()
         .get_mut(room_id)
-        .and_then(|ri| ri.timeline_update_receiver.take()
-            .map(|receiver| (ri.timeline_update_sender.clone(), receiver))
+        .and_then(|ri| ri.timeline_singleton_endpoints.take()
+            .map(|(receiver, request_sender)| {
+                (ri.timeline_update_sender.clone(), receiver, request_sender)
+            })
         )
 }
 
@@ -1236,10 +1252,12 @@ async fn add_new_room(room: &room_list_service::Room) -> Result<()> {
         .map(|n| n.to_string())
         .ok();
 
+    let (request_sender, request_receiver) = watch::channel(Vec::new());
     let timeline_subscriber_handler_task = Handle::current().spawn(timeline_subscriber_handler(
         room.inner_room().clone(),
         timeline.clone(),
         timeline_update_sender.clone(),
+        request_receiver,
     ));
 
     let latest = latest_event.as_ref().map(
@@ -1268,7 +1286,7 @@ async fn add_new_room(room: &room_list_service::Room) -> Result<()> {
         RoomInfo {
             room_id,
             timeline,
-            timeline_update_receiver: Some(timeline_update_receiver),
+            timeline_singleton_endpoints: Some((timeline_update_receiver, request_sender)),
             timeline_update_sender,
             timeline_subscriber_handler_task,
             typing_notice_subscriber: None,
@@ -1395,180 +1413,275 @@ fn get_latest_event_details(
 }
 
 
+pub struct BackwardsPaginateUntilEventRequest {
+    pub room_id: OwnedRoomId,
+    pub target_event_id: OwnedEventId,
+}
+
 const LOG_TIMELINE_DIFFS: bool = false;
 
+/// A per-room async task that listens for timeline updates and sends them to the UI thread.
+///
+/// One instance of this async task is spawned for each room the client knows about.
 async fn timeline_subscriber_handler(
     room: Room,
     timeline: Arc<Timeline>,
-    sender: crossbeam_channel::Sender<TimelineUpdate>,
+    timeline_update_sender: crossbeam_channel::Sender<TimelineUpdate>,
+    mut request_receiver: watch::Receiver<Vec<BackwardsPaginateUntilEventRequest>>,
 ) {
+
+    /// An inner function that searches the given new timeline items for a target event.
+    ///
+    /// If the target event is found, it is removed from the `target_event_id_opt` and returned,
+    /// along with the index/position of that event in the given iterator of new items.
+    fn find_target_event<'a>(
+        target_event_id_opt: &mut Option<OwnedEventId>,
+        mut new_items_iter: impl Iterator<Item = &'a Arc<TimelineItem>>,
+    ) -> Option<(usize, OwnedEventId)> {
+        let found_index = target_event_id_opt
+            .as_ref()
+            .and_then(|target_event_id| new_items_iter
+                .position(|new_item| new_item
+                    .as_event()
+                    .is_some_and(|new_ev| new_ev.event_id() == Some(target_event_id))
+                )
+            );
+
+        if let Some(index) = found_index {
+            target_event_id_opt.take().map(|ev| (index, ev))
+        } else {
+            None
+        }
+    }
+
+
     let room_id = room.room_id().to_owned();
     log!("Starting timeline subscriber for room {room_id}...");
     let (mut timeline_items, mut subscriber) = timeline.subscribe_batched().await;
     log!("Received initial timeline update of {} items for room {room_id}.", timeline_items.len());
 
-    sender.send(TimelineUpdate::NewItems {
-        new_items: timeline_items.clone(),
-        changed_indices: usize::MIN..usize::MAX,
-        is_append: false,
-        clear_cache: true,
+    timeline_update_sender.send(TimelineUpdate::FirstUpdate {
+        initial_items: timeline_items.clone(),
     }).unwrap_or_else(
-        |_e| panic!("Error: timeline update sender couldn't send update to room {room_id} with initial items!")
+        |_e| panic!("Error: timeline update sender couldn't send first update ({} items) to room {room_id}!", timeline_items.len())
     );
 
     let mut latest_event = timeline.latest_event().await;
 
-    while let Some(batch) = subscriber.next().await {
-        let mut num_updates = 0;
-        // For now we always requery the latest event, but this can be better optimized.
-        let mut reobtain_latest_event = true;
-        let mut index_of_first_change = usize::MAX;
-        let mut index_of_last_change = usize::MIN;
-        // whether to clear the entire cache of drawn items
-        let mut clear_cache = false;
-        // whether the changes include items being appended to the end of the timeline
-        let mut is_append = false;
-        for diff in batch {
-            match diff {
-                VectorDiff::Append { values } => {
-                    let _values_len = values.len();
-                    index_of_first_change = min(index_of_first_change, timeline_items.len());
-                    timeline_items.extend(values);
-                    index_of_last_change = max(index_of_last_change, timeline_items.len());
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Append {_values_len}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                    reobtain_latest_event = true;
-                    is_append = true;
-                    num_updates += 1;
-                }
-                VectorDiff::Clear => {
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Clear"); }
-                    clear_cache = true;
-                    timeline_items.clear();
-                    reobtain_latest_event = true;
-                    num_updates += 1;
-                }
-                VectorDiff::PushFront { value } => {
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PushFront"); }
-                    clear_cache = true;
-                    timeline_items.push_front(value);
-                    reobtain_latest_event |= latest_event.is_none();
-                    num_updates += 1;
-                }
-                VectorDiff::PushBack { value } => {
-                    index_of_first_change = min(index_of_first_change, timeline_items.len());
-                    timeline_items.push_back(value);
-                    index_of_last_change = max(index_of_last_change, timeline_items.len());
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PushBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                    reobtain_latest_event = true;
-                    is_append = true;
-                    num_updates += 1;
-                }
-                VectorDiff::PopFront => {
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PopFront"); }
-                    clear_cache = true;
-                    timeline_items.pop_front();
-                    // This doesn't affect whether we should reobtain the latest event.
-                    num_updates += 1;
-                }
-                VectorDiff::PopBack => {
-                    timeline_items.pop_back();
-                    index_of_first_change = min(index_of_first_change, timeline_items.len());
-                    index_of_last_change = usize::MAX;
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PopBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                    reobtain_latest_event = true;
-                    num_updates += 1;
-                }
-                VectorDiff::Insert { index, value } => {
-                    if index == 0 {
-                        clear_cache = true;
-                    } else {
-                        index_of_first_change = min(index_of_first_change, index);
-                        index_of_last_change = usize::MAX;
-                    }
-                    if index >= timeline_items.len() {
-                        is_append = true;
-                    }
-                    timeline_items.insert(index, value);
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Insert at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                    reobtain_latest_event = true;
-                    num_updates += 1;
-                }
-                VectorDiff::Set { index, value } => {
-                    index_of_first_change = min(index_of_first_change, index);
-                    index_of_last_change  = max(index_of_last_change, index.saturating_add(1));
-                    timeline_items.set(index, value);
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Set at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                    reobtain_latest_event = true;
-                    num_updates += 1;
-                }
-                VectorDiff::Remove { index } => {
-                    if index == 0 {
-                        clear_cache = true;
-                    } else {
-                        index_of_first_change = min(index_of_first_change, index.saturating_sub(1));
-                        index_of_last_change = usize::MAX;
-                    }
-                    timeline_items.remove(index);
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Remove at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                    reobtain_latest_event = true;
-                    num_updates += 1;
-                }
-                VectorDiff::Truncate { length } => {
-                    if length == 0 {
-                        clear_cache = true;
-                    } else {
-                        index_of_first_change = min(index_of_first_change, length.saturating_sub(1));
-                        index_of_last_change = usize::MAX;
-                    }
-                    timeline_items.truncate(length);
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Truncate to length {length}. Changes: {index_of_first_change}..{index_of_last_change}"); }
-                    reobtain_latest_event = true;
-                    num_updates += 1;
-                }
-                VectorDiff::Reset { values } => {
-                    if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Reset, new length {}", values.len()); }
-                    clear_cache = true; // we must assume all items have changed.
-                    timeline_items = values;
-                    reobtain_latest_event = true;
-                    num_updates += 1;
-                }
-            }
+    let mut target_event_id = None;
+    let mut found_target_event_id = None;
+
+    loop { tokio::select! {
+        // we must check for new requests before handling new timeline updates.
+        biased;
+
+        Ok(()) = request_receiver.changed() => {
+            target_event_id = request_receiver
+                .borrow_and_update()
+                .iter()
+                .find_map(|req| (req.room_id == room_id).then(|| req.target_event_id.clone()));
         }
 
-        if num_updates > 0 {
-            let new_latest_event = if reobtain_latest_event {
-                timeline.latest_event().await
+        batch_opt = subscriber.next() => {
+            if let Some(batch) = batch_opt {
+                let mut num_updates = 0;
+                // For now we always requery the latest event, but this can be better optimized.
+                let mut reobtain_latest_event = true;
+                let mut index_of_first_change = usize::MAX;
+                let mut index_of_last_change = usize::MIN;
+                // whether to clear the entire cache of drawn items
+                let mut clear_cache = false;
+                // whether the changes include items being appended to the end of the timeline
+                let mut is_append = false;
+                for diff in batch {
+                    match diff {
+                        VectorDiff::Append { values } => {
+                            let _values_len = values.len();
+                            index_of_first_change = min(index_of_first_change, timeline_items.len());
+                            timeline_items.extend(values);
+                            index_of_last_change = max(index_of_last_change, timeline_items.len());
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Append {_values_len}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                            reobtain_latest_event = true;
+                            is_append = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::Clear => {
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Clear"); }
+                            clear_cache = true;
+                            timeline_items.clear();
+                            reobtain_latest_event = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::PushFront { value } => {
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PushFront"); }
+                            if let Some((index, _ev)) = found_target_event_id.as_mut() {
+                                *index += 1; // account for this new `value` being prepended.
+                            } else {
+                                found_target_event_id = find_target_event(&mut target_event_id, std::iter::once(&value));
+                            }
+                            
+                            clear_cache = true;
+                            timeline_items.push_front(value);
+                            reobtain_latest_event |= latest_event.is_none();
+                            num_updates += 1;
+                        }
+                        VectorDiff::PushBack { value } => {
+                            index_of_first_change = min(index_of_first_change, timeline_items.len());
+                            timeline_items.push_back(value);
+                            index_of_last_change = max(index_of_last_change, timeline_items.len());
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PushBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                            reobtain_latest_event = true;
+                            is_append = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::PopFront => {
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PopFront"); }
+                            clear_cache = true;
+                            timeline_items.pop_front();
+                            if let Some((i, _ev)) = found_target_event_id.as_mut() {
+                                *i = i.saturating_sub(1); // account for the first item being removed.
+                            }
+                            // This doesn't affect whether we should reobtain the latest event.
+                            num_updates += 1;
+                        }
+                        VectorDiff::PopBack => {
+                            timeline_items.pop_back();
+                            index_of_first_change = min(index_of_first_change, timeline_items.len());
+                            index_of_last_change = usize::MAX;
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff PopBack. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                            reobtain_latest_event = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::Insert { index, value } => {
+                            if index == 0 {
+                                clear_cache = true;
+                            } else {
+                                index_of_first_change = min(index_of_first_change, index);
+                                index_of_last_change = usize::MAX;
+                            }
+                            if index >= timeline_items.len() {
+                                is_append = true;
+                            }
+
+                            if let Some((i, _ev)) = found_target_event_id.as_mut() {
+                                // account for this new `value` being inserted before the previously-found target event's index.
+                                if index <= *i {
+                                    *i += 1;
+                                }
+                            } else {
+                                found_target_event_id = find_target_event(&mut target_event_id, std::iter::once(&value))
+                                    .map(|(i, ev)| (i + index, ev));
+                            }
+
+                            timeline_items.insert(index, value);
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Insert at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                            reobtain_latest_event = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::Set { index, value } => {
+                            index_of_first_change = min(index_of_first_change, index);
+                            index_of_last_change  = max(index_of_last_change, index.saturating_add(1));
+                            timeline_items.set(index, value);
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Set at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                            reobtain_latest_event = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::Remove { index } => {
+                            if index == 0 {
+                                clear_cache = true;
+                            } else {
+                                index_of_first_change = min(index_of_first_change, index.saturating_sub(1));
+                                index_of_last_change = usize::MAX;
+                            }
+                            if let Some((i, _ev)) = found_target_event_id.as_mut() {
+                                // account for an item being removed before the previously-found target event's index.
+                                if index <= *i {
+                                    *i = i.saturating_sub(1);
+                                }
+                            } 
+                            timeline_items.remove(index);
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Remove at {index}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                            reobtain_latest_event = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::Truncate { length } => {
+                            if length == 0 {
+                                clear_cache = true;
+                            } else {
+                                index_of_first_change = min(index_of_first_change, length.saturating_sub(1));
+                                index_of_last_change = usize::MAX;
+                            }
+                            timeline_items.truncate(length);
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Truncate to length {length}. Changes: {index_of_first_change}..{index_of_last_change}"); }
+                            reobtain_latest_event = true;
+                            num_updates += 1;
+                        }
+                        VectorDiff::Reset { values } => {
+                            if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id} diff Reset, new length {}", values.len()); }
+                            clear_cache = true; // we must assume all items have changed.
+                            timeline_items = values;
+                            reobtain_latest_event = true;
+                            num_updates += 1;
+                        }
+                    }
+                }
+        
+                if num_updates > 0 {
+                    let new_latest_event = if reobtain_latest_event {
+                        timeline.latest_event().await
+                    } else {
+                        None
+                    };
+        
+                    let changed_indices = index_of_first_change..index_of_last_change;
+        
+                    if LOG_TIMELINE_DIFFS {
+                        log!("timeline_subscriber: applied {num_updates} updates for room {room_id}, timeline now has {} items. is_append? {is_append}, clear_cache? {clear_cache}. Changes: {changed_indices:?}.", timeline_items.len());
+                    }
+                    timeline_update_sender.send(TimelineUpdate::NewItems {
+                        new_items: timeline_items.clone(),
+                        changed_indices,
+                        clear_cache,
+                        is_append,
+                    }).expect("Error: timeline update sender couldn't send update with new items!");
+
+                    // We must send this update *after* the actual NewItems update,
+                    // otherwise the UI thread (RoomScreen) won't be able to correctly locate the target event.
+                    if let Some((index, target_event_id)) = found_target_event_id.take() {
+                        timeline_update_sender.send(
+                            TimelineUpdate::TargetEventFound {
+                                target_event_id: target_event_id.clone(),
+                                index,
+                            }
+                        ).unwrap_or_else(
+                            |_e| panic!("Error: timeline update sender couldn't send TargetEventFound({target_event_id}, {index}) to room {room_id}!")
+                        );
+                    }
+
+                    // Send a Makepad-level signal to update this room's timeline UI view.
+                    SignalToUI::set_ui_signal();
+                
+                    // Update the latest event for this room.
+                    if let Some(new_latest) = new_latest_event {
+                        if latest_event.as_ref().map_or(true, |ev| ev.timestamp() < new_latest.timestamp()) {
+                            let room_avatar_changed = update_latest_event(room_id.clone(), &new_latest);
+                            latest_event = Some(new_latest);
+                            if room_avatar_changed {
+                                spawn_fetch_room_avatar(room.clone());
+                            }
+                        }
+                    }
+                }
             } else {
-                None
-            };
-
-            let changed_indices = index_of_first_change..index_of_last_change;
-
-            if LOG_TIMELINE_DIFFS {
-                log!("timeline_subscriber: applied {num_updates} updates for room {room_id}, timeline now has {} items. is_append? {is_append}, clear_cache? {clear_cache}. Changes: {changed_indices:?}.", timeline_items.len());
+                break;
             }
-            sender.send(TimelineUpdate::NewItems {
-                new_items: timeline_items.clone(),
-                changed_indices,
-                clear_cache,
-                is_append,
-            }).expect("Error: timeline update sender couldn't send update with new items!");
-        
-            // Send a Makepad-level signal to update this room's timeline UI view.
-            SignalToUI::set_ui_signal();
-        
-            // Update the latest event for this room.
-            if let Some(new_latest) = new_latest_event {
-                if latest_event.as_ref().map_or(true, |ev| ev.timestamp() < new_latest.timestamp()) {
-                    let room_avatar_changed = update_latest_event(room_id.clone(), &new_latest);
-                    latest_event = Some(new_latest);
-                    if room_avatar_changed {
-                        spawn_fetch_room_avatar(room.clone());
-                    }
-                }
-            }
+
         }
-    }
+
+        else => {
+            break;
+        }
+    } }
 
     error!("Error: unexpectedly ended timeline subscriber for room {room_id}.");
 }


### PR DESCRIPTION
Closes #223 

A modal is displayed while the backwards pagination requests are ongoing, and the user can cancel/abort the search if it's taking too long.

~~Tested to work for basic scenarios; probably still needs more testing. For example, I haven't tested the cancel feature yet, or the cleanup that happens if you close a RoomScreen while the modal is being displayed and the backwards pagination procedure is running in the background.~~

TODO before merging:
- [ ] ensure modal is only displaying as an overlay on a single RoomScreen widget instead of overlaid on the entire app window
- [ ] test behavior when closing a RoomScreen
    - cannot test this until the modal is fixed to not occupy the entire screen 
- [x] test cancel button
- [x] test dismissing the modal
- [x] test behavior of label content in modal
- [x] ensure status updates are sent  and handled in a timely manner, and that the modal display is refreshed quickly so that the user can see the status interactively.
- [x] hide the modal _before_ starting the scroll up animation, such that the user can see the animation.
- [x] Submit PR to makepad with support for `Modal::is_open()` function.
- [ ] Fix Makepad `PortalList::smooth_scroll_to()` to avoid drawing _every_ item, and jump to 10 or so items beneath the target item to start, and _then_ scroll upwards to the target item from there.
