### PR TITLE
display to tooltip above the verification badge

### DIFF
--- a/src/home/spaces_dock.rs
+++ b/src/home/spaces_dock.rs
@@ -67,7 +67,11 @@ live_design! {
             verification_badge = <VerificationBadge> {}
         }
 
-        profile_tooltip = <ColorTooltip> {}
+        profile_tooltip = <ColorTooltip> {
+            content: {
+                width: 200
+            }
+        }
 
     }
 
@@ -189,10 +193,11 @@ impl Widget for Profile {
         }; // view borrow end
 
         if let Event::MouseMove(e) = event {
+
             let (is_mouse_over_icons, verification_text, tooltip_pos) = {
                 if let Some(badge) = self
                     .widget(id!(verification_badge))
-                    .borrow_mut::<VerificationBadge>()
+                    .borrow::<VerificationBadge>()
                 {
                     let icons_rect = badge.get_icons_rect(cx);
                     let is_over = icons_rect.contains(e.abs);
@@ -210,9 +215,13 @@ impl Widget for Profile {
                             y: icons_rect.pos.y - 10.,
                         }
                     } else {
-                        DVec2 {
-                            x: profile_rect.pos.x,
-                            y: profile_rect.pos.y - 10.,
+                        if let Some(tooltip) = self
+                            .widget(id!(profile_tooltip))
+                            .borrow::<ColorTooltip>()
+                        {
+                            tooltip.calculate_above_position(cx, profile_rect)
+                        } else {
+                            DVec2 { x: 0., y: 0. }
                         }
                     };
                     (is_over, text.to_string(), tooltip_pos)

--- a/src/shared/color_tooltip.rs
+++ b/src/shared/color_tooltip.rs
@@ -39,6 +39,7 @@ live_design! {
                 tooltip_label = <Label> {
                     width: Fill,
                     height: Fit,
+                    padding: {left: 5.0, right: 5.0}
                     draw_text: {
                         text_style: <REGULAR_TEXT> {}
                         color: #fff
@@ -145,6 +146,34 @@ impl ColorTooltip {
                 }
             },
         );
+    }
+
+    pub fn get_size(&self, cx: &mut Cx) -> Option<DVec2> {
+        let content = self.view(id!(content)) ;
+        let rect = content.area().rect(cx);
+        Some(rect.size)
+    }
+
+    pub fn get_full_dimensions(&self, cx: &mut Cx) -> Option<(DVec2, DVec2)> {
+        let content_size = self.view(id!(content)).area().rect(cx).size;
+        let bg_size = self.view(id!(tooltip_bg)).area().rect(cx).size;
+
+        Some((content_size, bg_size))
+    }
+
+    pub fn calculate_above_position(&self, cx: &mut Cx, rect: Rect) -> DVec2 {
+        let size = self.get_size(cx).unwrap_or(DVec2{x: 300.0, y: 30.0});
+
+        let center_x = rect.pos.x + (rect.size.x * 0.5);
+        let actual_height = self.view(id!(tooltip_bg)).area().rect(cx).size.y;
+
+        DVec2 {
+            x: center_x - (size.x * 0.5),
+            // If we directly use rect.pos.y, the top left corner of the tooltip will align with the top of the rectangle.
+            // If we want the tooltip to appear above the rectangle,
+            // we need to move the y-coordinate up by the height of the tooltip.
+            y: rect.pos.y - actual_height,
+        }
     }
 }
 


### PR DESCRIPTION
Fixed issue [#310 ](https://github.com/project-robius/robrix/issues/310) .

**Remaining Issue Description:**

When the tooltip is displayed, it first appears directly below the target element before "jumping" to the correct position (above the target element). This transition lacks visual smoothness, creating a noticeable jumping effect. Please refer to the video demonstration.

**Root Cause Analysis:**

The root cause may lie in Makepad's rendering and layout pipeline (though I'm not entirely certain).

1. Initially, Makepad renders using a default position, before completing the proper layout calculations
2. Only after the first frame is rendered does the layout system calculate the actual dimensions of the tooltip
3. Once the actual dimensions are available, the final correct position can be calculated
4. Finally, a re-render is triggered, moving the tooltip to its correct position

I've attempted various solutions, including manually requesting redraws, calculating positions in advance, and controlling visibility, but the issue persists. I'll revisit this when time permits for further investigation.


https://github.com/user-attachments/assets/fef80652-ce1e-416f-a017-e14bbf1a9764


https://github.com/user-attachments/assets/3387f7b0-1ed9-4e6b-bda2-44d067d9e4bb

