### PR TITLE
Support displaying server notices

### DIFF
--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -9,7 +9,7 @@ use crate::{
     utils::{self, relative_format},
 };
 
-use super::rooms_list::{RoomPreviewAvatar, RoomPreviewEntry};
+use super::rooms_list::{RoomPreviewAvatar, RoomsListEntry};
 
 live_design! {
     import makepad_draw::shader::std::*;
@@ -209,7 +209,7 @@ impl Widget for RoomPreviewContent {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        if let Some(room_info) = scope.props.get::<RoomPreviewEntry>() {
+        if let Some(room_info) = scope.props.get::<RoomsListEntry>() {
             if let Some(ref name) = room_info.room_name {
                 self.view.label(id!(room_name)).set_text(name);
             }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2620,9 +2620,6 @@ fn populate_message_view(
                 new_drawn_status.content_drawn = true;
                 (item, false)
             }
-            // set the avatar image to a red exclamation mark
-
-            // maybe test with a room that has been upgraded? Office of the Matrix Foundation has been recently upgraded
         }
         // An emote is just like a message but is prepended with the user's name
         // to indicate that it's an "action" that the user is performing.

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ops::Deref};
 use crossbeam_queue::SegQueue;
 use makepad_widgets::*;
-use matrix_sdk::ruma::{MilliSecondsSinceUnixEpoch, OwnedRoomId};
+use matrix_sdk::ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch, OwnedRoomId};
 
 use crate::{app::AppState, sliding_sync::{submit_async_request, MatrixRequest, PaginationDirection}};
 
@@ -80,7 +80,7 @@ pub enum RoomsListUpdate {
     /// the max number of rooms that will ever be loaded.
     LoadedRooms{ max_rooms: Option<u32> },
     /// Add a new room to the list of all rooms.
-    AddRoom(RoomPreviewEntry),
+    AddRoom(RoomsListEntry),
     /// Clear all rooms in the list of all rooms.
     ClearRooms,
     /// Update the latest event content and timestamp for the given room.
@@ -102,6 +102,11 @@ pub enum RoomsListUpdate {
     },
     /// Remove the given room from the list of all rooms.
     RemoveRoom(OwnedRoomId),
+    /// Update the tags for the given room.
+    Tags {
+        room_id: OwnedRoomId,
+        new_tags: Option<Tags>,
+    },
     /// Update the status label at the bottom of the list of all rooms.
     Status {
         status: String,
@@ -132,11 +137,15 @@ pub enum RoomListAction {
 }
 
 #[derive(Debug)]
-pub struct RoomPreviewEntry {
+pub struct RoomsListEntry {
     /// The matrix ID of this room.
     pub room_id: OwnedRoomId,
     /// The displayable name of this room, if known.
     pub room_name: Option<String>,
+    /// The tags associated with this room, if any.
+    /// This includes things like is_favourite, is_low_priority,
+    /// whether the room is a server notice room, etc.
+    pub tags: Option<Tags>,
     /// The timestamp and Html text content of the latest message in this room.
     pub latest: Option<(MilliSecondsSinceUnixEpoch, String)>,
     /// The avatar for this room: either an array of bytes holding the avatar image
@@ -179,14 +188,14 @@ impl Default for RoomPreviewAvatar {
 ///    .collect();
 /// // Then redraw the rooms_list widget.
 /// ```
-pub struct RoomDisplayFilter(Box<dyn Fn(&RoomPreviewEntry) -> bool>);
+pub struct RoomDisplayFilter(Box<dyn Fn(&RoomsListEntry) -> bool>);
 impl Default for RoomDisplayFilter {
     fn default() -> Self {
         RoomDisplayFilter(Box::new(|_| true))
     }
 }
 impl Deref for RoomDisplayFilter {
-    type Target = Box<dyn Fn(&RoomPreviewEntry) -> bool>;
+    type Target = Box<dyn Fn(&RoomsListEntry) -> bool>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -197,7 +206,7 @@ pub struct RoomsList {
     #[deref] view: View,
 
     /// The single set of all known rooms and their cached preview info.
-    #[rust] all_rooms: HashMap<OwnedRoomId, RoomPreviewEntry>,
+    #[rust] all_rooms: HashMap<OwnedRoomId, RoomsListEntry>,
 
     /// The currently-active filter function for the list of rooms.
     ///
@@ -322,6 +331,13 @@ impl Widget for RoomsList {
                     RoomsListUpdate::LoadedRooms { max_rooms } => {
                         self.max_known_rooms = max_rooms;
                         self.update_status_rooms_count();
+                    }
+                    RoomsListUpdate::Tags { room_id, new_tags } => {
+                        if let Some(room) = self.all_rooms.get_mut(&room_id) {
+                            room.tags = new_tags;
+                        } else {
+                            error!("Error: couldn't find room {room_id} to update tags");
+                        }
                     }
                     RoomsListUpdate::Status { status } => {
                         self.status = status;


### PR DESCRIPTION
These are untested, since I cannot find any rooms used for server notices.

Also, obtain the `Tags` for each room and include them in the `RoomsListEntry` struct, which will allow the rooms_list to sort & filter rooms by details like `is_favourite` or `is_low_priority`.