### PR TITLE
Refactor Verificatiion Badge and tooltip and Fixed Dock DrawDepth Bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1998,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2024,17 +2024,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2053,7 +2053,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2071,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2079,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2089,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2097,17 +2097,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2124,12 +2124,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4323,7 +4323,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#406783658b42e9c037249f2649853cda1164aace"
+source = "git+https://github.com/makepad/makepad?branch=rik#0084948c176a99740af92a71578543c3fcc0b63f"
 
 [[package]]
 name = "typenum"

--- a/src/home/light_themed_dock.rs
+++ b/src/home/light_themed_dock.rs
@@ -5,7 +5,7 @@ live_design! {
     use link::shaders::*;
     use link::widgets::*;
 
-    use crate::shared::styles::*;    
+    use crate::shared::styles::*;
 
     pub Splitter = <SplitterBase> {
         draw_splitter: {
@@ -90,7 +90,7 @@ live_design! {
             }
         }
     }
-    
+
     pub TabCloseButton = <TabCloseButtonBase> {
             // TODO: NEEDS FOCUS STATE
         height: 10.0, width: 10.0,
@@ -260,7 +260,6 @@ live_design! {
         flow: Down,
 
         round_corner: {
-            draw_depth: 20.0
             border_radius: 20.
             fn pixel(self) -> vec4 {
                 let pos = vec2(

--- a/src/shared/color_tooltip.rs
+++ b/src/shared/color_tooltip.rs
@@ -9,7 +9,6 @@ live_design! {
     pub ColorTooltip = {{ColorTooltip}} {
         width: Fill,
         height: Fill,
-        visible: false
         flow: Overlay
         align: {x: 0.0, y: 0.0}
 
@@ -20,18 +19,17 @@ live_design! {
         }
 
         content : <View> {
-            width: Fit
+            width: 300
             height: Fit
-
+            visible: false,
             padding: 2.0
 
             tooltip_bg = <RoundedView> {
-                width: Fit,
+                width: Fill,
                 height: Fit,
                 padding: 7,
 
                 draw_bg: {
-                    // color: #ff0000aa,
                     color: #fff,
                     border_width: 1.5,
                     border_color: #fff,
@@ -39,7 +37,7 @@ live_design! {
                 }
 
                 tooltip_label = <Label> {
-                    width: Fit,
+                    width: Fill,
                     height: Fit,
                     draw_text: {
                         text_style: <REGULAR_TEXT> {}

--- a/src/shared/color_tooltip.rs
+++ b/src/shared/color_tooltip.rs
@@ -1,0 +1,183 @@
+use makepad_widgets::*;
+
+live_design! {
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+    use crate::shared::styles::*;
+
+    pub ColorTooltip = {{ColorTooltip}} {
+        width: Fill,
+        height: Fill,
+        visible: false
+        flow: Overlay
+        align: {x: 0.0, y: 0.0}
+
+        draw_bg: {
+            fn pixel(self) -> vec4 {
+                return vec4(0., 0., 0., 0.0)
+            }
+        }
+
+        content : <View> {
+            width: Fit
+            height: Fit
+
+            padding: 2.0
+
+            tooltip_bg = <RoundedView> {
+                width: Fit,
+                height: Fit,
+                padding: 7,
+
+                draw_bg: {
+                    // color: #ff0000aa,
+                    color: #fff,
+                    border_width: 1.5,
+                    border_color: #fff,
+                    radius: 3.0
+                }
+
+                tooltip_label = <Label> {
+                    width: Fit,
+                    height: Fit,
+                    draw_text: {
+                        text_style: <REGULAR_TEXT> {}
+                        color: #fff
+                        text_wrap: Word
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct ColorTooltip {
+    #[rust]
+    opened: bool,
+
+    #[live]
+    #[find]
+    content: View,
+
+    #[rust(DrawList2d::new(cx))]
+    draw_list: DrawList2d,
+
+    #[redraw]
+    #[area]
+    #[live]
+    draw_bg: DrawQuad,
+
+    #[layout]
+    layout: Layout,
+
+    #[walk]
+    walk: Walk,
+}
+
+impl Widget for ColorTooltip {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if self.opened {
+            self.content.handle_event(cx, event, scope);
+        }
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, _walk: Walk) -> DrawStep {
+        // Start a new overlay,
+        // which allows us to break through the boundaries of the parent component.
+        self.draw_list.begin_overlay_reuse(cx);
+        // Create an independent rendering pass to ensure correct size calculations.
+        cx.begin_pass_sized_turtle(self.layout);
+
+        self.draw_bg.begin(cx, self.walk, self.layout);
+        if self.opened {
+            let _ = self.content.draw_all(cx, scope);
+        }
+        self.draw_bg.end(cx);
+        cx.end_pass_sized_turtle();
+        self.draw_list.end(cx);
+        DrawStep::done()
+    }
+
+    fn set_text(&mut self, text: &str) {
+        self.label(id!(tooltip_label)).set_text(text);
+    }
+}
+
+impl ColorTooltip {
+    pub fn set_pos(&mut self, cx: &mut Cx, pos: DVec2) {
+        self.apply_over(
+            cx,
+            live! {
+                content: { margin: { left: (pos.x), top: (pos.y) } }
+            },
+        );
+    }
+
+    pub fn show(&mut self, cx: &mut Cx) {
+        self.opened = true;
+        self.content.visible = true;
+        self.redraw(cx);
+    }
+
+    pub fn hide(&mut self, cx: &mut Cx) {
+        self.opened = false;
+        self.content.visible = false;
+        self.redraw(cx);
+    }
+
+    pub fn show_with_options(&mut self, cx: &mut Cx, pos: DVec2, text: &str, color: Vec4) {
+        self.set_text(text);
+        self.set_pos(cx, pos);
+        self.set_bg_color(cx, color);
+        self.show(cx);
+    }
+
+    fn set_bg_color(&mut self, cx: &mut Cx, color: Vec4) {
+        self.apply_over(
+            cx,
+            live! {
+                content: {
+                    tooltip_bg = {
+                        draw_bg: {
+                            color: (color)
+                        }
+                    }
+                }
+            },
+        );
+    }
+}
+
+impl ColorTooltipRef {
+    pub fn set_text(&self, text: &str) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_text(text);
+        }
+    }
+
+    pub fn set_pos(&self, cx: &mut Cx, pos: DVec2) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_pos(cx, pos);
+        }
+    }
+
+    pub fn show(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.show(cx);
+        }
+    }
+
+    pub fn hide(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.hide(cx);
+        }
+    }
+
+    pub fn show_with_options(&self, cx: &mut Cx, pos: DVec2, text: &str, color: Vec4) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.show_with_options(cx, pos, text, color);
+        }
+    }
+}

--- a/src/shared/color_tooltip.rs
+++ b/src/shared/color_tooltip.rs
@@ -92,7 +92,7 @@ impl Widget for ColorTooltip {
 
         self.draw_bg.begin(cx, self.walk, self.layout);
         if self.opened {
-            let _ = self.content.draw_all(cx, scope);
+            self.content.draw_all(cx, scope);
         }
         self.draw_bg.end(cx);
         cx.end_pass_sized_turtle();

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -3,6 +3,7 @@ use makepad_widgets::Cx;
 pub mod adaptive_view;
 pub mod avatar;
 pub mod clickable_view;
+pub mod color_tooltip;
 pub mod helpers;
 pub mod html_or_plaintext;
 pub mod icon_button;
@@ -27,4 +28,5 @@ pub fn live_design(cx: &mut Cx) {
     typing_animation::live_design(cx);
     jump_to_bottom_button::live_design(cx);
     verification_badge::live_design(cx);
+    color_tooltip::live_design(cx);
 }

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -1,10 +1,13 @@
 use makepad_widgets::*;
+use matrix_sdk::encryption::VerificationState;
 
+// First, define the verification icons component layout
 live_design! {
     use link::theme::*;
     use link::shaders::*;
     use link::widgets::*;
     use crate::shared::styles::*;
+    use crate::shared::my_tooltip::*;
 
     VERIFICATION_YES = dep("crate://self/resources/icons/verification_yes.svg")
     VERIFICATION_NO = dep("crate://self/resources/icons/verification_no.svg")
@@ -13,6 +16,7 @@ live_design! {
     VerificationIcon = <Icon> {
         icon_walk: { width: 23 }
     }
+
     pub IconYes = <View> {
         visible: false
         width: 31, height: 31
@@ -25,6 +29,7 @@ live_design! {
             }
         }
     }
+
     pub IconNo = <View> {
         visible: false
         width: 31, height: 31
@@ -37,6 +42,7 @@ live_design! {
             }
         }
     }
+
     pub IconUnk = <View> {
         visible: false
         width: 31, height: 31
@@ -50,43 +56,98 @@ live_design! {
         }
     }
 
-    pub VerificationNotice = <TooltipBase> {
-        width: Fill, height: Fill,
+    pub VerificationBadge = {{VerificationBadge}} {
+        width: Fit, height: Fit
         flow: Overlay
+        align: { x: 0.5, y: 0.5 }
 
-        draw_bg: {
-            fn pixel(self) -> vec4 {
-                return vec4(0., 0., 0., 0.0)
-            }
-        }
+        visible: true
 
-        content: <View> {
+        verification_icons = <View> {
             flow: Overlay
+            align: { x: 0.5, y: 0.5 }
+            width: 31, height: 31
 
-            //The 'Fill' allows it shows anywhere we want over the app screen,
-            //our goal is to set the global relative position to make it an illusion of following the cursor.
-            width: Fill, height: Fill
+            icon_yes = <IconYes> {}
+            icon_no = <IconNo> {}
+            icon_unk = <IconUnk> {}
+        }
+    }
+}
 
-            <RoundedView> {
-                width: Fit, height: Fit,
-                padding: 7,
+// Define the verification states and messages
+#[derive(Default)]
+pub enum VerificationText {
+    #[default]
+    Unknown,
+    Verified,
+    Unverified,
+}
 
-                draw_bg: {
-                    color: (COLOR_TOOLTIP_BG),
-                    border_width: 1.0,
-                    border_color: #000000,
-                    radius: 2.5
-                }
+impl VerificationText {
+    pub fn get_text(&self) -> &'static str {
+        match self {
+            VerificationText::Verified => "This device is fully verified.",
+            VerificationText::Unverified => " This device is unverified. To view your encrypted message history, please verify it from another client.",
+            VerificationText::Unknown => " Verification state is unknown.",
+        }
+    }
 
-                tooltip_label = <Label> {
-                    width: 230
-                    draw_text: {
-                        text_style: <THEME_FONT_REGULAR> { font_size: (SMALL_STATE_FONT_SIZE) },
-                        text_wrap: Word,
-                        color: #000
-                    }
-                }
+    pub fn from_state(state: VerificationState) -> Self {
+        match state {
+            VerificationState::Verified => Self::Verified,
+            VerificationState::Unverified => Self::Unverified,
+            VerificationState::Unknown => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct VerificationBadge {
+    #[deref]
+    view: View,
+    #[rust(VerificationState::Unknown)]
+    pub verification_state: VerificationState,
+}
+
+impl VerificationBadge {
+    pub fn get_icons_rect(&self, cx: &Cx) -> Rect {
+        self.view(id!(verification_icons)).area().rect(cx)
+    }
+}
+
+impl Widget for VerificationBadge {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope)
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl VerificationBadgeRef {
+    pub fn set_verification_state(&mut self, cx: &mut Cx, state: VerificationState) {
+        if let Some(mut inner) = self.0.borrow_mut::<VerificationBadge>() {
+            if inner.verification_state != state {
+                inner.verification_state = state;
+                inner.update_icon_visibility();
+                inner.redraw(cx);
             }
         }
+    }
+}
+
+impl VerificationBadge {
+    pub fn update_icon_visibility(&mut self) {
+        let (yes, no, unk) = match self.verification_state {
+            VerificationState::Unknown => (false, false, true),
+            VerificationState::Unverified => (false, true, false),
+            VerificationState::Verified => (true, false, false),
+        };
+
+        self.view(id!(icon_yes)).set_visible(yes);
+        self.view(id!(icon_no)).set_visible(no);
+        self.view(id!(icon_unk)).set_visible(unk);
     }
 }

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -87,8 +87,8 @@ pub enum VerificationText {
 impl VerificationText {
     pub fn get_text(&self) -> &'static str {
         match self {
-            VerificationText::Verified => "This device is fully verified.",
-            VerificationText::Unverified => " This device is unverified. To view your encrypted message history, please verify it from another client.",
+            VerificationText::Verified => "This device is fully verified.To view your encrypted message history, please verify it from another client.",
+            VerificationText::Unverified => "This device is unverified. To view your encrypted message history, please verify it from another client.",
             VerificationText::Unknown => " Verification state is unknown.",
         }
     }

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -87,7 +87,7 @@ pub enum VerificationText {
 impl VerificationText {
     pub fn get_text(&self) -> &'static str {
         match self {
-            VerificationText::Verified => "This device is fully verified.To view your encrypted message history, please verify it from another client.",
+            VerificationText::Verified => "This device is fully verified.",
             VerificationText::Unverified => "This device is unverified. To view your encrypted message history, please verify it from another client.",
             VerificationText::Unknown => " Verification state is unknown.",
         }


### PR DESCRIPTION
Closes #299 

1. Refactored VerificationBadge, encapsulating logic related to Badge state within the VerificationBadge component.  
2. Modify the tooltip display position to be relative to the Profile’s position.
3. Added a new ColorTooltip component, which can dynamically set the background color of the tooltip, such as automatically changing color based on the VerificationBadge state. 
4. Fixed the UI bug in [issue 299](https://github.com/project-robius/robrix/issues/299), which was caused by the `draw_depth` setting in `DockBase`, and it has been removed. The corresponding deletion will also be made in the Makepad widget code ( [Makepad PR #624](https://github.com/makepad/makepad/pull/624) ).


![Screenshot 2024-12-28 at 23 23 19](https://github.com/user-attachments/assets/9c083282-39ec-455a-9b79-a96275870e91)

<img width="278" alt="Screenshot 2024-12-28 at 17 32 12" src="https://github.com/user-attachments/assets/c1bf69c1-e9f5-492d-953c-beb454aa2503" />

<img width="526" alt="Screenshot 2024-12-28 at 17 32 03" src="https://github.com/user-attachments/assets/db6e966b-4b05-45c2-9dc9-6580aa6eaa39" />

