### PR TITLE
Persistent event cache for timeline event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ bytesize = "1.3.0"
 bitflags = "2.6.0"
 indexmap = "2.6.0"
 blurhash = { version = "0.2.3", default-features = false }
+ruma-events = { git = "https://github.com/ruma/ruma", rev = "7755c7cbc580f8d8aea30d78cc1a6850b1a6fd39"}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1693,6 +1693,7 @@ impl RoomScreen {
                 room_id: tl.room_id.clone(),
                 num_events: 50,
                 direction: PaginationDirection::Backwards,
+                use_cache: false
             });
         }
 
@@ -2306,6 +2307,7 @@ impl RoomScreen {
                 room_id: room_id.clone(),
                 num_events: 50,
                 direction: PaginationDirection::Backwards,
+                use_cache: true
             });
 
             // Even though we specify that room member profiles should be lazy-loaded,
@@ -2535,6 +2537,7 @@ impl RoomScreen {
                 room_id: tl.room_id.clone(),
                 num_events: 50,
                 direction: PaginationDirection::Backwards,
+                use_cache: false
             });
         }
         tl.last_scrolled_index = first_index;

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -662,6 +662,7 @@ impl Widget for RoomsList {
                             room_id: room_info.room_id.clone(),
                             num_events: 50,
                             direction: PaginationDirection::Backwards,
+                            use_cache: false
                         });
                     }
 

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -226,7 +226,7 @@ pub enum MatrixRequest {
         /// The maximum number of timeline events to fetch in each pagination batch.
         num_events: u16,
         direction: PaginationDirection,
-        /// If true, skipp timeline pagination if the length of event cache is larger or equal to num_events
+        /// If true, skips timeline pagination if the length of event cache is larger or equal to number of events
         use_cache: bool
     },
     /// Request to edit the content of an event in the given room's timeline.

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -418,10 +418,12 @@ async fn async_worker(
                     (timeline_ref, sender)
                 };
                 if use_cache {
-                    let (ec, ed) = timeline.room().event_cache().await.unwrap();
-                    let (cache_timelines, _) = ec.subscribe().await;
+                    let Ok((room_event_cache, _event_cache_drop_handler))  = timeline.room().event_cache().await else {
+                        continue;
+                    };
+                    let (cache_timelines, _) = room_event_cache.subscribe().await;
                     if cache_timelines.len() >= num_events.into() {
-                        log!("Fetching timeline events from the cache with length: {:?} for room {room_id}...", timelines.len());
+                        log!("Fetching timeline events from the cache with length: {:?} for room {room_id}...", cache_timelines.len());
                         sender.send(TimelineUpdate::PaginationIdle {
                             fully_paginated: true,
                             direction: PaginationDirection::Backwards,


### PR DESCRIPTION
Fixes #164 

1. Added Event_cache enable storage before client's synchronization 
2. Added "use_cache" boolean for MatrixRequest::PaginateRoomTimeline
3. Added logic to decide whether to do timeline pagination based on event cache's length. 

There is not need to manually add initial event to event cache because there is synchronization. [EventCache::add_initial_events()](https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk/event_cache/struct.EventCache.html#method.add_initial_events)

There is also no need to use Clientbuilder.sqlite_store_with_cache_path method as it just separates the cache path from the app data.
