### PR TITLE
Adopt new hit-handling logic, and fix clicks on reply previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2059,7 +2059,9 @@ dependencies = [
  "makepad-platform",
  "makepad-rustybuzz",
  "makepad-vector",
+ "png",
  "sdfer",
+ "ttf-parser 0.25.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-segmentation",
@@ -2068,17 +2070,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2086,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2097,7 +2099,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2107,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2115,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2123,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2133,17 +2135,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2152,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2160,12 +2162,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -2189,12 +2191,12 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
  "smallvec",
- "ttf-parser",
+ "ttf-parser 0.21.1",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-properties",
@@ -2204,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2212,16 +2214,16 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "resvg",
- "ttf-parser",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2230,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2244,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4386,7 +4388,13 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hits_handling_redesign#e31ea9ea2014c539f7b1d48156fff868b199d396"
+source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ version = "0.0.1-pre-alpha-2"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "hits_handling_redesign" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "rik" }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"

--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -192,7 +192,7 @@ impl Widget for LoadingPane {
             || event.back_pressed()
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
-                Hit::FingerDown(_fde, _) => {
+                Hit::FingerDown(_fde) => {
                     cx.set_key_focus(area);
                     false
                 }

--- a/src/home/new_message_context_menu.rs
+++ b/src/home/new_message_context_menu.rs
@@ -356,7 +356,7 @@ impl Widget for NewMessageContextMenu {
             event.back_pressed()
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
-                Hit::FingerDown(fde, _) => {
+                Hit::FingerDown(fde) => {
                     let reaction_text_input = self.view.text_input(id!(reaction_input_view.reaction_text_input));
                     if reaction_text_input.area().rect(cx).contains(fde.abs) {
                         reaction_text_input.set_key_focus(cx);

--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -237,14 +237,17 @@ impl Widget for RoomPreview {
         let uid = self.widget_uid();
         let rooms_list_props = scope.props.get::<RoomsListScopeProps>().unwrap();
 
+        // We handle hits on this widget first to ensure that any clicks on it
+        // will just select the room, rather than resulting in a click on any child view
+        // within the room preview content itself, such as links or avatars.
         match event.hits(cx, self.view.area()) {
             Hit::FingerDown(..) => {
                 cx.set_key_focus(self.view.area());
             }
-            Hit::FingerUp(fe) if !rooms_list_props.was_scrolling &&
-                fe.is_over && fe.is_primary_hit() && fe.was_tap() =>
-            {
-                cx.widget_action(uid, &scope.path, RoomPreviewAction::Click);
+            Hit::FingerUp(fe) => {
+                if !rooms_list_props.was_scrolling && fe.is_over && fe.is_primary_hit() && fe.was_tap() {
+                    cx.widget_action(uid, &scope.path, RoomPreviewAction::Click);
+                }
             }
             _ => { }
         }

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -449,7 +449,7 @@ impl Widget for UserProfileSlidingPane {
             || event.back_pressed()
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
-                Hit::FingerDown(_fde, _) => {
+                Hit::FingerDown(_fde) => {
                     cx.set_key_focus(area);
                     false
                 }

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -106,7 +106,7 @@ impl Widget for Avatar {
         let area = self.view.area();
         let widget_uid = self.widget_uid();
         match event.hits(cx, area) {
-            Hit::FingerDown(_fde, _) => {
+            Hit::FingerDown(_fde) => {
                 cx.set_key_focus(area);
             }
             Hit::FingerUp(fue) => if fue.is_over && fue.is_primary_hit() && fue.was_tap() {


### PR DESCRIPTION
For things like `RoomPreview` and the `replied_to_messsage` above a given `Message` body, we handle hits on those widgets *before* we allow other child widgets to handle hits/events on themselves.

This ensure that sub-widgets within a `RoomPreview` or a `replied_to_message` view *cannot* handle a click (such a link, avatar), and that a click on one of those "parent" widgets just acts to select it and not interact with subwidgets within it.