### PR TITLE
Modify RoomPreview formatting to waste less whitespace

### DIFF
--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -44,10 +44,10 @@ live_design! {
 
     MessagePreview = <View> {
         width: Fill, height: Fit
-        flow: Down, spacing: 5.
+        // flow: Down, spacing: 5.
 
         latest_message = <HtmlOrPlaintext> {
-            padding: {top: 3.0}
+            // padding: {top: 3.0}
             html_view = { html = {
                 font_size: 9.3,
                 draw_normal:      { text_style: { font_size: 9.3 } },
@@ -66,7 +66,8 @@ live_design! {
     }
 
     RoomPreviewContent = {{RoomPreviewContent}} {
-        flow: Right, spacing: 10., padding: 10.
+        flow: Right,
+        spacing: 10., padding: 10.
         width: Fill, height: Fit
         show_bg: true
         draw_bg: {
@@ -155,23 +156,27 @@ live_design! {
                 unread_badge = <UnreadBadge> {}
             }
             FullPreview = <RoomPreviewContent> {
+                padding: 10
                 avatar = <Avatar> {}
                 <View> {
-                    flow: Right
+                    flow: Down
                     width: Fill, height: 56
-                    align: { x: 0.5, y: 0.5 }
-                    left = <View> {
-                        width: Fill, height: Fill,
-                        flow: Down,
+                    align: { x: 0.0, y: 0.0 }
+                    top = <View> {
+                        width: Fill, height: Fit,
+                        spacing: 5,
+                        flow: Right,
                         room_name = <RoomName> {}
-                        preview = <MessagePreview> {}
+                        timestamp = <Timestamp> { margin: { top: 1.3 } }
                     }
-                    right = <View> {
-                        width: Fit, height: Fill,
-                        flow: Down,
-                        timestamp = <Timestamp> {}
+                    bottom = <View> {
+                        width: Fill, height: Fill,
+                        spacing: 5,
+                        margin: { top: 7. }
+                        flow: Right,
+                        preview = <MessagePreview> {}
                         <View> {
-                            width: Fill, height: Fill
+                            width: Fit, height: Fit
                             align: { x: 1.0 }
                             unread_badge = <UnreadBadge> {
                                 margin: { top: 5. } // Align the badge with the timestamp, same as the message preview's margin top.

--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -44,10 +44,8 @@ live_design! {
 
     MessagePreview = <View> {
         width: Fill, height: Fit
-        // flow: Down, spacing: 5.
 
         latest_message = <HtmlOrPlaintext> {
-            // padding: {top: 3.0}
             html_view = { html = {
                 font_size: 9.3,
                 draw_normal:      { text_style: { font_size: 9.3 } },
@@ -167,6 +165,7 @@ live_design! {
                         spacing: 5,
                         flow: Right,
                         room_name = <RoomName> {}
+                        // Use a small top margin to align the timestamp text baseline with the room name text baseline. 
                         timestamp = <Timestamp> { margin: { top: 1.3 } }
                     }
                     bottom = <View> {


### PR DESCRIPTION
It's now split into a top part and a bottom part instead of left/right. The top part is the RoomName and latest timestamp, while the bottom part is the latest message content and then unread message/mentions badge.