### PR TITLE
Display Stickers as messages by re-using message display infra

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -8,19 +8,16 @@ use imbl::Vector;
 use makepad_widgets::*;
 use matrix_sdk::{
     ruma::{
-        events::room::{
+        events::{room::{
             message::{
-                AudioMessageEventContent, EmoteMessageEventContent, FileMessageEventContent, FormattedBody, ImageMessageEventContent, LocationMessageEventContent, MessageFormat, MessageType, NoticeMessageEventContent, RoomMessageEventContent, TextMessageEventContent, VideoMessageEventContent
-            },
-            MediaSource,
-        }, matrix_uri::MatrixId, uint, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, UserId
+                AudioMessageEventContent, CustomEventContent, EmoteMessageEventContent, FileMessageEventContent, FormattedBody, ImageMessageEventContent, KeyVerificationRequestEventContent, LocationMessageEventContent, MessageFormat, MessageType, NoticeMessageEventContent, RoomMessageEventContent, ServerNoticeMessageEventContent, TextMessageEventContent, VideoMessageEventContent
+            }, ImageInfo, MediaSource
+        }, sticker::StickerEventContent}, matrix_uri::MatrixId, uint, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, UserId
     },
     OwnedServerName,
 };
 use matrix_sdk_ui::timeline::{
-    self, EventTimelineItem, MemberProfileChange, Profile, ReactionsByKeyBySender, RepliedToInfo,
-    RoomMembershipChange, TimelineDetails, TimelineItem, TimelineItemContent, TimelineItemKind,
-    VirtualTimelineItem,
+    self, EventTimelineItem, InReplyToDetails, MemberProfileChange, Profile, ReactionsByKeyBySender, RepliedToInfo, RoomMembershipChange, TimelineDetails, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem
 };
 use robius_location::Coordinates;
 
@@ -30,7 +27,7 @@ use crate::{
         user_profile_cache,
     }, shared::{
         avatar::{AvatarRef, AvatarWidgetRefExt}, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt}, jump_to_bottom_button::JumpToBottomButtonWidgetExt, text_or_image::{TextOrImageRef, TextOrImageWidgetRefExt}, typing_animation::TypingAnimationWidgetExt
-    }, sliding_sync::{get_client, submit_async_request, take_timeline_endpoints, BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineRequestSender}, utils::{self, unix_time_millis_to_datetime, MediaFormatConst}
+    }, sliding_sync::{get_client, submit_async_request, take_timeline_endpoints, BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineRequestSender}, utils::{self, unix_time_millis_to_datetime, ImageFormat, MediaFormatConst}
 };
 use rangemap::RangeSet;
 
@@ -1386,7 +1383,22 @@ impl Widget for RoomScreen {
                                     item_id,
                                     room_id,
                                     event_tl_item,
-                                    message,
+                                    MessageOrSticker::Message(message),
+                                    prev_event,
+                                    &mut tl_state.media_cache,
+                                    item_drawn_status,
+                                    room_screen_widget_uid,
+                                )
+                            }
+                            TimelineItemContent::Sticker(sticker) => {
+                                let prev_event = tl_items.get(tl_idx.saturating_sub(1));
+                                populate_message_view(
+                                    cx,
+                                    list,
+                                    item_id,
+                                    room_id,
+                                    event_tl_item,
+                                    MessageOrSticker::Sticker(sticker.content()),
                                     prev_event,
                                     &mut tl_state.media_cache,
                                     item_drawn_status,
@@ -1431,7 +1443,7 @@ impl Widget for RoomScreen {
                             ),
                             unhandled => {
                                 let item = list.item(cx, item_id, live_id!(SmallStateEvent));
-                                item.label(id!(content)).set_text(&format!("[TODO] {:?}", unhandled));
+                                item.label(id!(content)).set_text(&format!("[Unsupported] {:?}", unhandled));
                                 (item, ItemDrawnStatus::both_drawn())
                             }
                         }
@@ -2357,18 +2369,127 @@ impl ItemDrawnStatus {
     }
 }
 
+/// Abstracts over a message or sticker that can be displayed in a timeline.
+pub enum MessageOrSticker<'e> {
+    Message(&'e timeline::Message),
+    Sticker(&'e StickerEventContent),
+}
+impl MessageOrSticker<'_> {
+    /// Returns the type of this message or sticker.
+    pub fn get_type(&self) -> MessageOrStickerType {
+        match self {
+            Self::Message(msg) => match msg.msgtype() {
+                MessageType::Audio(audio) => MessageOrStickerType::Audio(audio),
+                MessageType::Emote(emote) => MessageOrStickerType::Emote(emote),
+                MessageType::File(file) => MessageOrStickerType::File(file),
+                MessageType::Image(image) => MessageOrStickerType::Image(image),
+                MessageType::Location(location) => MessageOrStickerType::Location(location),
+                MessageType::Notice(notice) => MessageOrStickerType::Notice(notice),
+                MessageType::ServerNotice(server_notice) => MessageOrStickerType::ServerNotice(server_notice),
+                MessageType::Text(text) => MessageOrStickerType::Text(text),
+                MessageType::Video(video) => MessageOrStickerType::Video(video),
+                MessageType::VerificationRequest(verification_request) => MessageOrStickerType::VerificationRequest(verification_request),
+                MessageType::_Custom(custom) => MessageOrStickerType::_Custom(custom),
+                _ => MessageOrStickerType::Unknown,
+            },
+            Self::Sticker(sticker) => MessageOrStickerType::Sticker(sticker),
+        }
+    }
+
+    /// Returns the body of this message or sticker, which is a text representation of its content.
+    pub fn body(&self) -> &str {
+        match self {
+            Self::Message(msg) => msg.body(),
+            Self::Sticker(sticker) => sticker.body.as_str(),
+        }
+    }
+    /// Returns the event that this message is replying to, if any.
+    ///
+    /// Returns `None` for stickers.
+    pub fn in_reply_to(&self) -> Option<&InReplyToDetails> {
+        match self {
+            Self::Message(msg) => msg.in_reply_to(),
+            _ => None,
+        }
+    }
+}
+
+/// Abstracts over the different types of messages or stickers that can be displayed in a timeline.
+pub enum MessageOrStickerType<'e> {
+    /// An audio message.
+    Audio(&'e AudioMessageEventContent),
+    /// An emote message.
+    Emote(&'e EmoteMessageEventContent),
+    /// A file message.
+    File(&'e FileMessageEventContent),
+    /// An image message.
+    Image(&'e ImageMessageEventContent),
+    /// A location message.
+    Location(&'e LocationMessageEventContent),
+    /// A notice message.
+    Notice(&'e NoticeMessageEventContent),
+    /// A server notice message.
+    ServerNotice(&'e ServerNoticeMessageEventContent),
+    /// A text message.
+    Text(&'e TextMessageEventContent),
+    /// A video message.
+    Video(&'e VideoMessageEventContent),
+    /// A request to initiate a key verification.
+    VerificationRequest(&'e KeyVerificationRequestEventContent),
+    /// A custom message.
+    _Custom(&'e CustomEventContent),
+    /// A sticker message.
+    Sticker(&'e StickerEventContent),
+    Unknown,
+}
+impl MessageOrStickerType<'_> {
+    /// Returns details of the image for this message or sticker, if it contains one.
+    pub fn get_image_info(&self) -> Option<(Option<ImageInfo>, MediaSource)> {
+        match self {
+            Self::Image(image) => Some((
+                image.info.clone().map(|info| *info),
+                image.source.clone(),
+            )),
+            Self::Sticker(sticker) => Some((
+                Some(sticker.info.clone()),
+                sticker.source.clone().into(),
+            )),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Audio(_) => "Audio",
+            Self::Emote(_) => "Emote",
+            Self::File(_) => "File",
+            Self::Image(_) => "Image",
+            Self::Location(_) => "Location",
+            Self::Notice(_) => "Notice",
+            Self::ServerNotice(_) => "ServerNotice",
+            Self::Text(_) => "Text",
+            Self::Video(_) => "Video",
+            Self::VerificationRequest(_) => "VerificationRequest",
+            Self::_Custom(_) => "Custom",
+            Self::Sticker(_) => "Sticker",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+
 /// Creates, populates, and adds a Message liveview widget to the given `PortalList`
 /// with the given `item_id`.
 ///
-/// The content of the returned `Message` widget is populated with data from the given `message`
-/// and its parent `EventTimelineItem`.
+/// The content of the returned `Message` widget is populated with data from a message
+/// or sticker and its containing `EventTimelineItem`.
 fn populate_message_view(
     cx: &mut Cx2d,
     list: &mut PortalList,
     item_id: usize,
     room_id: &OwnedRoomId,
     event_tl_item: &EventTimelineItem,
-    message: &timeline::Message,
+    message: MessageOrSticker,
     prev_event: Option<&Arc<TimelineItem>>,
     media_cache: &mut MediaCache,
     item_drawn_status: ItemDrawnStatus,
@@ -2381,10 +2502,10 @@ fn populate_message_view(
     let mut is_notice = false; // whether this message is a Notice
 
     // Determine whether we can use a more compact UI view that hides the user's profile info
-    // if the previous message was sent by the same user within 10 minutes.
+    // if the previous message (including stickers) was sent by the same user within 10 minutes.
     let use_compact_view = match prev_event.map(|p| p.kind()) {
         Some(TimelineItemKind::Event(prev_event_tl_item)) => match prev_event_tl_item.content() {
-            TimelineItemContent::Message(_prev_msg) => {
+            TimelineItemContent::Message(_) | TimelineItemContent::Sticker(_) => {
                 let prev_msg_sender = prev_event_tl_item.sender();
                 prev_msg_sender == event_tl_item.sender()
                     && ts_millis.0
@@ -2400,8 +2521,8 @@ fn populate_message_view(
     // to avoid having to call it twice.
     let mut set_username_and_get_avatar_retval = None;
 
-    let (item, used_cached_item) = match message.msgtype() {
-        MessageType::Text(TextMessageEventContent { body, formatted, .. }) => {
+    let (item, used_cached_item) = match message.get_type() {
+        MessageOrStickerType::Text(TextMessageEventContent { body, formatted, .. }) => {
             let template = if use_compact_view {
                 live_id!(CondensedMessage)
             } else {
@@ -2422,7 +2543,7 @@ fn populate_message_view(
         }
         // A notice message is just a message sent by an automated bot,
         // so we treat it just like a message but use a different font color.
-        MessageType::Notice(NoticeMessageEventContent { body, formatted, .. }) => {
+        MessageOrStickerType::Notice(NoticeMessageEventContent { body, formatted, .. }) => {
             is_notice = true;
             let template = if use_compact_view {
                 live_id!(CondensedMessage)
@@ -2456,7 +2577,7 @@ fn populate_message_view(
         }
         // An emote is just like a message but is prepended with the user's name
         // to indicate that it's an "action" that the user is performing.
-        MessageType::Emote(EmoteMessageEventContent { body, formatted, .. }) => {
+        MessageOrStickerType::Emote(EmoteMessageEventContent { body, formatted, .. }) => {
             let template = if use_compact_view {
                 live_id!(CondensedMessage)
             } else {
@@ -2498,7 +2619,8 @@ fn populate_message_view(
                 (item, false)
             }
         }
-        MessageType::Image(image) => {
+        // Handle images and sticker messages that are static images
+        mtype @ MessageOrStickerType::Image(_) | mtype @ MessageOrStickerType::Sticker(_) => {
             let template = if use_compact_view {
                 live_id!(CondensedImageMessage)
             } else {
@@ -2508,17 +2630,23 @@ fn populate_message_view(
             if existed && item_drawn_status.content_drawn {
                 (item, true)
             } else {
+                let image_info = mtype.get_image_info();
+                log!("populate_image_message: mimetype: {:?}, event ID: {:?}",
+                    image_info.as_ref().and_then(|(info, _)| info.as_ref().and_then(|i| i.mimetype.clone())),
+                    event_tl_item.event_id(),
+                );
+
                 let is_image_fully_drawn = populate_image_message_content(
                     cx,
                     &item.text_or_image(id!(content.message)),
-                    image,
+                    image_info,
                     media_cache,
                 );
                 new_drawn_status.content_drawn = is_image_fully_drawn;
                 (item, false)
             }
         }
-        MessageType::Location(location) => {
+        MessageOrStickerType::Location(location) => {
             let template = if use_compact_view {
                 live_id!(CondensedMessage)
             } else {
@@ -2536,7 +2664,7 @@ fn populate_message_view(
                 (item, false)
             }
         }
-        MessageType::File(file_content) => {
+        MessageOrStickerType::File(file_content) => {
             let template = if use_compact_view {
                 live_id!(CondensedMessage)
             } else {
@@ -2553,7 +2681,7 @@ fn populate_message_view(
                 (item, false)
             }
         }
-        MessageType::Audio(audio) => {
+        MessageOrStickerType::Audio(audio) => {
             let template = if use_compact_view {
                 live_id!(CondensedMessage)
             } else {
@@ -2570,7 +2698,7 @@ fn populate_message_view(
                 (item, false)
             }
         }
-        MessageType::Video(video) => {
+        MessageOrStickerType::Video(video) => {
             let template = if use_compact_view {
                 live_id!(CondensedMessage)
             } else {
@@ -2587,7 +2715,7 @@ fn populate_message_view(
                 (item, false)
             }
         }
-        MessageType::VerificationRequest(verification) => {
+        MessageOrStickerType::VerificationRequest(verification) => {
             let template = live_id!(Message);
             let (item, existed) = list.item_with_existed(cx, item_id, template);
             if existed && item_drawn_status.content_drawn {
@@ -2621,9 +2749,9 @@ fn populate_message_view(
             if existed && item_drawn_status.content_drawn {
                 (item, true)
             } else {
-                let kind = other.msgtype();
+                let kind = other.as_str();
                 item.label(id!(content.message))
-                    .set_text(&format!("[TODO {kind:?}] {}", other.body()));
+                    .set_text(&format!("[Unsupported ({kind})] {}", message.body()));
                 new_drawn_status.content_drawn = true;
                 (item, false)
             }
@@ -2639,7 +2767,7 @@ fn populate_message_view(
             cx,
             &item.view(id!(replied_to_message)),
             room_id,
-            message,
+            message.in_reply_to(),
             event_tl_item.event_id(),
         );
         replied_to_event_id = replied_to_ev_id;
@@ -2689,7 +2817,10 @@ fn populate_message_view(
         item_id,
         replied_to_event_id,
         room_screen_widget_uid,
-        does_message_mention_current_user(message),
+        match message {
+            MessageOrSticker::Message(msg) => does_message_mention_current_user(msg),
+            MessageOrSticker::Sticker(_) => false, // Stickers can't mention users.
+        }
     );
 
     // Set the timestamp.
@@ -2722,8 +2853,9 @@ fn does_message_mention_current_user(
     };
 
     // This covers both direct mentions ("@user") and a replied-to message.
-    message.mentions()
-        .is_some_and(|mentions| mentions.user_ids.contains(current_user_id))
+    message.mentions().is_some_and(
+        |mentions| mentions.user_ids.contains(current_user_id)
+    )
 }
 
 /// Draws the Html or plaintext body of the given Text or Notice message into the `message_content_widget`.
@@ -2750,25 +2882,31 @@ fn populate_text_message_content(
 fn populate_image_message_content(
     cx: &mut Cx2d,
     text_or_image_ref: &TextOrImageRef,
-    image: &ImageMessageEventContent,
+    image_info_source: Option<(Option<ImageInfo>, MediaSource)>,
     media_cache: &mut MediaCache,
 ) -> bool {
     // We don't use thumbnails, as their resolution is too low to be visually useful.
     // We also don't trust the provided mimetype, as it can be incorrect.
-    let (_mimetype, _width, _height) = if let Some(info) = image.info.as_ref() {
-        (
-            info.mimetype
-                .as_deref()
-                .and_then(utils::ImageFormat::from_mimetype),
-            info.width,
-            info.height,
+    let (mimetype, _width, _height) = image_info_source.as_ref()
+        .and_then(|(info, _)| info.as_ref()
+            .map(|info| (info.mimetype.as_deref(), info.width, info.height))
         )
-    } else {
-        (None, None, None)
-    };
+        .unwrap_or_default();
 
-    match &image.source {
-        MediaSource::Plain(mxc_uri) => {
+    // If we have a known mimetype and it's not an image (e.g., an animated)
+    // then show a message about it being unsupported.
+    if let Some(mime) = mimetype.as_ref() {
+        if ImageFormat::from_mimetype(mime).is_none() {
+            log!("populate_image_message_content: unsupported image mimetype: {mime:?}");
+            text_or_image_ref.show_text(&format!(
+                "Images/Stickers of type {mime:?} are not yet supported.",
+            ));
+            return true;
+        }
+    }
+
+    match image_info_source.map(|(_, source)| source) {
+        Some(MediaSource::Plain(mxc_uri)) => {
             // now that we've obtained the image URI and its metadata, try to fetch the image.
             match media_cache.try_get_media_or_fetch(mxc_uri.clone(), None) {
                 MediaCacheEntry::Loaded(data) => {
@@ -2779,35 +2917,39 @@ fn populate_image_message_content(
                     if let Err(e) = show_image_result {
                         let err_str = format!("Failed to display image: {e:?}");
                         error!("{err_str}");
-                        text_or_image_ref.set_text(&err_str);
+                        text_or_image_ref.show_text(&err_str);
                     }
 
                     // We're done drawing the image message content, so mark it as fully drawn.
                     true
                 }
                 MediaCacheEntry::Requested => {
-                    text_or_image_ref.set_text(&format!("Fetching image from {:?}", mxc_uri));
+                    text_or_image_ref.show_text(&format!("Fetching image from {:?}", mxc_uri));
                     // Do not consider this image as being fully drawn, as we're still fetching it.
                     false
                 }
                 MediaCacheEntry::Failed => {
                     text_or_image_ref
-                        .set_text(&format!("Failed to fetch image from {:?}", mxc_uri));
+                        .show_text(&format!("Failed to fetch image from {:?}", mxc_uri));
                     // For now, we consider this as being "complete". In the future, we could support
                     // retrying to fetch the image on a user click/tap.
                     true
                 }
             }
         }
-        MediaSource::Encrypted(encrypted) => {
-            text_or_image_ref.set_text(&format!(
+        Some(MediaSource::Encrypted(encrypted)) => {
+            text_or_image_ref.show_text(&format!(
                 "[TODO] fetch encrypted image at {:?}",
                 encrypted.url
             ));
-            // We consider this as "fully drawn" since we don't yet support encryption,
-            // but *only if* the reply preview was also fully drawn.
+            // We consider this as "fully drawn" since we don't yet support encryption.
             true
         }
+        None => {
+            text_or_image_ref.show_text("Image message had no source URL.");
+            true
+        }
+
     }
 }
 
@@ -2961,9 +3103,9 @@ fn populate_location_message_content(
     true
 }
 
-/// Draws a ReplyPreview above the given `message` if it was in-reply to another message.
+/// Draws a ReplyPreview above a message if it was in-reply to another message.
 ///
-/// If the given `message` was *not* in-reply to another message,
+/// If the given `in_reply_to` details are `None`,
 /// this function will mark the ReplyPreview as non-visible and consider it fully drawn.
 ///
 /// Returns whether the in-reply-to information was available and fully drawn,
@@ -2972,14 +3114,14 @@ fn draw_replied_to_message(
     cx: &mut Cx2d,
     replied_to_message_view: &ViewRef,
     room_id: &OwnedRoomId,
-    message: &timeline::Message,
+    in_reply_to: Option<&InReplyToDetails>,
     message_event_id: Option<&EventId>,
 ) -> (bool, Option<OwnedEventId>) {
     let fully_drawn: bool;
     let show_reply: bool;
     let mut replied_to_event_id = None;
 
-    if let Some(in_reply_to_details) = message.in_reply_to() {
+    if let Some(in_reply_to_details) = in_reply_to {
         replied_to_event_id = Some(in_reply_to_details.event_id.to_owned());
         show_reply = true;
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -436,10 +436,7 @@ live_design! {
         body = {
             content = {
                 padding: { left: 10.0 }
-                message = <TextOrImage> {
-                    width: Fill, height: 300,
-                    image_view = { image = { fit: Horizontal } }
-                }
+                message = <TextOrImage> { }
                 message_annotations = <MessageAnnotations> {}
             }
         }
@@ -451,10 +448,7 @@ live_design! {
     CondensedImageMessage = <CondensedMessage> {
         body = {
             content = {
-                message = <TextOrImage> {
-                    width: Fill, height: 300,
-                    image_view = { image = { fit: Horizontal } }
-                }
+                message = <TextOrImage> { }
                 message_annotations = <MessageAnnotations> {}
             }
         }


### PR DESCRIPTION


* Tweak the `TextOrImage` widget a bit to make it work better.
  Still not perfect, but that's unrelated. At least the text shows up now.

* Show sticker/image plaintext `body` as part of loading/error messages
  * This way the user will at least have some idea of what will be displayed or what was supposed to be displayed.

* remove overridden formatting for ImageMessage and CondensedImageMessage