### PR TITLE
Fix `clippy::doc_overindented_list_items` lints

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3877,12 +3877,12 @@ trait SmallStateEventContent {
     ///
     /// ## Arguments
     /// * `item`: a `SmallStateEvent` widget that has already been added to
-    ///    the given `PortalList` at the given `item_id`.
-    ///    This function may either modify that item or completely replace it
-    ///    with a different widget if needed.
+    ///   the given `PortalList` at the given `item_id`.
+    ///   This function may either modify that item or completely replace it
+    ///   with a different widget if needed.
     /// * `item_drawn_status`: the old (prior) drawn status of the item.
     /// * `new_drawn_status`: the new drawn status of the item, which may have already
-    ///    been updated to reflect the item's profile having been drawn right before this function.
+    ///   been updated to reflect the item's profile having been drawn right before this function.
     ///
     /// ## Return
     /// Returns a tuple of the drawn `item` and its `new_drawn_status`.

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -139,11 +139,11 @@ impl Avatar {
     ///
     /// ## Arguments
     /// * `info`: information about the user represented by this avatar, including a tuple of
-    ///    the user ID, displayable user name, and room ID.
-    ///    * Set this to `Some` to enable a user to click/tap on the Avatar itself.
-    ///    * Set this to `None` to disable the click/tap action.
+    ///   the user ID, displayable user name, and room ID.
+    ///   * Set this to `Some` to enable a user to click/tap on the Avatar itself.
+    ///   * Set this to `None` to disable the click/tap action.
     /// * `username`: the displayable text for this avatar, either a user name or user ID.
-    ///    Only the first non-`@` letter (Unicode grapheme) is displayed.
+    ///   Only the first non-`@` letter (Unicode grapheme) is displayed.
     pub fn show_text<T: AsRef<str>>(
         &mut self,
         cx: &mut Cx,
@@ -168,13 +168,13 @@ impl Avatar {
     ///
     /// ## Arguments
     /// * `info`: information about the user represented by this avatar:
-    ///    the user name, user ID, room ID, and avatar image data.
-    ///    * Set this to `Some` to enable a user to click/tap on the Avatar itself.
-    ///    * Set this to `None` to disable the click/tap action.
+    ///   the user name, user ID, room ID, and avatar image data.
+    ///   * Set this to `Some` to enable a user to click/tap on the Avatar itself.
+    ///   * Set this to `None` to disable the click/tap action.
     /// * `image_set_function`: - a function that is passed in the `&mut Cx`
-    ///    and an [ImageRef] that refers to the image that will be displayed in this avatar.
-    ///    This allows the caller to set the image contents in any way they want.
-    ///    If `image_set_function` returns an error, no change is made to the avatar.
+    ///   and an [ImageRef] that refers to the image that will be displayed in this avatar.
+    ///   This allows the caller to set the image contents in any way they want.
+    ///   If `image_set_function` returns an error, no change is made to the avatar.
     pub fn show_image<F, E>(
         &mut self,
         cx: &mut Cx,

--- a/src/shared/text_or_image.rs
+++ b/src/shared/text_or_image.rs
@@ -84,11 +84,11 @@ impl TextOrImage {
     ///
     /// ## Arguments
     /// * `image_set_function`: this function will be called with an [ImageRef] argument,
-    ///    which refers to the image that will be displayed within this `TextOrImage`.
-    ///    This allows the caller to set the image contents in any way they want.
-    ///    * If successful, the `image_set_function` should return the size of the image
-    ///      in pixels as a tuple, `(width, height)`.
-    ///    * If `image_set_function` returns an error, no change is made to this `TextOrImage`.
+    ///   which refers to the image that will be displayed within this `TextOrImage`.
+    ///   This allows the caller to set the image contents in any way they want.
+    ///   * If successful, the `image_set_function` should return the size of the image
+    ///     in pixels as a tuple, `(width, height)`.
+    ///   * If `image_set_function` returns an error, no change is made to this `TextOrImage`.
     pub fn show_image<F, E>(&mut self, cx: &mut Cx, image_set_function: F) -> Result<(), E>
         where F: FnOnce(&mut Cx, ImageRef) -> Result<(usize, usize), E>
     {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -190,9 +190,9 @@ async fn login(
 /// Which direction to paginate in.
 ///
 /// * `Forwards` will retrieve later events (towards the end of the timeline),
-///    which only works if the timeline is *focused* on a specific event.
+///   which only works if the timeline is *focused* on a specific event.
 /// * `Backwards`: the more typical choice, in which earlier events are retrieved
-///    (towards the start of the timeline), which works in  both live mode and focused mode.
+///   (towards the start of the timeline), which works in  both live mode and focused mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaginationDirection {
     Forwards,


### PR DESCRIPTION
This lint is slated to be added in Rust 1.86.