### PR TITLE
Migrate Pane widgets to Makepad's `Hit` API instead of raw `Event`s

### DIFF
--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -216,7 +216,7 @@ impl Widget for LoadingPane {
 
 
 impl LoadingPane {
-    /// Returns `true` if the pane is currently visible.
+    /// Returns `true` if this pane is currently being shown.
     pub fn is_currently_shown(&self, _cx: &mut Cx) -> bool {
         self.visible
     }

--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -33,14 +33,10 @@ live_design! {
         height: Fill,
         align: {x: 0.5, y: 0.5}
 
-        bg_view = <View> {
-            width: Fill
-            height: Fill
-            show_bg: true
-            draw_bg: {
-                fn pixel(self) -> vec4 {
-                    return vec4(0., 0., 0., 0.7)
-                }
+        show_bg: true
+        draw_bg: {
+            fn pixel(self) -> vec4 {
+                return vec4(0., 0., 0., 0.7)
             }
         }
 
@@ -179,18 +175,22 @@ impl Widget for LoadingPane {
         if !self.visible { return; }
         self.view.handle_event(cx, event, scope);
 
-        // Close the pane if the cancel button is clicked, the back mouse button is clicked,
-        // the escape key is pressed, the back button is pressed,
-        // or the user clicks outside the pane's content.
+        // Close the pane if:
+        // 1. The cancel button is clicked,
+        // 2. The back navigational gesture/action occurs (e.g., Back on Android),
+        // 3. The escape key is pressed
+        // 4. The back mouse button is clicked within this view,
+        // 5. The user clicks/touches outside the main_content view area.
         let close_pane = match event {
-            Event::Actions(actions) => self.button(id!(cancel_button)).clicked(actions),
-            Event::MouseUp(mouse) => mouse.button.is_back(),
-            Event::KeyUp(key) => key.key_code == KeyCode::Escape,
-            Event::BackPressed => true,
-            Event::MouseDown(e) => {
-                // TODO FIX THIS TO BE MORE SPECIFIC: the background area must contain the e.abs,
-                // AND the main_content area must NOT contain the e.abs.
-                !self.view(id!(main_content)).area().rect(cx).contains(e.abs)
+            Event::Actions(actions) => self.button(id!(cancel_button)).clicked(actions), // 1
+            Event::BackPressed => true,                                                  // 2
+            Event::KeyUp(key) => key.key_code == KeyCode::Escape,                        // 3
+            _ => false,
+        } || match event.hits_with_capture_overload(cx, self.view.area(), true) {
+            // Note: ideally we should handle `Hit::KeyUp` here, but that doesn't work as expected.
+            Hit::FingerUp(fue) => {
+                fue.mouse_button().is_some_and(|b| b.is_back())                          // 4
+                || !self.view(id!(main_content)).area().rect(cx).contains(fue.abs)       // 5
             }
             _ => false,
         };

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -456,7 +456,6 @@ impl Widget for UserProfileSlidingPane {
             }
             _ => false,
         };
-        log!("UserProfileSlidingPane: close_pane? {}", close_pane);
         if close_pane {
             self.animator_play(cx, id!(panel.hide));
             self.redraw(cx);
@@ -599,10 +598,9 @@ impl Widget for UserProfileSlidingPane {
 
 
 impl UserProfileSlidingPane {
-    /// Returns `true` if the pane is both currently visible *and*
-    /// animator is in the `show` state (meaning it's not animating out).
-    pub fn is_currently_shown(&self, cx: &mut Cx) -> bool {
-        self.visible && self.animator_in_state(cx, id!(panel.show))
+    /// Returns `true` if this pane is currently being shown.
+    pub fn is_currently_shown(&self, _cx: &mut Cx) -> bool {
+        self.visible
     }
 
     /// Sets the info to be displayed in this user profile sliding pane.


### PR DESCRIPTION
~~Not quite working fully just yet.~~

Still pending some answers from Makepad about why hit handling isn't working as expected for KeyUp and FingerUp events in a given area.

We can still merge it now, though. Can fix FingerUp/KeyUp specifics at a later date.