### PR TITLE
Use our improved `PortalList::smooth_scroll_to()` behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1936,7 +1936,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1962,17 +1962,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1991,7 +1991,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2009,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2017,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2035,17 +2035,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2062,12 +2062,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2105,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2113,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "simd-adler32",
 ]
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -4195,7 +4195,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=non-full-screen-modals#d7c03bc0e7f66eb1f9095dbf2cdefb6704b00d4a"
+source = "git+https://github.com/kevinaboos/makepad?branch=smooth_scroll_to_improvements#fd85b5bbf84f804d8789dc445775e5e75dcd71a9"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "non-full-screen-modals" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "smooth_scroll_to_improvements" }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1041,7 +1041,7 @@ impl Widget for RoomScreen {
                             // FIXME: `smooth_scroll_to` should accept a scroll offset parameter too,
                             //       so that we can scroll to the replied-to message and have it
                             //       appear beneath the top of the viewport.
-                            portal_list.smooth_scroll_to(cx, index.saturating_sub(1), scaled_speed);
+                            portal_list.smooth_scroll_to(cx, index.saturating_sub(1), scaled_speed, None);
                             // start highlight animation.
                             tl.message_highlight_animation_state = MessageHighlightAnimationState::Pending {
                                 item_id: index
@@ -1616,7 +1616,7 @@ impl RoomScreen {
                         // FIXME: `smooth_scroll_to` should accept a scroll offset parameter too,
                         //       so that we can scroll to the replied-to message and have it
                         //       appear beneath the top of the viewport.
-                        portal_list.smooth_scroll_to(cx, index.saturating_sub(1), scaled_speed);
+                        portal_list.smooth_scroll_to(cx, index.saturating_sub(1), scaled_speed, None);
                         // start highlight animation.
                         tl.message_highlight_animation_state = MessageHighlightAnimationState::Pending {
                             item_id: index

--- a/src/shared/jump_to_bottom_button.rs
+++ b/src/shared/jump_to_bottom_button.rs
@@ -1,6 +1,5 @@
 use makepad_widgets::*;
 
-const SCROLL_TO_BOTTOM_NUM_ANIMATION_ITEMS: usize = 30;
 const SCROLL_TO_BOTTOM_SPEED: f64 = 90.0;
 
 live_design! {
@@ -137,8 +136,8 @@ impl JumpToBottomButton {
         if self.button(id!(jump_to_bottom_button)).clicked(actions) {
             portal_list.smooth_scroll_to_end(
                 cx,
-                SCROLL_TO_BOTTOM_NUM_ANIMATION_ITEMS,
                 SCROLL_TO_BOTTOM_SPEED,
+                None,
             );
             self.update_visibility(false);
         } else {


### PR DESCRIPTION
This changeset ensures that we don't scroll through potentially hundreds or thousands of items on the way to a much older message. There is now a maximum configurable window (number of items) that will be included in the scrolling animation, such that we don't get bogged down rendering thousands of items unnecessarily that barely get shown during the animation.