### PR TITLE
Update makepad with our fixes to avoid all panics in image decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2003,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2029,17 +2029,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2058,7 +2058,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2092,27 +2092,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "makepad-markdown"
-version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
-dependencies = [
- "makepad-live-id",
-]
-
-[[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2121,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2129,12 +2121,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "bitflags 2.6.0",
  "hilog-sys",
@@ -2158,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2173,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2181,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2190,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2199,13 +2191,13 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
  "makepad-html",
- "makepad-markdown",
  "makepad-zune-png",
+ "pulldown-cmark",
  "unicode-segmentation",
  "zune-jpeg",
 ]
@@ -2213,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4332,7 +4324,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#fa9206b0e7a45cd2c5a465c897f851b83d50d103"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
 
 [[package]]
 name = "typenum"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::{Instant, SystemTime}};
+use std::{borrow::Cow, time::SystemTime};
 
 use chrono::{DateTime, Duration, Local, TimeZone};
 use makepad_widgets::{error, image_cache::ImageError, Cx, Event, ImageRef};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, time::SystemTime};
+use std::{borrow::Cow, time::{Instant, SystemTime}};
 
 use chrono::{DateTime, Duration, Local, TimeZone};
 use makepad_widgets::{error, image_cache::ImageError, Cx, Event, ImageRef};
@@ -72,16 +72,20 @@ pub fn load_png_or_jpg(img: &ImageRef, cx: &mut Cx, data: &[u8]) -> Result<(), I
         }
     };
     if let Err(err) = res.as_ref() {
-        // debugging: dump out the avatar image to disk
+        // debugging: dump out the bad image to disk
         let mut path = crate::temp_storage::get_temp_dir_path().clone();
-        let filename = format!("img_{}",
-            SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis(),
+        let filename = format!(
+            "img_{}",
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or_else(|_| rand::random::<u128>()),
         );
         path.push(filename);
         path.set_extension("unknown");
         error!("Failed to load PNG/JPG: {err}. Dumping bad image: {:?}", path);
-        std::fs::write(path, data)
-            .expect("Failed to write user avatar image to disk");
+        let _ = std::fs::write(path, data)
+            .inspect_err(|e| error!("Failed to write bad image to disk: {e}"));
     }
     res
 }


### PR DESCRIPTION
Also ensure that all image loading functions within Robrix do not panic at all.

Fixes #382.