### PR TITLE
Fix thumbnail

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -368,7 +368,7 @@ live_design! {
                         text: "<Username not available>"
                     }
                 }
-                
+
                 message = <HtmlOrPlaintext> { }
 
                 // <LineH> {
@@ -380,7 +380,7 @@ live_design! {
                     reaction_list = <ReactionList> { }
                     avatar_row = <AvatarRow> {}
                 }
-                
+
             }
         }
     }
@@ -439,7 +439,7 @@ live_design! {
                     avatar_row = <AvatarRow> {}
                 }
             }
-            
+
         }
     }
 
@@ -457,7 +457,7 @@ live_design! {
                     avatar_row = <AvatarRow> {}
                 }
             }
-            
+
         }
     }
 
@@ -980,7 +980,7 @@ live_design! {
 
             /*
              * This is broken currently, so I'm disabling it.
-             * 
+             *
             message_action_bar_popup = <PopupNotification> {
                 align: {x: 0.0, y: 0.0}
                 content: {
@@ -1096,8 +1096,8 @@ impl Widget for RoomScreen {
                     tooltip.hide(cx);
                 }
                 let avatar_row_ref = wr.avatar_row(id!(avatar_row));
-                if let RoomScreenTooltipActions::HoverInReadReceipt { 
-                    tooltip_pos, 
+                if let RoomScreenTooltipActions::HoverInReadReceipt {
+                    tooltip_pos,
                     tooltip_width ,
                     callout_offset,
                     pointing_up,
@@ -1121,7 +1121,7 @@ impl Widget for RoomScreen {
                 if avatar_row_ref.hover_out(actions) {
                     tooltip.hide(cx);
                 }
-            }   
+            }
             for action in actions {
                 // Handle actions on a message, e.g., clicking the reply button or clicking the reply preview.
                 match action.as_widget_action().widget_uid_eq(widget_uid).cast() {
@@ -2400,16 +2400,16 @@ pub enum RoomScreenTooltipActions {
         tooltip_pos: DVec2,
         tooltip_width: f64,
         /// Pointed arrow position relative to the tooltip.
-        /// 
+        ///
         /// It is calculated from the right corner of tooltip to position arrow.
         /// to point towards the center of the hovered widget.
         callout_offset: f64,
         /// Data that is bound together the widget
-        /// 
+        ///
         /// Includes the list of users who have seen this event
         read_receipts: indexmap::IndexMap<matrix_sdk::ruma::OwnedUserId, Receipt>,
         /// Boolean indicating if the callout should be pointing up.
-        /// 
+        ///
         /// If false, it is pointing left
         pointing_up: bool
     },
@@ -3361,7 +3361,6 @@ fn populate_image_message_content(
             }
         };
 
-    let mut media_format =  Some(MEDIA_THUMBNAIL_FORMAT.into());
     let mut fetch_and_show_media_source = |cx: &mut Cx2d, media_source: MediaSource, media_format: Option<MediaFormat>| {
         match media_source {
             MediaSource::Encrypted(encrypted) => {
@@ -3377,20 +3376,23 @@ fn populate_image_message_content(
         }
     };
 
-
     match image_info_source {
-        Some((None, media_source)) => {
-            media_format = None;
-            // We fetch the original (full-size) media if it does not have a thumbnail.
+        Some((image_info, media_source)) => {
+            let thumbnail_source = image_info.and_then(|image_info|{image_info.thumbnail_source});
+
+            // Only image doesnot have a thumbnail source, we fetch its origin source and apply the format `MEDIA_THUMBNAIL_FORMAT`.
+            // We don't apply any format if it has a thumbnail source.
+            // When an inmage's size is smaller than about 500KB, it won't have a thumbnail source, by my test.
+            let (media_source, media_format) =
+                if let Some(thumbnail_source) = thumbnail_source {
+                    (thumbnail_source, None)
+                }
+                else {
+                    (media_source, Some(MEDIA_THUMBNAIL_FORMAT.into()))
+                };
+
             fetch_and_show_media_source(cx, media_source, media_format);
-        },
-        Some((Some(image_info), media_source)) => {
-            if let Some(thumbnail_source) =  image_info.thumbnail_source {
-                fetch_and_show_media_source(cx, thumbnail_source, media_format);
-            } else {
-                fetch_and_show_media_source(cx, media_source, media_format);
-            }
-        },
+        }
         None => {
             text_or_image_ref.show_text(cx, "{body}\n\nImage message had no source URL.");
             fully_drawn = true;
@@ -3425,7 +3427,7 @@ fn populate_file_message_content(
     // TODO: add a button to download the file
 
     message_content_widget.show_html(
-        cx, 
+        cx,
         format!("<b>{filename}</b>{size}{caption}<br> → <i>File download not yet supported.</i>"),
     );
     true
@@ -3583,7 +3585,7 @@ fn draw_replied_to_message(
 
         match &in_reply_to_details.event {
             TimelineDetails::Ready(replied_to_event) => {
-                let (in_reply_to_username, is_avatar_fully_drawn) = 
+                let (in_reply_to_username, is_avatar_fully_drawn) =
                     replied_to_message_view
                         .avatar(id!(replied_to_message_content.reply_preview_avatar))
                         .set_avatar_and_get_username(

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3378,12 +3378,11 @@ fn populate_image_message_content(
 
     match image_info_source {
         Some((image_info, origin_source)) => {
-            let thumbnail_source = image_info.and_then(|image_info|{image_info.thumbnail_source});
-
             // When an inmage's size is smaller than about 500KB, it won't have a thumbnail source, by my test.
             // We must apply a format anyhow the image possess a thumbnail source.
-            let media_source =
-                if let Some(thumbnail_source) = thumbnail_source { thumbnail_source } else { origin_source };
+            let media_source = image_info
+                .and_then(|image_info|{image_info.thumbnail_source})
+                .unwrap_or(origin_source);
 
             fetch_and_show_media_source(cx, media_source);
         }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3377,13 +3377,11 @@ fn populate_image_message_content(
     };
 
     match image_info_source {
-        Some((image_info, origin_source)) => {
-            // When an inmage's size is smaller than about 500KB, it won't have a thumbnail source, by my test.
-            // We must apply a format anyhow the image possess a thumbnail source.
+        Some((image_info, original_source)) => {
+            // Use the provided thumbnail URI if it exists; otherwise use the original URI.
             let media_source = image_info
-                .and_then(|image_info|{image_info.thumbnail_source})
-                .unwrap_or(origin_source);
-
+                .and_then(|image_info| image_info.thumbnail_source)
+                .unwrap_or(original_source);
             fetch_and_show_media_source(cx, media_source);
         }
         None => {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -31,7 +31,7 @@ use crate::{
     }, login::login_screen::LoginAction, media_cache::MediaCacheEntry, persistent_state::{self, ClientSessionPersisted}, profile::{
         user_profile::{AvatarState, UserProfile},
         user_profile_cache::{enqueue_user_profile_update, UserProfileUpdate},
-    }, shared::{jump_to_bottom_button::UnreadMessageCount, popup_list::enqueue_popup_notification}, utils::MEDIA_THUMBNAIL_FORMAT, verification::add_verification_event_handlers_and_sync_client
+    }, shared::{jump_to_bottom_button::UnreadMessageCount, popup_list::enqueue_popup_notification}, utils::AVATAR_THUMBNAIL_FORMAT, verification::add_verification_event_handlers_and_sync_client
 };
 
 #[derive(Parser, Debug, Default)]
@@ -740,7 +740,7 @@ async fn async_worker(
 
                 let (timeline, sender) = {
                     let mut all_room_info = ALL_ROOM_INFO.lock().unwrap();
-                    let Some(room_info) = all_room_info.get_mut(&room_id) else {    
+                    let Some(room_info) = all_room_info.get_mut(&room_id) else {
                         log!("BUG: room info not found for subscribe to own user read receipts changed request, room {room_id}");
                         continue;
                     };
@@ -764,8 +764,8 @@ async fn async_worker(
                     if let Some(client_user_id) = current_user_id() {
                         if let Some((event_id, receipt)) = timeline.latest_user_read_receipt(&client_user_id).await {
                             log!("Received own user read receipt: {receipt:?} {event_id:?}");
-                            if let Err(e) = sender.send(TimelineUpdate::OwnUserReadReceipt(receipt)) { 
-                                error!("Failed to get own user read receipt: {e:?}"); 
+                            if let Err(e) = sender.send(TimelineUpdate::OwnUserReadReceipt(receipt)) {
+                                error!("Failed to get own user read receipt: {e:?}");
                             }
                         }
                         while (update_receiver.next().await).is_some() {
@@ -776,8 +776,8 @@ async fn async_worker(
                                 break;
                             }
                             if let Some((_, receipt)) = timeline.latest_user_read_receipt(&client_user_id).await {
-                                if let Err(e) = sender.send(TimelineUpdate::OwnUserReadReceipt(receipt)) { 
-                                    error!("Failed to get own user read receipt: {e:?}"); 
+                                if let Err(e) = sender.send(TimelineUpdate::OwnUserReadReceipt(receipt)) {
+                                    error!("Failed to get own user read receipt: {e:?}");
                                 }
                             }
                         }
@@ -802,7 +802,7 @@ async fn async_worker(
                     // log!("Sending fetch avatar request for {mxc_uri:?}...");
                     let media_request = MediaRequest {
                         source: MediaSource::Plain(mxc_uri.clone()),
-                        format: MEDIA_THUMBNAIL_FORMAT.into(),
+                        format: AVATAR_THUMBNAIL_FORMAT.into(),
                     };
                     let res = client.media().get_media_content(&media_request, true).await;
                     // log!("Fetched avatar for {mxc_uri:?}, succeeded? {}", res.is_ok());
@@ -889,7 +889,7 @@ async fn async_worker(
                 };
                 let _send_frr_task = Handle::current().spawn(async move {
                     match timeline.send_single_receipt(ReceiptType::FullyRead, ReceiptThread::Unthreaded, event_id.clone()).await {
-                        Ok(sent) => log!("{} fully read receipt to room {room_id} for event {event_id}", 
+                        Ok(sent) => log!("{} fully read receipt to room {room_id} for event {event_id}",
                             if sent { "Sent" } else { "Already sent" }
                         ),
                         Err(_e) => error!("Failed to send fully read receipt to room {room_id} for event {event_id}; error: {_e:?}"),
@@ -1526,7 +1526,7 @@ async fn add_new_room(room: &room_list_service::Room, room_list_service: &RoomLi
     //     log!("Room {room_id} is now fully synced? {}", room.is_state_fully_synced());
     // }
 
-    // This will sync the room 
+    // This will sync the room
     room_list_service.subscribe_to_rooms(&[&room_id]);
 
     // Do not add tombstoned rooms to the rooms list; they require special handling.
@@ -2160,13 +2160,13 @@ fn spawn_fetch_room_avatar(room: Room) {
 /// Fetches and returns the avatar image for the given room (if one exists),
 /// otherwise returns a text avatar string of the first character of the room name.
 async fn room_avatar(room: &Room, room_name: &Option<String>) -> RoomPreviewAvatar {
-    match room.avatar(MEDIA_THUMBNAIL_FORMAT.into()).await {
+    match room.avatar(AVATAR_THUMBNAIL_FORMAT.into()).await {
         Ok(Some(avatar)) => RoomPreviewAvatar::Image(avatar),
         _ => {
             if let Ok(room_members) = room.members(RoomMemberships::ACTIVE).await {
                 if room_members.len() == 2 {
                     if let Some(non_account_member) = room_members.iter().find(|m| !m.is_account_user()) {
-                        return match non_account_member.avatar(MEDIA_THUMBNAIL_FORMAT.into()).await {
+                        return match non_account_member.avatar(AVATAR_THUMBNAIL_FORMAT.into()).await {
                             Ok(Some(avatar)) => RoomPreviewAvatar::Image(avatar),
                             _ => avatar_from_room_name(room_name.as_deref().unwrap_or_default()),
                         };
@@ -2185,7 +2185,7 @@ fn avatar_from_room_name(room_name: &str) -> RoomPreviewAvatar {
     RoomPreviewAvatar::Text(
         room_name
             .graphemes(true)
-            .find(|&g| g != "@") 
+            .find(|&g| g != "@")
             .map(ToString::to_string)
             .unwrap_or_default()
     )

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -197,13 +197,25 @@ impl From<MediaThumbnailSizeConst> for MediaThumbnailSize {
     }
 }
 
-/// The default media format to use for thumbnail requests.
-pub const MEDIA_THUMBNAIL_FORMAT: MediaFormatConst = MediaFormatConst::Thumbnail(
+/// The avatar format to use for thumbnail requests.
+pub const AVATAR_THUMBNAIL_FORMAT: MediaFormatConst = MediaFormatConst::Thumbnail(
     MediaThumbnailSettingsConst {
         size: MediaThumbnailSizeConst {
             method: Method::Scale,
             width: 40,
             height: 40,
+        },
+        animated: false,
+    }
+);
+
+/// The timeline image format to use for thumbnail requests.
+pub const TIMELINE_IMAGE_THUMBNAIL_FORMAT: MediaFormatConst = MediaFormatConst::Thumbnail(
+    MediaThumbnailSettingsConst {
+        size: MediaThumbnailSizeConst {
+            method: Method::Scale,
+            width: 400,
+            height: 400,
         },
         animated: false,
     }


### PR DESCRIPTION
We must apply the thumbnail format for the image anyhow it possess a thumbnail source or not.

Btw, an image won't possess a thumbnail source unless its size is larger than 500KB or so, by my test.

#### before:
![Screenshot from 2025-01-26 21-04-46](https://github.com/user-attachments/assets/e3d95524-61b6-4edb-926b-d5c57246d350)

 
#### after:
![Screenshot from 2025-01-26 22-48-31](https://github.com/user-attachments/assets/7f39a4be-b6f0-4662-824f-bbf1054c7267)

----
> Btw, an image won't possess a thumbnail source unless its size is larger than 500KB or so, by my test.

I found this by accident on deving, you can take a look (notice the size I marked)
![Screenshot from 2025-01-26 21-15-48](https://github.com/user-attachments/assets/8d5bcfed-db4d-421c-b2fd-affa8d8fc257)

