### PR TITLE
Redesign user profile cache to fetch missing cache entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1998,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2024,17 +2024,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2053,7 +2053,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2071,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2079,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2089,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2097,17 +2097,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2124,12 +2124,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4323,7 +4323,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#5e5e260235ee0049aa1287f8f19c283d69c35db4"
+source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
 
 [[package]]
 name = "typenum"

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1017,6 +1017,13 @@ impl Widget for RoomScreen {
         // that its timeline events have been updated in the background.
         if let Event::Signal = event {
             self.process_timeline_updates(cx, &portal_list);
+
+            // Ideally we would do this elsewhere on the main thread, because it's not room-specific,
+            // but it doesn't hurt to do it here.
+            // TODO: move this up a layer to something higher in the UI tree,
+            //       and wrap it in a `if let Event::Signal` conditional.
+            user_profile_cache::process_user_profile_updates(cx);
+            avatar_cache::process_avatar_updates(cx);
         }
 
         if let Event::Actions(actions) = event {
@@ -3628,10 +3635,12 @@ fn set_avatar_and_get_username(
     // Get the display name and avatar URL from the sender's profile, if available,
     // or if the profile isn't ready, fall back to qeurying our user profile cache.
     let (username_opt, avatar_state) = match sender_profile {
-        TimelineDetails::Ready(profile) => (
-            profile.display_name.clone(),
-            AvatarState::Known(profile.avatar_url.clone()),
-        ),
+        TimelineDetails::Ready(profile) => {
+            (
+                profile.display_name.clone(),
+                AvatarState::Known(profile.avatar_url.clone()),
+            )
+        }
         not_ready => {
             if matches!(not_ready, TimelineDetails::Unavailable) {
                 if let Some(event_id) = event_id {
@@ -3642,7 +3651,7 @@ fn set_avatar_and_get_username(
                 }
             }
             // log!("populate_message_view(): sender profile not ready yet for event {not_ready:?}");
-            user_profile_cache::with_user_profile(cx, sender_user_id, |profile, room_members| {
+            user_profile_cache::with_user_profile(cx, sender_user_id.to_owned(), true, |profile, room_members| {
                 room_members
                     .get(room_id)
                     .map(|rm| {
@@ -3651,7 +3660,12 @@ fn set_avatar_and_get_username(
                             AvatarState::Known(rm.avatar_url().map(|u| u.to_owned())),
                         )
                     })
-                    .unwrap_or_else(|| (profile.username.clone(), profile.avatar_state.clone()))
+                    .unwrap_or_else(|| {
+                        (
+                            profile.username.clone(),
+                            profile.avatar_state.clone(),
+                        )
+                    })
             })
             .unwrap_or((None, AvatarState::Unknown))
         }

--- a/src/profile/user_profile_cache.rs
+++ b/src/profile/user_profile_cache.rs
@@ -1,11 +1,15 @@
+//! A cache of user profiles and room membership info, indexed by user ID.
+//!
+//! The cache is only accessible from the main UI thread.
+
 use crossbeam_queue::SegQueue;
 use makepad_widgets::{log, warning, Cx, SignalToUI};
 use matrix_sdk::{room::RoomMember, ruma::{OwnedRoomId, OwnedUserId, RoomId, UserId}};
 use std::{cell::RefCell, collections::{btree_map::Entry, BTreeMap}};
 
-use crate::profile::user_profile::AvatarState;
+use crate::{profile::user_profile::AvatarState, sliding_sync::{submit_async_request, MatrixRequest}};
 
-use super::user_profile::{UserProfile, UserProfilePaneInfo};
+use super::user_profile::UserProfile;
 
 thread_local! {
     /// A cache of each user's profile and the rooms they are a member of, indexed by user ID.
@@ -13,9 +17,14 @@ thread_local! {
     /// To be of any use, this cache must only be accessed by the main UI thread.
     static USER_PROFILE_CACHE: RefCell<BTreeMap<OwnedUserId, UserProfileCacheEntry>> = const { RefCell::new(BTreeMap::new()) };
 }
-struct UserProfileCacheEntry {
-    user_profile: UserProfile,
-    room_members: BTreeMap<OwnedRoomId, RoomMember>,
+enum UserProfileCacheEntry {
+    /// A request has been issued and we're waiting for it to complete.
+    Requested,
+    /// The profile has been successfully loaded from the server.
+    Loaded {
+        user_profile: UserProfile,
+        rooms: BTreeMap<OwnedRoomId, RoomMember>,
+    },
 }
 
 /// The queue of user profile updates waiting to be processed by the UI thread's event handler.
@@ -55,56 +64,31 @@ impl UserProfileUpdate {
         }
     }
 
-    /// Applies this update to the given user profile pane info,
-    /// only if the user_id and room_id match that of the update.
-    ///
-    /// Returns `true` if the update resulted in any actual content changes.
-    #[allow(unused)]
-    fn apply_to_current_pane(&self, info: &mut UserProfilePaneInfo) -> bool {
-        match self {
-            UserProfileUpdate::Full { new_profile, room_id, room_member } => {
-                if info.user_id == new_profile.user_id {
-                    info.profile_and_room_id.user_profile = new_profile.clone();
-                    if &info.room_id == room_id {
-                        info.room_member = Some(room_member.clone());
-                    }
-                    return true;
-                }
-            }
-            UserProfileUpdate::RoomMemberOnly { room_id, room_member } => {
-                log!("Applying RoomMemberOnly update to user profile pane info: user_id={}, room_id={}, ignored={}",
-                    room_member.user_id(), room_id, room_member.is_ignored(),
-                );
-                if info.user_id == room_member.user_id() && &info.room_id == room_id {
-                    log!("RoomMemberOnly update matches user profile pane info, updating room member.");
-                    info.room_member = Some(room_member.clone());
-                    return true;
-                }
-            }
-            UserProfileUpdate::UserProfileOnly(new_profile) => {
-                if info.user_id == new_profile.user_id {
-                    info.profile_and_room_id.user_profile = new_profile.clone();
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
     /// Applies this update to the given user profile info cache.
     fn apply_to_cache(self, cache: &mut BTreeMap<OwnedUserId, UserProfileCacheEntry>) {
         match self {
             UserProfileUpdate::Full { new_profile, room_id, room_member } => {
-                match cache.entry(new_profile.user_id.to_owned()) {
-                    Entry::Occupied(mut entry) => {
-                        let entry_mut = entry.get_mut();
-                        entry_mut.user_profile = new_profile;
-                        entry_mut.room_members.insert(room_id, room_member);
+                match cache.entry(new_profile.user_id.clone()) {
+                    Entry::Occupied(mut entry) => match entry.get_mut() {
+                        e @ UserProfileCacheEntry::Requested => {
+                            *e = UserProfileCacheEntry::Loaded {
+                                user_profile: new_profile,
+                                rooms: {
+                                    let mut room_members_map = BTreeMap::new();
+                                    room_members_map.insert(room_id, room_member);
+                                    room_members_map
+                                },
+                            };
+                        }
+                        UserProfileCacheEntry::Loaded { user_profile, rooms } => {
+                            *user_profile = new_profile;
+                            rooms.insert(room_id, room_member);
+                        }
                     }
                     Entry::Vacant(entry) => {
-                        entry.insert(UserProfileCacheEntry {
+                        entry.insert(UserProfileCacheEntry::Loaded {
                             user_profile: new_profile,
-                            room_members: {
+                            rooms: {
                                 let mut room_members_map = BTreeMap::new();
                                 room_members_map.insert(room_id, room_member);
                                 room_members_map
@@ -115,19 +99,37 @@ impl UserProfileUpdate {
             }
             UserProfileUpdate::RoomMemberOnly { room_id, room_member } => {
                 match cache.entry(room_member.user_id().to_owned()) {
-                    Entry::Occupied(mut entry) => {
-                        entry.get_mut().room_members.insert(room_id, room_member);
+                    Entry::Occupied(mut entry) => match entry.get_mut() {
+                        e @ UserProfileCacheEntry::Requested => {
+                            // This shouldn't happen, but we can still technically handle it correctly.
+                            warning!("BUG: User profile cache entry was `Requested` for user {} when handling RoomMemberOnly update", room_member.user_id());
+                            *e = UserProfileCacheEntry::Loaded {
+                                user_profile: UserProfile {
+                                    user_id: room_member.user_id().to_owned(),
+                                    username: None,
+                                    avatar_state: AvatarState::Known(room_member.avatar_url().map(|url| url.to_owned())),
+                                },
+                                rooms: {
+                                    let mut room_members_map = BTreeMap::new();
+                                    room_members_map.insert(room_id, room_member);
+                                    room_members_map
+                                },
+                            };
+                        }
+                        UserProfileCacheEntry::Loaded { rooms, .. } => {
+                            rooms.insert(room_id, room_member);
+                        }
                     }
                     Entry::Vacant(entry) => {
                         // This shouldn't happen, but we can still technically handle it correctly.
                         warning!("BUG: User profile cache entry not found for user {} when handling RoomMemberOnly update", room_member.user_id());
-                        entry.insert(UserProfileCacheEntry {
+                        entry.insert(UserProfileCacheEntry::Loaded {
                             user_profile: UserProfile {
                                 user_id: room_member.user_id().to_owned(),
                                 username: None,
                                 avatar_state: AvatarState::Known(room_member.avatar_url().map(|url| url.to_owned())),
                             },
-                            room_members: {
+                            rooms: {
                                 let mut room_members_map = BTreeMap::new();
                                 room_members_map.insert(room_id, room_member);
                                 room_members_map
@@ -137,12 +139,22 @@ impl UserProfileUpdate {
                 }
             }
             UserProfileUpdate::UserProfileOnly(new_profile) => {
-                match cache.entry(new_profile.user_id.to_owned()) {
-                    Entry::Occupied(mut entry) => entry.get_mut().user_profile = new_profile,
+                match cache.entry(new_profile.user_id.clone()) {
+                    Entry::Occupied(mut entry) => match entry.get_mut() {
+                        e @ UserProfileCacheEntry::Requested => {
+                            *e = UserProfileCacheEntry::Loaded {
+                                user_profile: new_profile,
+                                rooms: BTreeMap::new(),
+                            };
+                        }
+                        UserProfileCacheEntry::Loaded { user_profile, .. } => {
+                            *user_profile = new_profile;
+                        }
+                    }
                     Entry::Vacant(entry) => {
-                        entry.insert(UserProfileCacheEntry {
+                        entry.insert(UserProfileCacheEntry::Loaded {
                             user_profile: new_profile,
-                            room_members: BTreeMap::new(),
+                            rooms: BTreeMap::new(),
                         });
                     }
                 }
@@ -171,65 +183,86 @@ pub fn process_user_profile_updates(_cx: &mut Cx) {
 /// This function requires passing in a reference to `Cx`,
 /// which isn't used, but acts as a guarantee that this function
 /// must only be called by the main UI thread.
-#[allow(unused)]
-pub fn with_user_profile<F, R>(_cx: &mut Cx, user_id: &UserId, f: F) -> Option<R>
+pub fn with_user_profile<F, R>(
+    _cx: &mut Cx,
+    user_id: OwnedUserId,
+    fetch_if_missing: bool,
+    f: F,
+) -> Option<R>
 where
     F: FnOnce(&UserProfile, &BTreeMap<OwnedRoomId, RoomMember>) -> R,
 {
-    USER_PROFILE_CACHE.with_borrow(|cache| cache
-        .get(user_id)
-        .map(|entry| f(&entry.user_profile, &entry.room_members))
+    USER_PROFILE_CACHE.with_borrow_mut(|cache|
+        match cache.entry(user_id) {
+            Entry::Occupied(entry) => match entry.get() {
+                UserProfileCacheEntry::Loaded { user_profile, rooms } => {
+                    Some(f(user_profile, rooms))
+                }
+                UserProfileCacheEntry::Requested => {
+                    // log!("User {} profile request is already in flight....", entry.key());
+                    None
+                }
+            }
+            Entry::Vacant(entry) => {
+                if fetch_if_missing {
+                    log!("Did not find User {} in cache, fetching from server.", entry.key());
+                    // TODO: use the extra `via` parameters from `matrix_to_uri.via()`.
+                    submit_async_request(MatrixRequest::GetUserProfile {
+                        user_id: entry.key().clone(),
+                        room_id: None,
+                        local_only: false,
+                    });
+                    entry.insert(UserProfileCacheEntry::Requested);
+                }
+                None
+            }
+        }
     )
 }
 
-/// Returns a clone of the cached user profile for the given user ID, if it exists.
-///
-/// This function requires passing in a reference to `Cx`,
-/// which isn't used, but acts as a guarantee that this function
-/// must only be called by the main UI thread.
-#[allow(unused)]
-pub fn get_user_profile(_cx: &mut Cx, user_id: &UserId) -> Option<UserProfile> {
-    USER_PROFILE_CACHE.with_borrow(|cache| {
-        cache.get(user_id).map(|entry| entry.user_profile.clone())
-    })
-}
 
 /// Returns a clone of the cached user profile for the given user ID
-/// and a clone of that user's room member info for the given room ID.
+/// and a clone of that user's room member info for the given room ID,
+/// only if both are found in the cache.
+///
+/// If either the `user_id` or `room_id` wasn't found in the cache,
+/// and if `fetch_if_missing` is true, then this function will submit a request
+/// to asynchronously fetch the user's room membership info from the server.
 ///
 /// This function requires passing in a reference to `Cx`,
 /// which isn't used, but acts as a guarantee that this function
 /// must only be called by the main UI thread.
 pub fn get_user_profile_and_room_member(
-    _cx: &mut Cx,
-    user_id: &UserId,
+#[allow(unused)]
+_cx: &mut Cx,
+    user_id: OwnedUserId,
     room_id: &RoomId,
+    fetch_if_missing: bool,
 ) -> (Option<UserProfile>, Option<RoomMember>) {
-    USER_PROFILE_CACHE.with_borrow(|cache|
-        if let Some(entry) = cache.get(user_id) {
-            (
-                Some(entry.user_profile.clone()),
-                entry.room_members.get(room_id).cloned(),
-            )
-        } else {
-            (None, None)
+    USER_PROFILE_CACHE.with_borrow_mut(|cache|
+        match cache.entry(user_id) {
+            Entry::Occupied(entry) => match entry.get() {
+                UserProfileCacheEntry::Loaded { user_profile, rooms } => {
+                    (Some(user_profile.clone()), rooms.get(room_id).cloned())
+                }
+                UserProfileCacheEntry::Requested => {
+                    // log!("User {} Room ID {room_id} room member info request is already in flight....", entry.key());
+                    (None, None)
+                }
+            }
+            Entry::Vacant(entry) => {
+                if fetch_if_missing {
+                    log!("Did not find User {} Room ID {room_id} room member info in cache, fetching from server.", entry.key());
+                    // TODO: use the extra `via` parameters from `matrix_to_uri.via()`.
+                    submit_async_request(MatrixRequest::GetUserProfile {
+                        user_id: entry.key().clone(),
+                        room_id: Some(room_id.to_owned()),
+                        local_only: false,
+                    });
+                    entry.insert(UserProfileCacheEntry::Requested);
+                }
+                (None, None)
+            }
         }
-    )
-}
-
-/// Returns a clone of the cached room member info for the given user ID and room ID,
-/// only if both are found in the cache.
-///
-/// This function requires passing in a reference to `Cx`,
-/// which isn't used, but acts as a guarantee that this function
-/// must only be called by the main UI thread.
-pub fn get_user_room_member_info(
-    _cx: &mut Cx,
-    user_id: &UserId,
-    room_id: &RoomId,
-) -> Option<RoomMember> {
-    USER_PROFILE_CACHE.with_borrow(|cache|
-        cache.get(user_id)
-            .and_then(|entry| entry.room_members.get(room_id).cloned())
     )
 }


### PR DESCRIPTION
* Also, track in-flight fetch requests in order to ensure that redundant requests are not re-issued.

* Fix how user profile info is used in the user profile sliding pane, and ensure that an existing avatar image isn't replaced with a not-yet-loaded new one, until that new one is fully loaded.
* Do the same for user display names too.