### PR TITLE
fix stop animate not stopping the bouncing animation in typing animation

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -25,7 +25,7 @@ use crate::{
         user_profile::{AvatarState, ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     }, shared::{
-        avatar::AvatarWidgetRefExt, callout_tooltip::TooltipAction, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::enqueue_popup_notification, text_or_image::{TextOrImageRef, TextOrImageWidgetRefExt}, typing_animation::TypingAnimationWidgetExt
+        avatar::AvatarWidgetRefExt, callout_tooltip::TooltipAction, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::enqueue_popup_notification, text_or_image::{TextOrImageRef, TextOrImageWidgetRefExt},
     }, sliding_sync::{self, get_client, submit_async_request, take_timeline_endpoints, BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineRequestSender, UserPowerLevels}, utils::{self, unix_time_millis_to_datetime, ImageFormat, MediaFormatConst, MEDIA_THUMBNAIL_FORMAT}
 };
 use crate::home::event_reaction_list::ReactionListWidgetRefExt;

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1721,14 +1721,11 @@ impl RoomScreen {
             self.view.view(id!(typing_notice)).set_visible(cx, true);
             // Animate in the typing notice view (sliding it up from the bottom).
             self.animator_play(cx, id!(typing_notice_animator.show));
-            // Start the typing notice text animation of bouncing dots.
-            let typing_animation = self.view.typing_animation(id!(typing_animation));
-            typing_animation.animate(cx);
+     
         } else {
             // Animate out the typing notice view (sliding it out towards the bottom).
             self.animator_play(cx, id!(typing_notice_animator.hide));
-            let typing_animation = self.view.typing_animation(id!(typing_animation));
-            typing_animation.stop_animation();
+
         }
 
         if num_updates > 0 {

--- a/src/shared/typing_animation.rs
+++ b/src/shared/typing_animation.rs
@@ -15,7 +15,6 @@ live_design! {
             uniform freq: 5.0,  // Animation frequency
             uniform phase_offset: 102.0, // Phase difference
             uniform dot_radius: 1.5, // Dot radius
-            uniform the_time: 0.0,
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                 let amplitude = self.rect_size.y * 0.22;
@@ -23,19 +22,19 @@ live_design! {
                 // Create three circle SDFs
                 sdf.circle(
                     self.rect_size.x * 0.25, 
-                    amplitude * sin(self.the_time * self.freq) + center_y, 
+                    amplitude * sin(self.time * self.freq) + center_y, 
                     self.dot_radius
                 );
                 sdf.fill(self.color);
                 sdf.circle(
                     self.rect_size.x * 0.5, 
-                    amplitude * sin(self.the_time * self.freq + self.phase_offset) + center_y, 
+                    amplitude * sin(self.time * self.freq + self.phase_offset) + center_y, 
                     self.dot_radius
                 );
                 sdf.fill(self.color);
                 sdf.circle(
                     self.rect_size.x * 0.75, 
-                    amplitude * sin(self.the_time * self.freq + self.phase_offset * 2) + center_y, 
+                    amplitude * sin(self.time * self.freq + self.phase_offset * 2) + center_y, 
                     self.dot_radius
                 );
                 sdf.fill(self.color);
@@ -48,43 +47,15 @@ live_design! {
 #[derive(Live, LiveHook, Widget)]
 pub struct TypingAnimation {
     #[deref] view: View,
-    #[rust] next_frame: NextFrame,
-    #[rust] is_play: bool,
+
 }
 impl Widget for TypingAnimation {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        
-        if let Some(ne) = self.next_frame.is_event(event) {
-            let time = ((ne.time * 10.0).round() as u32 % 360) as f32;
-            self.draw_bg.set_uniform(cx, id!(the_time), &[time as f32]);
-            self.redraw(cx);
-            if !self.is_play {
-                return
-            }
-            self.next_frame = cx.new_next_frame();
-        }
 
         self.view.handle_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         self.view.draw_walk(cx, scope, walk)
-    }
-}
-
-
-impl TypingAnimationRef {
-    /// Starts animation of the bouncing dots.
-    pub fn animate(&self, cx: &mut Cx) {
-        if let Some(mut inner) = self.borrow_mut() {
-            inner.is_play = true;
-            inner.next_frame = cx.new_next_frame();
-        }
-    }
-    /// Stops animation of the bouncing dots.
-    pub fn stop_animation(&self) {
-        if let Some(mut inner) = self.borrow_mut() {
-            inner.is_play = false;
-        }
     }
 }

--- a/src/shared/typing_animation.rs
+++ b/src/shared/typing_animation.rs
@@ -15,6 +15,7 @@ live_design! {
             uniform freq: 5.0,  // Animation frequency
             uniform phase_offset: 102.0, // Phase difference
             uniform dot_radius: 1.5, // Dot radius
+            uniform the_time: 0.0,
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
                 let amplitude = self.rect_size.y * 0.22;
@@ -22,19 +23,19 @@ live_design! {
                 // Create three circle SDFs
                 sdf.circle(
                     self.rect_size.x * 0.25, 
-                    amplitude * sin(self.time * self.freq) + center_y, 
+                    amplitude * sin(self.the_time * self.freq) + center_y, 
                     self.dot_radius
                 );
                 sdf.fill(self.color);
                 sdf.circle(
                     self.rect_size.x * 0.5, 
-                    amplitude * sin(self.time * self.freq + self.phase_offset) + center_y, 
+                    amplitude * sin(self.the_time * self.freq + self.phase_offset) + center_y, 
                     self.dot_radius
                 );
                 sdf.fill(self.color);
                 sdf.circle(
                     self.rect_size.x * 0.75, 
-                    amplitude * sin(self.time * self.freq + self.phase_offset * 2) + center_y, 
+                    amplitude * sin(self.the_time * self.freq + self.phase_offset * 2) + center_y, 
                     self.dot_radius
                 );
                 sdf.fill(self.color);
@@ -47,15 +48,15 @@ live_design! {
 #[derive(Live, LiveHook, Widget)]
 pub struct TypingAnimation {
     #[deref] view: View,
-    #[live] time: f32,
     #[rust] next_frame: NextFrame,
     #[rust] is_play: bool,
 }
 impl Widget for TypingAnimation {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        
         if let Some(ne) = self.next_frame.is_event(event) {
-            self.time += ne.time as f32;       
-            self.time = (self.time.round() as u32 % 360) as f32;
+            let time = ((ne.time * 10.0).round() as u32 % 360) as f32;
+            self.draw_bg.set_uniform(cx, id!(the_time), &[time as f32]);
             self.redraw(cx);
             if !self.is_play {
                 return


### PR DESCRIPTION
## PR Content
There are currently 2 issues.

1. Previously, the self.time in the pixel function continues to run despite the next frame event has stopped. This causes the 3 dots to continue bouncing. This issue is pointed out when new intern migrated the typing animation to a separate project.

Even without the fix, the issue is unnoticeable.

2. There is extra redraw when we calls the next frame that re-draws everything.

Solution: Just keep the 3 dots bouncing, even if we hide it as it does not revoke extra draw execution

## Related PR

- https://github.com/project-robius/robrix/issues/353
