### PR TITLE
Use our latest Makepad update to fix duplicate Back button handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,7 +1899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2068,17 +2068,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2097,7 +2097,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2123,7 +2123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2133,17 +2133,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2160,12 +2160,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4386,7 +4386,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#2e8ab828189944b8eee4886092c85647b9d1b8c3"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
 
 [[package]]
 name = "typenum"

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -155,6 +155,11 @@ impl Widget for ReactionList {
                     self.do_hover_out(cx, scope, button_ref);
                     break;
                 }
+                // A long press is treated as a hover-in.
+                Hit::FingerLongPress(_) => {
+                    self.do_hover_in(cx, scope, button_ref, reaction_data.clone());
+                    break;
+                }
                 Hit::FingerUp(fue) => {
                     // If the finger is not over the button, treat it as a hover-out.
                     if !fue.is_over {
@@ -162,13 +167,8 @@ impl Widget for ReactionList {
                         break;
                     }
 
-                    // A right-click or a long-press is treated as a hover-in.
-                    if fue.is_over &&
-                        (
-                            fue.mouse_button().is_some_and(|b| b.is_secondary())
-                            || (fue.is_primary_hit() && fue.was_long_press())
-                        )
-                    {
+                    // A right-click or is treated as a hover-in.
+                    if fue.is_over && fue.mouse_button().is_some_and(|b| b.is_secondary()) {
                         self.do_hover_in(cx, scope, button_ref, reaction_data.clone());
                         break;
                     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -21,7 +21,7 @@ use matrix_sdk_ui::timeline::{
 use robius_location::Coordinates;
 
 use crate::{
-    avatar_cache, event_preview::{body_of_timeline_item, text_preview_of_member_profile_change, text_preview_of_other_state, text_preview_of_redacted_message, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}}, location::{get_latest_location, init_location_subscriber, request_location_update, LocationAction, LocationRequest, LocationUpdate}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    avatar_cache, event_preview::{body_of_timeline_item, text_preview_of_member_profile_change, text_preview_of_other_state, text_preview_of_redacted_message, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, location::{get_latest_location, init_location_subscriber, request_location_update, LocationAction, LocationRequest, LocationUpdate}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
         user_profile::{AvatarState, ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     }, shared::{
@@ -1134,12 +1134,11 @@ impl Widget for RoomScreen {
                 }
             }
 
-            // Handle the send message button being clicked and enter key being pressed.
-            let send_message_shortcut_pressed = message_input
-                .key_down_unhandled(actions)
-                .is_some_and(|ke| ke.key_code == KeyCode::ReturnKey && ke.modifiers.is_primary());
-            if send_message_shortcut_pressed
-                || self.button(id!(send_message_button)).clicked(actions)
+            // Handle the send message button being clicked or Cmd/Ctrl + Return being pressed.
+            if self.button(id!(send_message_button)).clicked(actions)
+                || message_input.key_down_unhandled(actions).is_some_and(
+                    |ke| ke.key_code == KeyCode::ReturnKey && ke.modifiers.is_primary()
+                )
             {
                 let entered_text = message_input.text().trim().to_string();
                 if !entered_text.is_empty() {

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -441,21 +441,24 @@ impl Widget for UserProfileSlidingPane {
         // 3. The escape key is pressed if this pane has key focus,
         // 4. The back mouse button is clicked within this view,
         // 5. The user clicks/touches outside the main_content view area.
-        let close_pane = match event {
-            Event::Actions(actions) => self.button(id!(close_button)).clicked(actions),  // 1
-            Event::BackPressed => true,                                                  // 2
-            _ => false,
-        } || match event.hits_with_capture_overload(cx, area, true) {
-            Hit::KeyUp(key) => key.key_code == KeyCode::Escape,                          // 3
-            Hit::FingerDown(_fde) => {
-                cx.set_key_focus(area);
-                false
+        let close_pane = {
+            matches!(
+                event,
+                Event::Actions(actions) if self.button(id!(close_button)).clicked(actions)
+            )
+            || event.back_pressed()
+            || match event.hits_with_capture_overload(cx, area, true) {
+                Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
+                Hit::FingerDown(_fde) => {
+                    cx.set_key_focus(area);
+                    false
+                }
+                Hit::FingerUp(fue) if fue.is_over => {
+                    fue.mouse_button().is_some_and(|b| b.is_back())
+                    || !self.view(id!(main_content)).area().rect(cx).contains(fue.abs)
+                }
+                _ => false,
             }
-            Hit::FingerUp(fue) if fue.is_over => {
-                fue.mouse_button().is_some_and(|b| b.is_back())                          // 4
-                || !self.view(id!(main_content)).area().rect(cx).contains(fue.abs)       // 5
-            }
-            _ => false,
         };
         if close_pane {
             self.animator_play(cx, id!(panel.hide));


### PR DESCRIPTION
Previously, the `BackPressed` event in Makepad wasn't handled correctly, and could not be properly represented via the `hits()` API.

Now, we have modified it in Makepad to include an internal `handled` boolean which is set to `true` once a widget has handled that event, ensuring that multiple widgets can't respond to a single `Backpressed`.

We also fixed the StackNavigation widget to ensure that it will only respond to a `BackPressed` event if no other child widget had already handled it previously.
Together, this fixes the issue where a UserProfileSlidingPane would be hidden *AND* the StackNavigation widget would return to the root RoomsList view upon a *single* `BackPressed` event. Now, it takes two separate `BackPressed` events for that to happen, which matches the user's expectations.