### PR TITLE
Minor UI tweaks: shorten RoomPreview to show exactly 2 lines of text

### DIFF
--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -155,7 +155,7 @@ live_design! {
                 avatar = <Avatar> {}
                 <View> {
                     flow: Right
-                    width: Fill, height: 60
+                    width: Fill, height: 56
                     align: { x: 0.5, y: 0.5 }
                     left = <View> {
                         width: Fill, height: Fill,

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -53,6 +53,8 @@ live_design! {
         span = <MatrixHtmlSpan> { }
 
         a = {
+            hover_color: #21b070
+            grab_key_focus: false,
             padding: {left: 1.0, right: 1.5},
         }
 


### PR DESCRIPTION
Change HTML link hover color, and prevent it from grabbing focus upon a FingerDown hit.