### PR TITLE
Use a fixed height for room previews in the RoomsList

### DIFF
--- a/src/event_preview.rs
+++ b/src/event_preview.rs
@@ -151,7 +151,7 @@ pub fn text_preview_of_message(
         ),
         MessageType::Notice(notice) => format!("<i>{}</i>",
             if let Some(formatted_body) = notice.formatted.as_ref() {
-                &formatted_body.body
+                utils::trim_start_html_whitespace(&formatted_body.body)
             } else {
                 &notice.body
             }
@@ -162,9 +162,16 @@ pub fn text_preview_of_message(
             notice.body,
         ),
         MessageType::Text(text) => {
-            text.formatted.as_ref()
-                .and_then(|fb| (fb.format == MessageFormat::Html)
-                    .then(|| utils::linkify(&fb.body, true).to_string())
+            text.formatted
+                .as_ref()
+                .and_then(|fb|
+                    (fb.format == MessageFormat::Html).then(||
+                        utils::linkify(
+                            utils::trim_start_html_whitespace(&fb.body),
+                            true,
+                        )
+                        .to_string()
+                    )
                 )
                 .unwrap_or_else(|| utils::linkify(&text.body, false).to_string())
         }

--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -103,8 +103,8 @@ live_design! {
     }
 
     pub RoomPreview = {{RoomPreview}} {
-        // Wraps the RoomPreviewContent in an AdaptiveView
-        // to change the displayed content (and its layout) based on the available space in the sidebar.
+        // Wrap the RoomPreviewContent in an AdaptiveView to change the displayed content
+        // (and its layout) based on the available space in the sidebar.
         adaptive_preview = <AdaptiveView> {
             OnlyIcon = <RoomPreviewContent> {
                 align: {x: 0.5, y: 0.5}
@@ -121,7 +121,8 @@ live_design! {
                 avatar = <Avatar> {}
                 <View> {
                     flow: Down
-                    width: Fill, height: Fit
+                    width: Fill, height: 60
+                    spacing: 5
                     header = <View> {
                         width: Fill, height: Fit
                         flow: Right

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2923,11 +2923,19 @@ fn populate_text_message_content(
     body: &str,
     formatted_body: Option<&FormattedBody>,
 ) {
-    if let Some(formatted_body) = formatted_body.as_ref()
-        .and_then(|fb| (fb.format == MessageFormat::Html).then(|| fb.body.clone()))
+    // The message was HTML-formatted rich text.
+    if let Some(fb) = formatted_body.as_ref()
+        .and_then(|fb| (fb.format == MessageFormat::Html).then_some(fb))
     {
-        message_content_widget.show_html(utils::linkify(formatted_body.as_ref(), true));
-    } else {
+        message_content_widget.show_html(
+            utils::linkify(
+                utils::trim_start_html_whitespace(&fb.body),
+                true,
+            )
+        );
+    }
+    // The message was non-HTML plaintext.
+    else {
         match utils::linkify(body, false) {
             Cow::Owned(linkified_html) => message_content_widget.show_html(&linkified_html),
             Cow::Borrowed(plaintext) => message_content_widget.show_plaintext(plaintext),
@@ -3144,10 +3152,11 @@ fn populate_location_message_content(
         let short_lat = lat.find('.').and_then(|dot| lat.get(..dot + 7)).unwrap_or(lat);
         let short_long = long.find('.').and_then(|dot| long.get(..dot + 7)).unwrap_or(long);
         let html_body = format!(
-            "Location: {short_lat},{short_long}\
+            "Location: <a href=\"{}\">{short_lat},{short_long}</a><br>\
             <p><a href=\"https://www.openstreetmap.org/?mlat={lat}&amp;mlon={long}#map=15/{lat}/{long}\">Open in OpenStreetMap</a></p>\
             <p><a href=\"https://www.google.com/maps/search/?api=1&amp;query={lat},{long}\">Open in Google Maps</a></p>\
             <p><a href=\"https://maps.apple.com/?ll={lat},{long}&amp;q={lat},{long}\">Open in Apple Maps</a></p>",
+            location.geo_uri,
         );
         message_content_widget.show_html(html_body);
     } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -189,6 +189,24 @@ pub const MEDIA_THUMBNAIL_FORMAT: MediaFormatConst = MediaFormatConst::Thumbnail
     }
 );
 
+/// Removes leading whitespace and HTML whitespace tags (`<p>` and `<br>`) from the given `text`.
+pub fn trim_start_html_whitespace(mut text: &str) -> &str {
+    let mut prev_text_len = text.len();
+    loop {
+        text = text
+            .trim_start_matches("<p>")
+            .trim_start_matches("<br>")
+            .trim_start_matches("<br/>")
+            .trim_start_matches("<br />")
+            .trim_start();
+
+        if text.len() == prev_text_len {
+            break;
+        }
+        prev_text_len = text.len();
+    }
+    text
+}
 
 /// Looks for bare links in the given `text` and converts them into proper HTML links.
 pub fn linkify(text: &str, is_html: bool) -> Cow<'_, str> {

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -2,13 +2,12 @@ use std::sync::Arc;
 use futures_util::StreamExt;
 use makepad_widgets::{log, warning, ActionDefaultRef, Cx, DefaultNone};
 use matrix_sdk::{
-    crypto::{AcceptedProtocols, CancelInfo, EmojiShortAuthString}, encryption::{VerificationState, verification::{
+    crypto::{AcceptedProtocols, CancelInfo, EmojiShortAuthString}, encryption::{verification::{
         SasState, SasVerification, Verification, VerificationRequest,
         VerificationRequestState,
-    }}, ruma::{
+    }, VerificationState}, ruma::{
         events::{
-            key::verification::{request::ToDeviceKeyVerificationRequestEvent, VerificationMethod},
-            room::message::{MessageType, OriginalSyncRoomMessageEvent},
+            key::verification::{request::ToDeviceKeyVerificationRequestEvent, VerificationMethod}, room::message::{MessageType, OriginalSyncRoomMessageEvent}
         },
         UserId,
     }, Client
@@ -69,17 +68,6 @@ pub fn add_verification_event_handlers_and_sync_client(client: Client) {
             }
         }
     );
-
-    // This doesn't seem to be necessary, as we do receive verification requests
-    // without this block.
-    // The sliding sync service must be handling the synchronization already.
-    //
-    /*
-    Handle::current().spawn(async move {
-        client.sync(SyncSettings::new()).await
-            .expect("Client sync loop failed");
-    });
-    */
 }
 
 


### PR DESCRIPTION
* This can probably be further improved to squash it a bit more, and also to add a fade/shadow effect towards the bottom in order to make the visual separation between room previews a bit clearer.

Other miscellaneous formatting improvements:
* Strip leading whitespace and whitespace-like HTML tags (`<p>`, `<br>`) from HTML-formatted messages, both in the timeline and in text previews. This helps avoid weird line breaks in small brief text previews.
* Make the location messages display a clickable `geo:` link.