### PR TITLE
Adding Callout Tooltip for Verification Badge tooltip fix#310

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
 
 use crate::{
-    home::{main_desktop_ui::RoomsPanelAction, room_screen::MessageAction, rooms_list::RoomsListAction, spaces_dock::ProfileTooltipAction}, login::login_screen::LoginAction, shared::{color_tooltip::ColorTooltipWidgetRefExt, popup_list::PopupNotificationAction}, verification::VerificationAction, verification_modal::{VerificationModalAction, VerificationModalWidgetRefExt}
+    home::{main_desktop_ui::RoomsPanelAction, room_screen::MessageAction, rooms_list::RoomsListAction, spaces_dock::ProfileTooltipAction}, login::login_screen::LoginAction, shared::popup_list::PopupNotificationAction, verification::VerificationAction, verification_modal::{VerificationModalAction, VerificationModalWidgetRefExt}
 };
 
 live_design! {
@@ -270,10 +270,10 @@ impl MatchEvent for App {
             }
 
             match action.as_widget_action().cast() {
-                ProfileTooltipAction::ShowCallout { apply, text , color} => {
+                ProfileTooltipAction::HoverIn { callout_live_nodes, text , color} => {
                     let mut tooltip = self.ui.tooltip(id!(profile_tooltip));
-                    for apply in apply.iter() {
-                        tooltip.apply_over(cx, &apply);
+                    for nodes in callout_live_nodes {
+                        tooltip.apply_over(cx, &nodes);
                     }
                     if let Some(color) = color {
                         tooltip.apply_over(cx, live!(
@@ -289,7 +289,7 @@ impl MatchEvent for App {
                     tooltip.set_text(cx, &text);
                     tooltip.show(cx);
                 }
-                ProfileTooltipAction::Hide => {
+                ProfileTooltipAction::HoverOut => {
                     let tooltip = self.ui.tooltip(id!(profile_tooltip));
                     tooltip.hide(cx);
                 }

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -1,3 +1,4 @@
+use crate::shared;
 use crate::sliding_sync::{current_user_id, submit_async_request, MatrixRequest};
 use makepad_widgets::*;
 use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId};
@@ -6,7 +7,6 @@ use crate::profile::user_profile_cache::get_user_profile_and_room_member;
 use crate::home::room_screen::RoomScreenTooltipActions;
 use indexmap::IndexMap;
 
-use super::room_screen::room_screen_tooltip_position_helper;
 
 const TOOLTIP_WIDTH: f64 = 200.0;
 const EMOJI_BORDER_COLOR_INCLUDE_SELF: Vec4 = Vec4 { x: 0.0, y: 0.6, z: 0.47, w: 1.0 }; // DarkGreen
@@ -127,16 +127,11 @@ impl Widget for ReactionList {
             match event.hits(cx, widget_ref.area()) {
                 Hit::FingerHoverIn(_) => {
                     let widget_rect = widget_ref.area().rect(cx);
-                    let (tooltip_pos, 
-                        callout_offset, 
-                        too_close_to_right, 
-                    ) = room_screen_tooltip_position_helper(widget_rect, window_geom, TOOLTIP_WIDTH);
-                    cx.widget_action(uid, &scope.path, RoomScreenTooltipActions::HoverInReactionButton {
-                        tooltip_pos, 
-                        tooltip_width: TOOLTIP_WIDTH, 
-                        callout_offset,
-                        reaction_data: reaction_data.clone(),
-                        pointing_up: too_close_to_right,
+                    let callout_live_nodes = shared::callout_tooltip::position_helper(widget_rect, window_geom.inner_size, TOOLTIP_WIDTH);
+                    cx.widget_action(uid, &scope.path, RoomScreenTooltipActions::HoverInReactionButton { 
+                        callout_live_nodes, 
+                        color: None, 
+                        reaction_data: reaction_data.clone() 
                     });
                     cx.set_cursor(MouseCursor::Hand);
                     widget_ref.apply_over(cx, live!(draw_bg: {hover: 1.0}));

--- a/src/home/room_read_receipt.rs
+++ b/src/home/room_read_receipt.rs
@@ -1,5 +1,6 @@
 use crate::app::AppState;
 use crate::profile::user_profile_cache::get_user_profile_and_room_member;
+use crate::shared;
 use crate::shared::avatar::{AvatarRef, AvatarWidgetRefExt};
 use crate::home::room_screen::RoomScreenTooltipActions;
 use crate::utils::human_readable_list;
@@ -8,7 +9,6 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::{events::receipt::Receipt, EventId, OwnedUserId, RoomId};
 use matrix_sdk_ui::timeline::EventTimelineItem;
 use std::cmp;
-use super::room_screen::room_screen_tooltip_position_helper;
 
 /// The default width of the room screen tooltip for read receipts.
 const TOOLTIP_WIDTH: f64 = 180.0;
@@ -96,17 +96,12 @@ impl Widget for AvatarRow {
         let widget_rect = self.area.rect(cx);
         match event.hits(cx, self.area) {
             Hit::FingerHoverIn(_) => {
-                let (tooltip_pos, 
-                    callout_offset, 
-                    too_close_to_right, 
-                ) = room_screen_tooltip_position_helper(widget_rect, window_geom, TOOLTIP_WIDTH);
                 if let Some(read_receipts) = &self.read_receipts {
-                    cx.widget_action(uid, &scope.path, RoomScreenTooltipActions::HoverInReadReceipt{
-                        tooltip_pos,
-                        callout_offset,
-                        read_receipts: read_receipts.clone(),
-                        tooltip_width: TOOLTIP_WIDTH,
-                        pointing_up: too_close_to_right,
+                    let callout_live_nodes = shared::callout_tooltip::position_helper(widget_rect, window_geom.inner_size, TOOLTIP_WIDTH);
+                    cx.widget_action(uid, &scope.path, RoomScreenTooltipActions::HoverInReadReceipt { 
+                        callout_live_nodes, 
+                        color: None, 
+                        read_receipts: read_receipts.clone()
                     });
                 }
             }

--- a/src/home/spaces_dock.rs
+++ b/src/home/spaces_dock.rs
@@ -1,7 +1,5 @@
 use makepad_widgets::*;
 
-use crate::shared::color_tooltip::*;
-
 live_design! {
     use link::theme::*;
     use link::shaders::*;
@@ -170,17 +168,15 @@ live_design! {
 /// An action emitted to show or hide the `profile_tooltip`.
 #[derive(Clone, Debug, DefaultNone)]
 pub enum ProfileTooltipAction {
-    Show {
-        pos: DVec2,
-        text: &'static str,
-        color: Vec4,
-    },
-    ShowCallout {
-        apply: Vec<Vec<LiveNode>>,
+    HoverIn {
+        /// Nodes to apply to draw the callout properly based on the widget's position and size with respect to the screen
+        callout_live_nodes: Vec<Vec<LiveNode>>,
+        /// Color of the background
         color: Option<Vec4>,
+        /// Tooltip text
         text: String,
     },
-    Hide,
+    HoverOut,
     None,
 }
 

--- a/src/home/spaces_dock.rs
+++ b/src/home/spaces_dock.rs
@@ -60,7 +60,7 @@ live_design! {
             verification_badge = <VerificationBadge> {}
         }
 
-        profile_tooltip = <ColorTooltip> {}
+        
 
     }
 
@@ -175,6 +175,11 @@ pub enum ProfileTooltipAction {
         text: &'static str,
         color: Vec4,
     },
+    ShowCallout {
+        apply: Vec<Vec<LiveNode>>,
+        color: Option<Vec4>,
+        text: String,
+    },
     Hide,
     None,
 }
@@ -187,21 +192,6 @@ pub struct Profile {
 impl Widget for Profile {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
-
-        if let Event::Actions(actions) = event {
-            for action in actions {
-                match action.as_widget_action().cast() {
-                    ProfileTooltipAction::Show { pos, text, color } => {
-                        self.view.color_tooltip(id!(profile_tooltip))
-                            .show_with_options(cx, pos, text, color);
-                    }
-                    ProfileTooltipAction::Hide => {
-                        self.view.color_tooltip(id!(profile_tooltip)).hide(cx);
-                    }
-                    _ => { }
-                }
-            }
-        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {

--- a/src/shared/callout_tooltip.rs
+++ b/src/shared/callout_tooltip.rs
@@ -1,0 +1,203 @@
+use makepad_widgets::*;
+live_design! {
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+    use crate::shared::styles::*;
+    // A tooltip that appears when hovering over certain elements in the RoomScreen,
+    // such as reactions or read receipts.
+    pub CalloutTooltip = <Tooltip> {
+        content: <View> {
+            flow: Overlay
+            width: Fit
+            height: Fit
+
+            rounded_view = <RoundedView> {
+                width: Fill,
+                height: Fit,
+
+                padding: 10,
+
+                draw_bg: {
+                    color: #fff,
+                    border_width: 1.0,
+                    border_color: #D0D5DD,
+                    radius: 2.,
+                    instance background_color: (#3b444b),
+                    // Height of isoceles triangle
+                    instance callout_triangle_height: 7.5,
+                    instance callout_offset: 15.0,
+                    // callout angle in clockwise direction
+                    // 0.0 is pointing up,
+                    // 90.0 is pointing left, pointing right is not supported
+                    // 180.0 is pointing down,
+                    // 270.0 is pointing left
+                    instance callout_angle: 0.0,
+                    fn pixel(self) -> vec4 {
+                        let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                        let rect_size = self.rect_size;
+                        if self.callout_angle < 0.5 {
+                            sdf.box(
+                                // Minus 2.0 to overlap the triangle and rectangle
+                                self.border_width,
+                                (self.callout_triangle_height - 2.0) + self.border_width,
+                                rect_size.x - (self.border_width * 2.0) ,
+                                rect_size.y - (self.border_width * 2.0) - (self.callout_triangle_height - 2.0),
+                                max(1.0, self.radius)
+                            )
+                            sdf.fill(self.background_color);
+                            sdf.translate(self.callout_offset - 2.0 * self.callout_triangle_height, 1.0);
+                            // Draw up-pointed arrow triangle
+                            sdf.move_to(self.callout_triangle_height * 2.0, self.callout_triangle_height * 1.0);
+                            sdf.line_to(0.0, self.callout_triangle_height * 1.0);
+                            sdf.line_to(self.callout_triangle_height, 0.0);
+                        } else if self.callout_angle < 90.5 || self.callout_angle > 180.5{ // By right, it should 
+                            sdf.box(
+                                // Minus 2.0 to overlap the triangle and rectangle
+                                (self.callout_triangle_height - 2.0) + self.border_width,
+                                0.0 + self.border_width,
+                                rect_size.x - (self.border_width * 2.0) - (self.callout_triangle_height - 2.0),
+                                rect_size.y - (self.border_width * 2.0),
+                                max(1.0, self.radius)
+                            )
+                            sdf.fill(self.background_color);
+                            sdf.translate(0.5, self.callout_offset);
+                            // Draw left-pointed arrow triangle
+                            sdf.move_to(self.callout_triangle_height, 0.0);
+                            sdf.line_to(self.callout_triangle_height, self.callout_triangle_height * 2.0);
+                            sdf.line_to(0.5, self.callout_triangle_height);
+                        } else if self.callout_angle < 180.5 {
+                            sdf.box(
+                                // Minus 2.0 to overlap the triangle and rectangle
+                                self.border_width,
+                                self.border_width,
+                                rect_size.x - (self.border_width * 2.0) ,
+                                rect_size.y - (self.border_width * 2.0) - (self.callout_triangle_height - 2.0),
+                                max(1.0, self.radius)
+                            )
+                            sdf.fill(self.background_color);
+                            sdf.translate(self.callout_offset - self.callout_triangle_height, rect_size.y - 2.0);
+                            // Draw down-pointed arrow triangle
+                            sdf.move_to(self.callout_triangle_height * 2.0, - self.callout_triangle_height * 1.0);
+                            sdf.line_to(self.callout_triangle_height, -0.5);
+                            sdf.line_to(0.0, 0.0 - self.callout_triangle_height * 1.0);
+                        }
+
+                        sdf.close_path();
+
+                        sdf.fill((self.background_color));
+                        return sdf.result;
+                    }
+
+                }
+
+                tooltip_label = <Label> {
+                    width: Fill,
+                    height: Fit,
+                    draw_text: {
+                        text_style: <THEME_FONT_REGULAR>{font_size: 9},
+                        text_wrap: Word,
+                        color: (COLOR_PRIMARY)
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/// Calculates the position and styling attributes for a tooltip relative to a widget, 
+/// ensuring the tooltip stays within the visible window area.
+///
+/// This function determines the optimal position for the tooltip by checking if it's 
+/// too close to the right or bottom edge of the window, and adjusts its placement 
+/// accordingly. It also sets the offset and angle for the callout triangle based on 
+/// these conditions.
+///
+/// # Arguments
+///
+/// * `widget_rect` - The rectangle representing the widget's position and size.
+/// * `window_size` - The dimensions of the window in which the widget resides.
+/// * `tooltip_width` - The desired width of the tooltip.
+///
+/// # Returns
+///
+/// A vector of `LiveNode` vectors representing the tooltip's position, size, and 
+/// styling attributes to be applied.
+
+pub fn callout_tooltip_position_helper(widget_rect: Rect, window_size: DVec2, tooltip_width: f64) -> Vec<Vec<LiveNode>> {    
+    let mut too_close_to_right = false;
+    let mut too_close_to_down = false;
+    const TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM: f64 = 100.0;
+    if (widget_rect.pos.x + widget_rect.size.x) + tooltip_width > window_size.x {
+        too_close_to_right = true;
+    }
+    if (widget_rect.pos.y + widget_rect.size.y) + TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM > window_size.y {
+        too_close_to_down = true;
+    }
+    let mut pos =  if too_close_to_right {
+        DVec2 {
+            x: widget_rect.pos.x + (widget_rect.size.x - tooltip_width),
+            y: widget_rect.pos.y + widget_rect.size.y
+        }
+    } else {
+        DVec2 {
+            x: widget_rect.pos.x + widget_rect.size.x,
+            y: widget_rect.pos.y - 5.0
+        }
+    };
+    if too_close_to_down && !too_close_to_right {
+        pos.x = widget_rect.pos.x + (widget_rect.size.x - 10.0) / 2.0;
+        pos.y = widget_rect.pos.y - TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM + 10.0;
+    }
+    let callout_offset = if too_close_to_right {
+        tooltip_width - (widget_rect.size.x - 10.0) / 2.0
+    } else {
+        10.0
+    };
+    let callout_angle = match (too_close_to_right, too_close_to_down) {
+        (true, true) => 0.0, //point up
+        (true, false) => 90.0, // it is still pointing left, as point right is not supported
+        (false, true) => 180.0, //point down
+        (false, false) => 270.0 //point left
+    };
+    let mut to_apply = vec![live!(
+        content: {
+            margin: { left: (pos.x), top: (pos.y)},
+            width: (tooltip_width),
+            height: Fit,
+            rounded_view = {
+                draw_bg: {
+                    callout_offset: (callout_offset)
+                    // callout angle in clockwise direction
+                    callout_angle: (callout_angle)
+                }
+            }
+        }
+    ).to_vec()];
+    if too_close_to_down {
+        to_apply.push(live!(
+            content: {
+                height: (TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM),
+            }
+        ).to_vec());
+    }
+    to_apply
+}
+
+/// An action emitted to show or hide the `profile_tooltip`.
+#[derive(Clone, Debug, DefaultNone)]
+pub enum ProfileTooltipAction2 {
+    Show {
+        pos: DVec2,
+        text: &'static str,
+        color: Vec4,
+    },
+    ShowCallout {
+        apply: Vec<Vec<LiveNode>>,
+        color: Option<Vec4>,
+        text: String,
+    },
+    Hide,
+    None,
+}

--- a/src/shared/callout_tooltip.rs
+++ b/src/shared/callout_tooltip.rs
@@ -96,7 +96,8 @@ live_design! {
                     height: Fit,
                     draw_text: {
                         text_style: <THEME_FONT_REGULAR>{font_size: 9},
-                        text_wrap: Word,
+                        //text_wrap: Word,
+                        text_wrap: Line,
                         color: (COLOR_PRIMARY)
                     }
                 }
@@ -124,16 +125,15 @@ live_design! {
 ///
 /// A vector of `LiveNode` vectors representing the tooltip's position, size, and 
 /// styling attributes to be applied.
-
-pub fn callout_tooltip_position_helper(widget_rect: Rect, window_size: DVec2, tooltip_width: f64) -> Vec<Vec<LiveNode>> {    
+pub fn position_helper(widget_rect: Rect, window_size: DVec2, tooltip_width: f64) -> Vec<Vec<LiveNode>> {    
     let mut too_close_to_right = false;
-    let mut too_close_to_down = false;
-    const TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM: f64 = 100.0;
+    let mut too_close_to_bottom = false;
+    const TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM: f64 = 80.0;
     if (widget_rect.pos.x + widget_rect.size.x) + tooltip_width > window_size.x {
         too_close_to_right = true;
     }
     if (widget_rect.pos.y + widget_rect.size.y) + TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM > window_size.y {
-        too_close_to_down = true;
+        too_close_to_bottom = true;
     }
     let mut pos =  if too_close_to_right {
         DVec2 {
@@ -146,7 +146,7 @@ pub fn callout_tooltip_position_helper(widget_rect: Rect, window_size: DVec2, to
             y: widget_rect.pos.y - 5.0
         }
     };
-    if too_close_to_down && !too_close_to_right {
+    if too_close_to_bottom && !too_close_to_right {
         pos.x = widget_rect.pos.x + (widget_rect.size.x - 10.0) / 2.0;
         pos.y = widget_rect.pos.y - TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM + 10.0;
     }
@@ -155,7 +155,7 @@ pub fn callout_tooltip_position_helper(widget_rect: Rect, window_size: DVec2, to
     } else {
         10.0
     };
-    let callout_angle = match (too_close_to_right, too_close_to_down) {
+    let callout_angle = match (too_close_to_right, too_close_to_bottom) {
         (true, true) => 0.0, //point up
         (true, false) => 90.0, // it is still pointing left, as point right is not supported
         (false, true) => 180.0, //point down
@@ -167,6 +167,7 @@ pub fn callout_tooltip_position_helper(widget_rect: Rect, window_size: DVec2, to
             width: (tooltip_width),
             height: Fit,
             rounded_view = {
+                height: Fit,
                 draw_bg: {
                     callout_offset: (callout_offset)
                     // callout angle in clockwise direction
@@ -175,29 +176,18 @@ pub fn callout_tooltip_position_helper(widget_rect: Rect, window_size: DVec2, to
             }
         }
     ).to_vec()];
-    if too_close_to_down {
+    if too_close_to_bottom {
         to_apply.push(live!(
             content: {
                 height: (TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM),
+                //width: (tooltip_width + 50.0), // Make too close to bottom tooltip wider
+                //width: Fit
+                width: Fill
+                rounded_view = {
+                    height: (TOOLTIP_HEIGHT_FOR_TOO_CLOSE_BOTTOM - 10.0),
+                }
             }
         ).to_vec());
     }
     to_apply
-}
-
-/// An action emitted to show or hide the `profile_tooltip`.
-#[derive(Clone, Debug, DefaultNone)]
-pub enum ProfileTooltipAction2 {
-    Show {
-        pos: DVec2,
-        text: &'static str,
-        color: Vec4,
-    },
-    ShowCallout {
-        apply: Vec<Vec<LiveNode>>,
-        color: Option<Vec4>,
-        text: String,
-    },
-    Hide,
-    None,
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -12,6 +12,7 @@ pub mod text_or_image;
 pub mod typing_animation;
 pub mod popup_list;
 pub mod verification_badge;
+pub mod callout_tooltip;
 
 pub fn live_design(cx: &mut Cx) {
     // Order matters here, as some widget definitions depend on others.
@@ -27,4 +28,5 @@ pub fn live_design(cx: &mut Cx) {
     popup_list::live_design(cx);
     verification_badge::live_design(cx);
     color_tooltip::live_design(cx);
+    callout_tooltip::live_design(cx);
 }

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -3,6 +3,8 @@ use matrix_sdk::encryption::VerificationState;
 
 use crate::{home::spaces_dock::ProfileTooltipAction, sliding_sync::get_client, verification::VerificationStateAction};
 
+use super::callout_tooltip::callout_tooltip_position_helper;
+
 // First, define the verification icons component layout
 live_design! {
     use link::theme::*;
@@ -113,7 +115,8 @@ impl LiveHook for VerificationBadge {
 impl Widget for VerificationBadge {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
-
+        let Some(app_state) = scope.data.get::<crate::app::AppState>() else { return };
+        let Some(window_geom) = &app_state.window_geom else { return };
         if let Event::Actions(actions) = event {
             for action in actions {
                 if let Some(VerificationStateAction::Update(state)) = action.downcast_ref() {
@@ -145,21 +148,30 @@ impl Widget for VerificationBadge {
                     }
                 };
     
+                // cx.widget_action(
+                //     self.widget_uid(),
+                //     &scope.path,
+                //     ProfileTooltipAction::Show {
+                //         pos: tooltip_pos,
+                //         text: verification_state_str(self.verification_state),
+                //         color: verification_state_color(self.verification_state),
+                //     },
+                // );
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
-                    ProfileTooltipAction::Show {
-                        pos: tooltip_pos,
-                        text: verification_state_str(self.verification_state),
-                        color: verification_state_color(self.verification_state),
-                    },
+                    crate::shared::callout_tooltip::ProfileTooltipAction2::ShowCallout {
+                        apply: callout_tooltip_position_helper(badge_rect, window_geom.inner_size, 200.0),
+                        text: verification_state_str(self.verification_state).to_string(),
+                        color: Some(verification_state_color(self.verification_state))
+                    }
                 );
             }
             Hit::FingerHoverOut(_) => {
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
-                    ProfileTooltipAction::Hide,
+                    crate::shared::callout_tooltip::ProfileTooltipAction2::Hide,
                 );
             }
             _ => { }

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -3,8 +3,6 @@ use matrix_sdk::encryption::VerificationState;
 
 use crate::{home::spaces_dock::ProfileTooltipAction, sliding_sync::get_client, verification::VerificationStateAction};
 
-use super::callout_tooltip::callout_tooltip_position_helper;
-
 // First, define the verification icons component layout
 live_design! {
     use link::theme::*;
@@ -136,32 +134,11 @@ impl Widget for VerificationBadge {
             | Hit::FingerHoverIn(_)
             | Hit::FingerHoverOver(_) => {
                 let badge_rect = badge_area.rect(cx);
-                let tooltip_pos = if cx.display_context.is_desktop() {
-                    DVec2 {
-                        x: badge_rect.pos.x + badge_rect.size.x + 1.,
-                        y: badge_rect.pos.y - 10.,
-                    }
-                } else {
-                    DVec2 {
-                        x: badge_rect.pos.x,
-                        y: badge_rect.pos.y - 10.,
-                    }
-                };
-    
-                // cx.widget_action(
-                //     self.widget_uid(),
-                //     &scope.path,
-                //     ProfileTooltipAction::Show {
-                //         pos: tooltip_pos,
-                //         text: verification_state_str(self.verification_state),
-                //         color: verification_state_color(self.verification_state),
-                //     },
-                // );
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
-                    crate::shared::callout_tooltip::ProfileTooltipAction2::ShowCallout {
-                        apply: callout_tooltip_position_helper(badge_rect, window_geom.inner_size, 200.0),
+                    ProfileTooltipAction::HoverIn {
+                        callout_live_nodes: super::callout_tooltip::position_helper(badge_rect, window_geom.inner_size, 200.0),
                         text: verification_state_str(self.verification_state).to_string(),
                         color: Some(verification_state_color(self.verification_state))
                     }
@@ -171,7 +148,7 @@ impl Widget for VerificationBadge {
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
-                    crate::shared::callout_tooltip::ProfileTooltipAction2::Hide,
+                    ProfileTooltipAction::HoverOut,
                 );
             }
             _ => { }


### PR DESCRIPTION
Fixes #310

1. Added Callout Tooltip for Verification Badge
2. Moved RoomScreenTooltip to shared::callout_tooltip.
3. Passes LiveNodes into Tooltip Actions to style the tooltip

https://github.com/user-attachments/assets/2d5e2258-9734-4310-a8d8-c0839680a80f

