### PR TITLE
Don't handle hit events on the RoomsList while it's scrolling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2023,17 +2023,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2052,7 +2052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2096,17 +2096,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2123,12 +2123,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "bitflags 2.6.0",
  "hilog-sys",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4325,7 +4325,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#c6d7ee6143bda3a63da7e02c8a9ccbc730caf4ba"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
 
 [[package]]
 name = "typenum"

--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -8,7 +8,7 @@ use crate::{
     utils::{self, relative_format},
 };
 
-use super::rooms_list::{RoomPreviewAvatar, RoomsListEntry};
+use super::rooms_list::{RoomPreviewAvatar, RoomsListEntry, RoomsListScopeProps};
 live_design! {
     use link::theme::*;
     use link::shaders::*;
@@ -235,20 +235,16 @@ impl LiveHook for RoomPreview {
 impl Widget for RoomPreview {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         let uid = self.widget_uid();
+        let rooms_list_props = scope.props.get::<RoomsListScopeProps>().unwrap();
 
         match event.hits(cx, self.view.area()) {
             Hit::FingerDown(_fe) => {
                 cx.set_key_focus(self.view.area());
             }
-            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() => {
-                // This logic is taken from FingerUpEvent::was_tap(), but we ignore
-                // the time check because we want to allow for slower taps or long presses.
-                // All we do here is check that the finger hasn't moved too much (more than 3 pixels)
-                // since the start of the gesture (the FingerDown hit), because that would mean
-                // the user is trying to scroll rather than wanting to select a room.
-                if (fe.abs_start - fe.abs).length() < 3.0 {
-                    cx.widget_action(uid, &scope.path, RoomPreviewAction::Click);
-                }
+            Hit::FingerUp(fe) if !rooms_list_props.was_scrolling &&
+                fe.is_over && fe.is_primary_hit() && fe.was_tap() =>
+            {
+                cx.widget_action(uid, &scope.path, RoomPreviewAction::Click);
             }
             _ => (),
         }

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -575,8 +575,14 @@ impl Widget for RoomsList {
         }
 
         // Now, handle any actions on this widget, e.g., a user selecting a room.
-        let widget_uid = self.widget_uid();
-        for list_action in cx.capture_actions(|cx| self.view.handle_event(cx, event, scope)) {
+        // We use Scope `props` to pass down the current scrolling state of the PortalList.
+        let props = RoomsListScopeProps {
+            was_scrolling: self.view.portal_list(id!(list)).was_scrolling_on_latest_finger_down(),
+        };
+        let list_actions = cx.capture_actions(
+            |cx| self.view.handle_event(cx, event, &mut Scope::with_props(&props))
+        );
+        for list_action in list_actions {
             if let RoomPreviewAction::Click = list_action.as_widget_action().cast() {
                 let widget_action = list_action.as_widget_action();
 
@@ -598,7 +604,7 @@ impl Widget for RoomsList {
 
                 self.current_active_room_index = Some(displayed_room_index);
                 cx.widget_action(
-                    widget_uid,
+                    self.widget_uid(),
                     &scope.path,
                     RoomsListAction::Selected {
                         room_index: displayed_room_index,
@@ -735,4 +741,10 @@ impl WidgetMatchEvent for RoomsList {
             }
         }
     }
+}
+
+pub struct RoomsListScopeProps {
+    /// Whether the RoomsList's inner PortalList was scrolling
+    /// when the latest finger down event occurred.
+    pub was_scrolling: bool,
 }


### PR DESCRIPTION
Relies on some of my new additions to Makepad, namely the ability to determine whether the PortalList was scrolling when a FingerDown Hit event occurred.