### PR TITLE
Resolved DSL errors caused by changes in the naming system.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2051,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2070,17 +2070,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2099,7 +2099,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2117,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2135,17 +2135,17 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2154,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2162,12 +2162,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -2191,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2206,7 +2206,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2214,7 +2214,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "resvg",
  "ttf-parser 0.21.1",
@@ -2223,7 +2223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4370,7 +4370,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#905188bc488210a93ea0feec26429db4191aeeda"
+source = "git+https://github.com/makepad/makepad?branch=rik#6a008d9f5b551ec35a2e61d50462f34c8e681f85"
 
 [[package]]
 name = "ttf-parser"

--- a/src/home/editing_pane.rs
+++ b/src/home/editing_pane.rs
@@ -37,7 +37,7 @@ live_design! {
             instance opacity: 1.0
 
             fn pixel(self) -> vec4 {
-                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift) + vec4(self.marked, 0.0, 0.0, 0.0);
+                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift);
                 return Pal::premul(vec4(color.xyz, color.w * self.opacity))
             }
         }
@@ -82,7 +82,7 @@ live_design! {
                 draw_bg: {
                     border_color: (COLOR_DANGER_RED),
                     color: #fff0f0 // light red
-                    radius: 5
+                    border_radius: 5.0
                 }
                 draw_icon: {
                     svg_file: (ICON_CLOSE),
@@ -100,7 +100,7 @@ live_design! {
                 draw_bg: {
                     border_color: (COLOR_ACCEPT_GREEN),
                     color: #f0fff0 // light green
-                    radius: 5
+                    border_radius: 5.0
                 }
                 draw_icon: {
                     svg_file: (ICON_CHECKMARK)

--- a/src/home/light_themed_dock.rs
+++ b/src/home/light_themed_dock.rs
@@ -98,7 +98,7 @@ live_design! {
         draw_button: {
 
             instance hover: float;
-            instance selected: float;
+            instance active: float;
 
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
@@ -146,16 +146,16 @@ live_design! {
         padding: <THEME_MSPACE_3> { }
 
         close_button: <TabCloseButton> {}
-        draw_name: {
+        draw_text: {
             text_style: <THEME_FONT_REGULAR> {}
             instance hover: 0.0
-            instance selected: 0.0
+            instance active: 0.0
             fn get_color(self) -> vec4 {
                 return mix(
                     mix(
                         #x0, // THEME_COLOR_TEXT_INACTIVE,
                         #xf, // THEME_COLOR_TEXT_SELECTED,
-                        self.selected
+                        self.active
                     ),
                     THEME_COLOR_TEXT_HOVER,
                     self.hover
@@ -165,7 +165,7 @@ live_design! {
 
         draw_bg: {
             instance hover: float
-            instance selected: float
+            instance active: float
 
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
@@ -180,7 +180,7 @@ live_design! {
                     mix(
                         (COLOR_SECONDARY) * 0.95,
                         (COLOR_SELECTED_PRIMARY),
-                        self.selected
+                        self.active
                     )
                 )
                 return sdf.result
@@ -194,7 +194,7 @@ live_design! {
                     from: {all: Forward {duration: 0.2}}
                     apply: {
                         draw_bg: {hover: 0.0}
-                        draw_name: {hover: 0.0}
+                        draw_text: {hover: 0.0}
                     }
                 }
 
@@ -203,28 +203,28 @@ live_design! {
                     from: {all: Forward {duration: 0.1}}
                     apply: {
                         draw_bg: {hover: [{time: 0.0, value: 1.0}]}
-                        draw_name: {hover: [{time: 0.0, value: 1.0}]}
+                        draw_text: {hover: [{time: 0.0, value: 1.0}]}
                     }
                 }
             }
 
-            selected = {
+            active = {
                 default: off
                 off = {
                     from: {all: Forward {duration: 0.3}}
                     apply: {
-                        close_button: {draw_button: {selected: 0.0}}
-                        draw_bg: {selected: 0.0}
-                        draw_name: {selected: 0.0}
+                        close_button: {draw_button: {active: 0.0}}
+                        draw_bg: {active: 0.0}
+                        draw_text: {active: 0.0}
                     }
                 }
 
                 on = {
                     from: {all: Snap}
                     apply: {
-                        close_button: {draw_button: {selected: 1.0}}
-                        draw_bg: {selected: 1.0}
-                        draw_name: {selected: 1.0}
+                        close_button: {draw_button: {active: 1.0}}
+                        draw_bg: {active: 1.0}
+                        draw_text: {active: 1.0}
                     }
                 }
             }
@@ -249,7 +249,7 @@ live_design! {
             show_scroll_x: true
             show_scroll_y: false
             scroll_bar_x: {
-                draw_bar: {bar_width: 3.0}
+                draw_bg: {bar_width: 3.0}
                 bar_size: 4
                 use_vertical_finger_scroll: true
             }
@@ -283,11 +283,12 @@ live_design! {
                 return sdf.result
             }
         }
-        border_size: (THEME_DOCK_BORDER_SIZE)
+        //border_size: (THEME_DOCK_BORDER_SIZE) //removed as it's not supported in new dock
 
         padding: {left: (THEME_DOCK_BORDER_SIZE), top: 0, right: (THEME_DOCK_BORDER_SIZE), bottom: (THEME_DOCK_BORDER_SIZE)}
-        padding_fill: {color: (THEME_COLOR_BG_APP)} // TODO: unclear what this does
-        drag_quad: {
+        // padding_fill: {color: (THEME_COLOR_BG_APP)} // TODO: unclear what this does
+        //padding_fill_color: (THEME_COLOR_BG_APP) // removed as it's not supported in new dock
+        drag_target_preview: {
             draw_depth: 10.0
             color: (mix((COLOR_SECONDARY), #FFFFFF00, pow(0.25, THEME_COLOR_CONTRAST)))
         }

--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -20,7 +20,7 @@ live_design! {
             instance opacity: 1.0
 
             fn pixel(self) -> vec4 {
-                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift) + vec4(self.marked, 0.0, 0.0, 0.0);
+                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift);
                 return Pal::premul(vec4(color.xyz, color.w * self.opacity))
             }
         }
@@ -50,7 +50,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3.0
+                border_radius: 3.0
             }
 
             title_view = <View> {

--- a/src/home/new_message_context_menu.rs
+++ b/src/home/new_message_context_menu.rs
@@ -55,8 +55,8 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 5.0
-                border_width: 0.5
+                border_radius: 5.0
+                border_size: 0.5
                 border_color: #888
             }
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -68,7 +68,7 @@ live_design! {
 
     IMG_DEFAULT_AVATAR = dep("crate://self/resources/img/default_avatar.png")
 
-    ICO_LOCATION_PERSON = dep("crate://self/resources/icons/location-person.svg")
+    ICON_LOCATION_PERSON = dep("crate://self/resources/icons/location-person.svg")
 
     COLOR_BG = #xfff8ee
     COLOR_OVERLAY_BG = #x000000d8

--- a/src/home/spaces_dock.rs
+++ b/src/home/spaces_dock.rs
@@ -71,9 +71,9 @@ live_design! {
         show_bg: true
         draw_bg: {
             color: (COLOR_PRIMARY_DARKER)
-            radius: 4.0
+            border_radius: 4.0
             border_color: (COLOR_SELECTED_PRIMARY)
-            border_width: 1.5
+            border_size: 1.5
         }
 
         align: {x: 0.5, y: 0.5}

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -28,7 +28,7 @@ live_design! {
         padding: 10,
         margin: { left: 16.6, right: 16.6, top: 10, bottom: 10}
         draw_bg: {
-            border_width: 0.5,
+            border_size: 0.5,
             border_color: (#6c6c6c),
             color: (COLOR_PRIMARY)
         }
@@ -73,7 +73,7 @@ live_design! {
                 show_bg: true,
                 draw_bg: {
                     color: (COLOR_SECONDARY)
-                    radius: 6.0
+                    border_radius: 6.0
                 }
 
                 <View> {

--- a/src/login/login_status_modal.rs
+++ b/src/login/login_status_modal.rs
@@ -26,7 +26,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #CCC
-                radius: 3.0
+                border_radius: 3.0
             }
 
             <View> {

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -108,7 +108,7 @@ live_design! {
             instance opacity: 1.0
 
             fn pixel(self) -> vec4 {
-                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift) + vec4(self.marked, 0.0, 0.0, 0.0);
+                let color = sample2d_rt(self.image, self.pos * self.scale + self.shift);
                 return Pal::premul(vec4(color.xyz, color.w * self.opacity))
             }
         }

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -19,8 +19,10 @@ live_design! {
     use crate::shared::icon_button::*;
     use crate::shared::mentionable_text_input::MentionableTextInput;
 
-    ICO_LOCATION_PERSON = dep("crate://self/resources/icons/location-person.svg")
-    ICO_SEND = dep("crate://self/resources/icon_send.svg")
+    // 使用共享样式中定义的图标
+    use crate::shared::styles::ICON_SEND;
+    // 为位置图标定义一个新常量
+    ICON_LOCATION_PERSON = dep("crate://self/resources/icons/location-person.svg")
 
     pub RoomInputBar = {{RoomInputBar}} {
         width: Fill,
@@ -34,7 +36,7 @@ live_design! {
         draw_bg: {color: (COLOR_PRIMARY)}
 
         location_button = <IconButton> {
-            draw_icon: {svg_file: (ICO_LOCATION_PERSON)},
+            draw_icon: {svg_file: (ICON_LOCATION_PERSON)},
             icon_walk: {width: 22.0, height: Fit, margin: {left: 0, right: 5}},
             text: "",
         }
@@ -55,7 +57,7 @@ live_design! {
         }
 
         send_message_button = <IconButton> {
-            draw_icon: {svg_file: (ICO_SEND)},
+            draw_icon: {svg_file: (ICON_SEND)},
             icon_walk: {width: 18.0, height: Fit},
         }
     }

--- a/src/shared/callout_tooltip.rs
+++ b/src/shared/callout_tooltip.rs
@@ -25,9 +25,9 @@ live_design! {
 
                 draw_bg: {
                     color: #fff,
-                    border_width: 7.5,
+                    border_size: 7.5,
                     border_color: #D0D5DD,
-                    radius: 2.,
+                    border_radius: 2.,
                     instance background_color: #3b444b,
                     // Absolute position of top left corner of the tooltip
                     instance tooltip_pos: vec2(0.0, 0.0),
@@ -49,11 +49,11 @@ live_design! {
                         }
                         // Draw rounded box
                         sdf.box(
-                            self.border_width,
-                            self.border_width,
-                            rect_size.x - (self.border_width * 2.0),
-                            rect_size.y - (self.border_width * 2.0),
-                            max(1.0, self.radius)
+                            self.border_size,
+                            self.border_size,
+                            rect_size.x - (self.border_size * 2.0),
+                            rect_size.y - (self.border_size * 2.0),
+                            max(1.0, self.border_radius)
                         )
                         sdf.fill(self.background_color);
                         let triangle_height = self.triangle_height;
@@ -79,14 +79,14 @@ live_design! {
                         if angle == 45.0 || angle == 315.0 {
                             // Point upwards
                             // + 2.0 to overlap the triangle
-                            vertex1 = vec2(max(self.border_width + 2.0, diff_x), self.border_width + 2.0);
+                            vertex1 = vec2(max(self.border_size + 2.0, diff_x), self.border_size + 2.0);
                             vertex2 = vec2(vertex1.x + triangle_height, vertex1.y - triangle_height);
                             vertex3 = vec2(vertex1.x + triangle_height * 2.0, vertex1.y);
                         } else {
                             // Point downwards
                             // +/- 2.0 to overlap the triangle
                             vertex1 = vec2(
-                                max(self.border_width + 2.0, diff_x) + triangle_height * 2.0,
+                                max(self.border_size + 2.0, diff_x) + triangle_height * 2.0,
                                 rect_size.y - triangle_height - 2.0
                             );
                             vertex2 = vec2(vertex1.x - triangle_height, vertex1.y + triangle_height);

--- a/src/shared/icon_button.rs
+++ b/src/shared/icon_button.rs
@@ -14,7 +14,7 @@ live_design! {
     pub IconButton = <Button> {
         draw_text: {
             instance hover: 0.0
-            instance pressed: 0.0
+            instance down: 0.0
             text_style: {
                 font_size: 11.0
             }
@@ -26,7 +26,7 @@ live_design! {
                         self.hover
                     ),
                     (COLOR_BRAND_HOVER),
-                    self.pressed
+                    self.down
                 )
             }
         }
@@ -39,7 +39,7 @@ live_design! {
                         self.hover
                     ),
                     (COLOR_BRAND_HOVER),
-                    self.pressed
+                    self.down
                 )
             }
         }

--- a/src/shared/jump_to_bottom_button.rs
+++ b/src/shared/jump_to_bottom_button.rs
@@ -10,7 +10,7 @@ live_design! {
     use crate::shared::styles::*;
     use crate::shared::icon_button::*;
 
-    ICO_JUMP_TO_BOTTOM = dep("crate://self/resources/icon_jump_to_bottom.svg")
+    ICON_JUMP_TO_BOTTOM = dep("crate://self/resources/icon_jump_to_bottom.svg")
 
     // A jump to bottom button that appears when the timeline is not at the bottom.
     pub JumpToBottomButton = {{JumpToBottomButton}} {
@@ -26,7 +26,7 @@ live_design! {
             jump_to_bottom_button = <IconButton> {
                 width: 50, height: 50,
                 margin: {bottom: 8},
-                draw_icon: {svg_file: (ICO_JUMP_TO_BOTTOM)},
+                draw_icon: {svg_file: (ICON_JUMP_TO_BOTTOM)},
                 icon_walk: {width: 20, height: 20, margin: {top: 10, right: 4.5} }
                 // draw a circular background for the button
                 draw_bg: {

--- a/src/shared/popup_list.rs
+++ b/src/shared/popup_list.rs
@@ -19,7 +19,7 @@ live_design! {
 
     use crate::shared::styles::*;
     use crate::shared::icon_button::RobrixIconButton;
-    ICO_CLOSE = dep("crate://self/resources/icons/close.svg")
+    use crate::shared::styles::ICON_CLOSE;
 
     PopupDialog = <RoundedView> {
         width: 275

--- a/src/shared/search_bar.rs
+++ b/src/shared/search_bar.rs
@@ -24,9 +24,9 @@ live_design! {
         align: {x: 0.0, y: 0.5},
 
         draw_bg: {
-            radius: 0.0,
+            border_radius: 0.0,
             border_color: #d8d8d8,
-            border_width: 0.6,
+            border_size: 0.6,
         }
 
         <Icon> {

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -111,8 +111,8 @@ live_design! {
         empty_message: "Enter text..."
         draw_bg: {
             color: (COLOR_PRIMARY)
-            instance radius: 2.0
-            instance border_width: 0.0
+            instance border_radius: 2.0
+            instance border_size: 0.0
             instance border_color: #D0D5DD
             instance inset: vec4(0.0, 0.0, 0.0, 0.0)
 
@@ -127,15 +127,15 @@ live_design! {
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size)
                 sdf.box(
-                    self.inset.x + self.border_width,
-                    self.inset.y + self.border_width,
-                    self.rect_size.x - (self.inset.x + self.inset.z + self.border_width * 2.0),
-                    self.rect_size.y - (self.inset.y + self.inset.w + self.border_width * 2.0),
-                    max(1.0, self.radius)
+                    self.inset.x + self.border_size,
+                    self.inset.y + self.border_size,
+                    self.rect_size.x - (self.inset.x + self.inset.z + self.border_size * 2.0),
+                    self.rect_size.y - (self.inset.y + self.inset.w + self.border_size * 2.0),
+                    max(1.0, self.border_radius)
                 )
                 sdf.fill_keep(self.get_color())
-                if self.border_width > 0.0 {
-                    sdf.stroke(self.get_border_color(), self.border_width)
+                if self.border_size > 0.0 {
+                    sdf.stroke(self.get_border_color(), self.border_size)
                 }
                 return sdf.result;
             }
@@ -174,7 +174,7 @@ live_design! {
         }
 
         // TODO find a way to override colors
-        draw_selection: {
+        draw_highlight: {
             instance hover: 0.0
             instance focus: 0.0
             uniform border_radius: 2.0

--- a/src/verification_modal.rs
+++ b/src/verification_modal.rs
@@ -26,7 +26,7 @@ live_design! {
             show_bg: true
             draw_bg: {
                 color: #fff
-                radius: 3.0
+                border_radius: 3.0
             }
 
             title = <View> {


### PR DESCRIPTION
**This pull request is for migration reference only and does not need to be merged.**

 Makepad Naming System Field Changes Basic Field Renames 

- radius → border_radius
- border_width → border_size
- pressed → down (in Button components)
- selected → active (in TabBar components)
- draw_selection → draw_highlight
- draw_name → draw_text
- draw_bar → draw_bg
- padding_fill → (removed)
- drag_quad → drag_target_preview

 Removed Fields 

- marked (in CachedView shaders - completely remove usage)
- keyboard_focus_color (no longer supported)
- pointer_hover_color (no longer supported)