### PR TITLE
Use our new hit handling functionality in Makepad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2068,17 +2068,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2097,7 +2097,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2123,7 +2123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2133,17 +2133,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2160,12 +2160,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4386,7 +4386,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_without_mark_as_handled#3412f038b7ac2d3347ad248700da07ba6b2eae8c"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "hits_without_mark_as_handled" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "hits_handling_redesign" }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -143,11 +143,11 @@ impl Widget for ReactionList {
             // Note: the `break` statements are used to break out of the loop over
             // all reaction buttons, since a hit event can only occur on one button.
             match event.hits(cx, button_area) {
-                Hit::FingerDown(_) => {
+                Hit::FingerDown(..) => {
                     cx.set_key_focus(button_area);
                     break;
                 }
-                Hit::FingerHoverIn(_) | Hit::FingerHoverOver(_) => {
+                Hit::FingerHoverIn(..) | Hit::FingerHoverOver(..) => {
                     self.do_hover_in(cx, scope, button_ref, reaction_data.clone());
                     break;
                 }
@@ -164,17 +164,9 @@ impl Widget for ReactionList {
                     // If the finger is not over the button, treat it as a hover-out.
                     if !fue.is_over {
                         self.do_hover_out(cx, scope, button_ref);
-                        break;
                     }
-
-                    // A right-click or is treated as a hover-in.
-                    if fue.is_over && fue.mouse_button().is_some_and(|b| b.is_secondary()) {
-                        self.do_hover_in(cx, scope, button_ref, reaction_data.clone());
-                        break;
-                    }
-
-                    // A primary click/press should toggle the reaction button.
-                    if fue.is_over && fue.is_primary_hit() && fue.was_tap() {
+                    // Otherwise, a primary click/press over the button should toggle the reaction.
+                    else if fue.is_primary_hit() && fue.was_tap() {
                         let Some(room_id) = &self.room_id else { return };
                         let Some(timeline_event_id) = &self.timeline_event_id else {
                             return;
@@ -194,10 +186,8 @@ impl Widget for ReactionList {
                             draw_bg: { color: (bg_color) , border_color: (border_color) }
                         });
                         self.do_hover_in(cx, scope, button_ref, reaction_data.clone());
-                        break;
                     }
-
-                    
+                    break;
                 }
                 Hit::FingerScroll(_) => {
                     self.do_hover_out(cx, scope, button_ref);

--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -192,7 +192,7 @@ impl Widget for LoadingPane {
             || event.back_pressed()
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
-                Hit::FingerDown(_fde) => {
+                Hit::FingerDown(_fde, _) => {
                     cx.set_key_focus(area);
                     false
                 }

--- a/src/home/new_message_context_menu.rs
+++ b/src/home/new_message_context_menu.rs
@@ -356,7 +356,7 @@ impl Widget for NewMessageContextMenu {
             event.back_pressed()
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
-                Hit::FingerDown(fde) => {
+                Hit::FingerDown(fde, _) => {
                     let reaction_text_input = self.view.text_input(id!(reaction_input_view.reaction_text_input));
                     if reaction_text_input.area().rect(cx).contains(fde.abs) {
                         reaction_text_input.set_key_focus(cx);

--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -238,7 +238,7 @@ impl Widget for RoomPreview {
         let rooms_list_props = scope.props.get::<RoomsListScopeProps>().unwrap();
 
         match event.hits(cx, self.view.area()) {
-            Hit::FingerDown(_fe) => {
+            Hit::FingerDown(..) => {
                 cx.set_key_focus(self.view.area());
             }
             Hit::FingerUp(fe) if !rooms_list_props.was_scrolling &&
@@ -246,7 +246,7 @@ impl Widget for RoomPreview {
             {
                 cx.widget_action(uid, &scope.path, RoomPreviewAction::Click);
             }
-            _ => (),
+            _ => { }
         }
 
         self.view.handle_event(cx, event, scope);

--- a/src/home/room_read_receipt.rs
+++ b/src/home/room_read_receipt.rs
@@ -91,24 +91,28 @@ impl Widget for AvatarRow {
         }
         let uid: WidgetUid = self.widget_uid();
         let widget_rect = self.area.rect(cx);
-        match event.hits(cx, self.area) {
-            Hit::FingerHoverIn(_) | Hit::FingerHoverOver(_) | Hit::FingerUp(_) => {
-                if let Some(read_receipts) = &self.read_receipts {
-                    cx.widget_action(
-                        uid,
-                        &scope.path,
-                        RoomScreenTooltipActions::HoverInReadReceipt {
-                            widget_rect,
-                            bg_color: None,
-                            read_receipts: read_receipts.clone(),
-                        },
-                    );
-                }
-            }
+
+        let should_hover_in = match event.hits(cx, self.area) {
+            Hit::FingerLongPress(_) | Hit::FingerHoverIn(..) => true,
+            Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() => true,
             Hit::FingerHoverOut(_) => {
                 cx.widget_action(uid, &scope.path, RoomScreenTooltipActions::HoverOut);
+                false
             }
-            _ => {}
+            _ => false,
+        };
+        if should_hover_in {
+            if let Some(read_receipts) = &self.read_receipts {
+                cx.widget_action(
+                    uid,
+                    &scope.path,
+                    RoomScreenTooltipActions::HoverInReadReceipt {
+                        widget_rect,
+                        bg_color: None,
+                        read_receipts: read_receipts.clone(),
+                    },
+                );
+            }
         }
     }
 

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -449,7 +449,7 @@ impl Widget for UserProfileSlidingPane {
             || event.back_pressed()
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
-                Hit::FingerDown(_fde) => {
+                Hit::FingerDown(_fde, _) => {
                     cx.set_key_focus(area);
                     false
                 }

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -106,10 +106,10 @@ impl Widget for Avatar {
         let area = self.view.area();
         let widget_uid = self.widget_uid();
         match event.hits(cx, area) {
-            Hit::FingerDown(_fde) => {
+            Hit::FingerDown(_fde, _) => {
                 cx.set_key_focus(area);
             }
-            Hit::FingerUp(fue) => if fue.is_over && fue.was_tap() {
+            Hit::FingerUp(fue) => if fue.is_over && fue.is_primary_hit() && fue.was_tap() {
                 cx.widget_action(
                     widget_uid,
                     &scope.path,
@@ -211,22 +211,7 @@ impl Avatar {
             AvatarDisplayStatus::Text
         }
     }
-    /// Returns a hit event based on user interaction with the avatar
-    /// 
-    /// # Parameters
-    /// - `cx`: The draw context
-    /// - `event`: The input event
-    /// - `sweep_area`: The area to check for hits
-    /// 
-    /// # Returns
-    /// A `Hit` representing the type of interaction (hover, click, etc.)
-    fn hit(&mut self, cx: &mut Cx, event: &Event, sweep_area: Area) -> Hit {
-        
-        event.hits_with_options(
-            cx,
-            self.area(),
-            HitOptions::default().with_sweep_area(sweep_area))
-    }
+
     /// Sets the given avatar and returns a displayable username based on the
     /// given profile and user ID of the sender of the event with the given event ID.
     ///
@@ -391,11 +376,6 @@ impl AvatarRef {
         } else {
             AvatarDisplayStatus::Text
         }
-    }
-    
-    /// See [`Avatar::hit()`].
-    pub fn hit(&mut self, cx: &mut Cx, event: &Event, sweep_area: Area) -> Option<Hit> {
-        self.borrow_mut().map(|mut inner| inner.hit(cx, event, sweep_area))
     }
     
     /// See [`Avatar::set_avatar_and_get_username()`].

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -201,13 +201,13 @@ impl Widget for MatrixHtmlSpan {
         let mut needs_redraw = false;
         for area in self.drawn_areas.clone().into_iter() {
             match event.hits(cx, area) {
-                Hit::FingerDown(_fe) if self.grab_key_focus => {
+                Hit::FingerDown(..) if self.grab_key_focus => {
                     cx.set_key_focus(self.area());
                 }
-                Hit::FingerHoverIn(_) if self.spoiler.is_some() => {
+                Hit::FingerHoverIn(..) if self.spoiler.is_some() => {
                     cx.set_cursor(MouseCursor::Hand);
                 }
-                Hit::FingerUp(fe) if fe.is_over => {
+                Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
                     self.spoiler.toggle();
                     needs_redraw = true;
                 }

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -131,27 +131,27 @@ impl Widget for VerificationBadge {
 
         let badge = self.view(id!(verification_icons));
         let badge_area = badge.area();
-        match event.hits(cx, badge_area) {
-            Hit::FingerDown(_)
-            | Hit::FingerUp(_)
-            | Hit::FingerHoverIn(_)
-            | Hit::FingerHoverOver(_) => {
-                let badge_rect = badge_area.rect(cx);
-                cx.widget_action(
-                    self.widget_uid(),
-                    &scope.path,
-                    TooltipAction::HoverIn {
-                        widget_rect: badge_rect,
-                        text: verification_state_str(self.verification_state).to_string(),
-                        bg_color: Some(verification_state_color(self.verification_state)),
-                        text_color: None,
-                    },
-                );
-            }
+        let should_hover_in = match event.hits(cx, badge_area) {
+            Hit::FingerLongPress(_) | Hit::FingerHoverIn(..) => true,
+            Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() => true,
             Hit::FingerHoverOut(_) => {
                 cx.widget_action(self.widget_uid(), &scope.path, TooltipAction::HoverOut);
+                false
             }
-            _ => {}
+            _ => false,
+        };
+        if should_hover_in {
+            let badge_rect = badge_area.rect(cx);
+            cx.widget_action(
+                self.widget_uid(),
+                &scope.path,
+                TooltipAction::HoverIn {
+                    widget_rect: badge_rect,
+                    text: verification_state_str(self.verification_state).to_string(),
+                    bg_color: Some(verification_state_color(self.verification_state)),
+                    text_color: None,
+                },
+            );
         }
     }
 


### PR DESCRIPTION
The general idea is to let child widgets handle a given event before their parent widget handles it.
If a given child widget handles that event, the parent widget won't handle it duplicately.
However, if no child widgets handle it, then the event will be able to be handled by the parent widget.

Now, a child widget can handle an event and then mark it as not-handled, meaning that another widget will *also* be able to handle it.

Note that this Makepad change still preserves the historical behavior of an event being marked as handled by default upon *any* call to `event.hits()`, so if you want to override that behavior, you have to explicitly call `EventHandled::mark_as_handled(false)` for that specific `Hit` variant.

This also removes the our use on the previous callback-based implementation of `hits_without_mark_as_handled()`, which was a lot harder to use and less flexible.

See https://github.com/makepad/makepad/pull/673 for more details.

---------------------
Other improvements: 
* This PR also fixes hover-in and right-click handling for all widgets that display tooltips, e.g., reaction lists, read receipts.
* We also move right-click handling to the `FingerDown` hit, which seems to be the canonical behavior on most desktop platforms (rather than handling it on a click-up event).
* We also can now use the new long-press functionality that we added into Makepad here:https://github.com/makepad/makepad/pull/669, instead of using a timer (which didn't really work) in the Message widget specifically.
* We also ensure that only a primary click/touch activates certain things, e.g., clicking on an Avatar to show the user profile, clicking on a spoiler, etc
* We no longer send "show tooltip" actions on every `FingerHoverOver` event, as that is quite inefficient. We only need to emit that on the first `FingerHoverIn`, and then emit a "hide tooltip" action on the future `FingerHoverOut` event. 	

