### PR TITLE
Fix: title from Makepad to Robrix for windows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -102,6 +102,7 @@ live_design! {
     App = {{App}} {
         ui: <Window> {
             window: {inner_size: vec2(1280, 800), title: "Robrix"},
+            caption_bar = {caption_label = {label = {text: "Robrix"}}}
             pass: {clear_color: #2A}
 
             body = {


### PR DESCRIPTION
I have fixed the title of robrix, or more precisely, the `caption_label`, since the previous title was technically already in effect. On Windows, what is actually displayed is the `caption_label` within the `caption_bar`.

One issue is that in the widgets module `windows.rs`, the `caption_bar` has visible = false, but this setting does not take effect on Windows. This part needs to be specifically tracked in makepad.    

```rust
 pub Window = <WindowBase> {
        pass: { clear_color: (THEME_COLOR_BG_APP) }
        flow: Down
        nav_control: <NavControl> {}
        caption_bar = <SolidView> {
         // Here default is false, invalid for windows but macos is ok
            visible: false,
            
            flow: Right
            
            draw_bg: {color: (THEME_COLOR_APP_CAPTION_BAR)}
            height: 27,
            caption_label = <View> {
                width: Fill, height: Fill,
                align: {x: 0.5, y: 0.5},
                label = <Label> {text: "Makepad", margin: {left: 100}}
            }
......
```        

Related:
- #436
- https://github.com/makepad/makepad/issues/683 