### PR TITLE
Display room name in the navigation stack view header

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -194,7 +194,6 @@ impl MatchEvent for App {
                     room_index: _,
                     room_name,
                 } => {
-                    // self.ui.modal(id!(verification_modal)).open(cx);
 
                     self.app_state.rooms_panel.selected_room = Some(SelectedRoom {
                         id: room_id.clone(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -194,17 +194,23 @@ impl MatchEvent for App {
                     room_index: _,
                     room_name,
                 } => {
+                    // self.ui.modal(id!(verification_modal)).open(cx);
+
                     self.app_state.rooms_panel.selected_room = Some(SelectedRoom {
                         id: room_id.clone(),
                         name: room_name.clone(),
                     });
 
                     let widget_uid = self.ui.widget_uid();
+                    // Navigate to the main content view
                     cx.widget_action(
                         widget_uid,
                         &Scope::default().path,
                         StackNavigationAction::NavigateTo(live_id!(main_content_view))
                     );
+                    // Update the Stack Navigation header with the room name
+                    self.ui.label(id!(main_content_view.header.content.title_container.title))
+                        .set_text(&room_name.unwrap_or_else(|| format!("Room ID {}", &room_id)));
                     self.ui.redraw(cx);
                 }
                 RoomListAction::None => { }

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -57,6 +57,20 @@ live_design! {
 
                     main_content_view = <StackNavigationView> {
                         width: Fill, height: Fill
+                        header = {
+                            content = {
+                                button_container = {
+                                    padding: {left: 14}
+                                }
+                                title_container = {
+                                    title = {
+                                        draw_text: {
+                                            color: (ROOM_NAME_TEXT_COLOR)
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         body = {
                             main_content = <MainMobileUI> {}
                         }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1825,7 +1825,7 @@ impl RoomScreen {
         self.room_name = room_name;
         self.room_id = Some(room_id);
         self.show_timeline(cx);
-        self.label(id!(room_name)).set_text(&self.room_name);
+        // self.label(id!(room_name)).set_text(&self.room_name);
     }
 
     /// Sends read receipts based on the current scroll position of the timeline.

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1825,7 +1825,6 @@ impl RoomScreen {
         self.room_name = room_name;
         self.room_id = Some(room_id);
         self.show_timeline(cx);
-        // self.label(id!(room_name)).set_text(&self.room_name);
     }
 
     /// Sends read receipts based on the current scroll position of the timeline.

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -57,6 +57,8 @@ live_design! {
         font_size: (TIMESTAMP_FONT_SIZE),
     }
 
+    ROOM_NAME_TEXT_COLOR = #x0
+
     COLOR_META = #xccc
 
     COLOR_PROFILE_CIRCLE = #xfff8ee


### PR DESCRIPTION
Addresses the last two items of issue https://github.com/project-robius/robrix/issues/226

- The header was showing but with light colors that made it very hard to see
- Now we update the header title on navigation
- Added some padding to the back button

<img width="562" alt="Screenshot 2024-11-18 at 4 06 22 PM" src="https://github.com/user-attachments/assets/9f40dcf5-7f49-4b25-9f4d-c632427d0832">
