### PR TITLE
Close the panel when the mouse clicks outside the panel area.

### DIFF
--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -421,6 +421,7 @@ impl Widget for UserProfileSlidingPane {
             Event::MouseUp(mouse) => mouse.button == 3, // the "back" button on the mouse
             Event::KeyUp(key) => key.key_code == KeyCode::Escape,
             Event::BackPressed => true,
+            Event::MouseDown(e) => !self.view(id!(user_profile_view)).area().rect(cx).contains(e.abs), 
             _ => false,
         };
         if close_pane {


### PR DESCRIPTION
Add a small feature where the panel closes when the user clicks outside of it. This will also help fix some cases I mentioned yesterday where the panel pop-up causes the app to freeze. (Allowing the user to close the panel by clicking outside)