### PR TITLE
(WIP) allow taps (FingerDown/Up hits) to show/hide the profile tooltip

### DIFF
--- a/src/shared/color_tooltip.rs
+++ b/src/shared/color_tooltip.rs
@@ -78,6 +78,15 @@ impl Widget for ColorTooltip {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         if self.opened {
             self.content.handle_event(cx, event, scope);
+
+            // Hide the tooltip upon any press/click.
+            match event.hits(cx, self.draw_bg.area()) {
+                h @ Hit::FingerDown(_) | h @ Hit::FingerUp(_) => {
+                    log!("Got hit on ColorTooltip: {h:?}");
+                    self.hide(cx);
+                }
+                _ => (),
+            }
         }
     }
 
@@ -171,6 +180,10 @@ impl ColorTooltipRef {
         if let Some(mut inner) = self.borrow_mut() {
             inner.hide(cx);
         }
+    }
+
+    pub fn is_currently_shown(&self) -> bool {
+        self.borrow().is_some_and(|inner| inner.opened)
     }
 
     pub fn show_with_options(&self, cx: &mut Cx, pos: DVec2, text: &str, color: Vec4) {

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -112,8 +112,6 @@ impl LiveHook for VerificationBadge {
 
 impl Widget for VerificationBadge {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        self.view.handle_event(cx, event, scope);
-
         if let Event::Actions(actions) = event {
             for action in actions {
                 if let Some(VerificationStateAction::Update(state)) = action.downcast_ref() {
@@ -128,10 +126,11 @@ impl Widget for VerificationBadge {
         let badge = self.view(id!(verification_icons));
         let badge_area = badge.area();
         match event.hits(cx, badge_area) {
-            Hit::FingerDown(_)
-            | Hit::FingerUp(_)
-            | Hit::FingerHoverIn(_)
-            | Hit::FingerHoverOver(_) => {
+            h @ Hit::FingerDown(_)
+            | h @ Hit::FingerUp(_)
+            | h @ Hit::FingerHoverIn(_)
+            | h @ Hit::FingerHoverOver(_) => {
+                log!("Got hit on badge: {h:?}");
                 let badge_rect = badge_area.rect(cx);
                 let tooltip_pos = if cx.display_context.is_desktop() {
                     DVec2 {
@@ -155,7 +154,8 @@ impl Widget for VerificationBadge {
                     },
                 );
             }
-            Hit::FingerHoverOut(_) => {
+            Hit::FingerHoverOut(_fho) => {
+                log!("Got HoverOut hit on badge: {_fho:?}."); 
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
@@ -164,6 +164,8 @@ impl Widget for VerificationBadge {
             }
             _ => { }
         }
+
+        self.view.handle_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {


### PR DESCRIPTION
Not working yet, because the call to `hits()` inside of `ColorTooltip:handle_event()` causes a `FingerHoverOut` hit to be delivered to previous view area, which is the `VerificationBadge`, so the tooltip is immediately hidden again...