### PR TITLE
Fix scroll behavior in rooms list (follow-up to #394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2023,17 +2023,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2052,7 +2052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2096,17 +2096,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2123,12 +2123,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "bitflags 2.6.0",
  "hilog-sys",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2184,7 +2184,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4325,7 +4325,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#5eb02270a08210dc6e44a8c7972ac90de1a50922"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
 
 [[package]]
 name = "typenum"

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -595,6 +595,7 @@ live_design! {
             flow: Down
 
             auto_tail: true, // set to `true` to lock the view to the last item.
+            max_pull_down: 0.0, // set to `0.0` to disable the pulldown bounce animation.
 
             // Below, we must place all of the possible templates (views) that can be used in the portal list.
             Message = <Message> {}

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -577,7 +577,7 @@ impl Widget for RoomsList {
         // Now, handle any actions on this widget, e.g., a user selecting a room.
         // We use Scope `props` to pass down the current scrolling state of the PortalList.
         let props = RoomsListScopeProps {
-            was_scrolling: self.view.portal_list(id!(list)).was_scrolling_on_latest_finger_down(),
+            was_scrolling: self.view.portal_list(id!(list)).was_scrolling(),
         };
         let list_actions = cx.capture_actions(
             |cx| self.view.handle_event(cx, event, &mut Scope::with_props(&props))


### PR DESCRIPTION
Update makepad dep to incorporate my improvements to the PortalList scroll handling logic, particularly for touchscreen devices that use drag scrolling.
Basically, this changeset ensures that touches/clicks on the PortalList *during* an existing scroll action are no longer treated as clicking the underlying item within the PortalList.

This is a follow-up/continuation to #394 