### PR TITLE
Display images at their actual size

### DIFF
--- a/src/shared/text_or_image.rs
+++ b/src/shared/text_or_image.rs
@@ -9,7 +9,7 @@ live_design! {
     use link::theme::*;
     use link::shaders::*;
     use link::widgets::*;
-    
+
     use crate::shared::styles::*;
 
     pub TextOrImage = {{TextOrImage}} {
@@ -37,8 +37,8 @@ live_design! {
             cursor: NotAllowed, // we don't yet support clicking on the image
             width: Fill, height: Fit,
             image = <Image> {
-                width: Fill, height: Fit,
-                fit: Smallest,
+                width: Fill, height: Fill,
+                fit: Size,
             }
         }
     }


### PR DESCRIPTION
Currently, the width of the image in timeline, always equal to RoomScreen's width.

It was fixed now.

#### Lastest main:
[Screencast from 2025-01-22 10-40-33.webm](https://github.com/user-attachments/assets/b449c7aa-3fac-4fff-88b3-f73ad3849461)

#### After:
[Screencast from 2025-01-22 10-31-36.webm](https://github.com/user-attachments/assets/fe00f4a9-3e22-4c87-a2cc-4f292229ee10)
