### PR TITLE
Update makepad to include our recent fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2068,17 +2068,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2097,7 +2097,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2107,7 +2107,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2123,7 +2123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2133,17 +2133,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2160,12 +2160,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -2221,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4386,7 +4386,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#b9af3766d09fe8cbde1fc5a65dcfb5f0e5f57908"
+source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
 
 [[package]]
 name = "typenum"

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -147,7 +147,8 @@ impl Widget for ReactionList {
                     cx.set_key_focus(button_area);
                     break;
                 }
-                Hit::FingerHoverIn(..) | Hit::FingerHoverOver(..) => {
+                Hit::FingerHoverOver(..) // TODO: remove once CalloutTooltip bug is fixed
+                | Hit::FingerHoverIn(..) => {
                     self.do_hover_in(cx, scope, button_ref, reaction_data.clone());
                     break;
                 }

--- a/src/home/room_read_receipt.rs
+++ b/src/home/room_read_receipt.rs
@@ -93,7 +93,9 @@ impl Widget for AvatarRow {
         let widget_rect = self.area.rect(cx);
 
         let should_hover_in = match event.hits(cx, self.area) {
-            Hit::FingerLongPress(_) | Hit::FingerHoverIn(..) => true,
+            Hit::FingerLongPress(_)
+            | Hit::FingerHoverOver(..) // TODO: remove once CalloutTooltip bug is fixed
+            | Hit::FingerHoverIn(..) => true,
             Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() => true,
             Hit::FingerHoverOut(_) => {
                 cx.widget_action(uid, &scope.path, RoomScreenTooltipActions::HoverOut);

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -132,7 +132,9 @@ impl Widget for VerificationBadge {
         let badge = self.view(id!(verification_icons));
         let badge_area = badge.area();
         let should_hover_in = match event.hits(cx, badge_area) {
-            Hit::FingerLongPress(_) | Hit::FingerHoverIn(..) => true,
+            Hit::FingerLongPress(_)
+            | Hit::FingerHoverOver(..) // TODO: remove once CalloutTooltip bug is fixed
+            | Hit::FingerHoverIn(..) => true,
             Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() => true,
             Hit::FingerHoverOut(_) => {
                 cx.widget_action(self.widget_uid(), &scope.path, TooltipAction::HoverOut);


### PR DESCRIPTION
Due to a minor display bug in CalloutTooltip,
we need to ensure that all emitted tooltip actions are also triggered on `FingerHoverIn` *and* `FingerHoverOver`, even though it ideally should not be necessary to re-trigger redundant tooltip actions on a simple `FingerHoverOver`.