### PR TITLE
Skip the `@` char when displaying a room Avatar based on its name 

### DIFF
--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1999,7 +1999,7 @@ fn avatar_from_room_name(room_name: &str) -> RoomPreviewAvatar {
     RoomPreviewAvatar::Text(
         room_name
             .graphemes(true)
-            .next()
+            .find(|g| g.chars().all(char::is_alphanumeric))
             .map(ToString::to_string)
             .unwrap_or_default()
     )

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1999,7 +1999,7 @@ fn avatar_from_room_name(room_name: &str) -> RoomPreviewAvatar {
     RoomPreviewAvatar::Text(
         room_name
             .graphemes(true)
-            .find(|g| g.chars().all(char::is_alphanumeric))
+            .find(|&g| g != "@") 
             .map(ToString::to_string)
             .unwrap_or_default()
     )


### PR DESCRIPTION
![截图 2025-01-01 15-50-05](https://github.com/user-attachments/assets/f87b8b55-2d16-47dd-85d9-ccb675d62a7b)

The original algorithm only returned the first character, so if the first character of the room name was a special character, it wouldn't show up in the user avatar. I modified the code to return the first valid character, ensuring the avatar displays properly. In the image above, the first and third rooms show correctly. Without this fix, it would return a `"?"`.