### PR TITLE
Fixed Bug : Issue 450 and Issue 457

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 .vscode
 .DS_Store
+CLAUDE.md

--- a/src/shared/mentionable_text_input.rs
+++ b/src/shared/mentionable_text_input.rs
@@ -37,7 +37,7 @@ live_design! {
             color: #fff,
             uniform border_radius: 6.0,
             instance hover: 0.0,
-            instance selected: 0.0
+            instance selected: 0.0,
 
             fn pixel(self) -> vec4 {
                 let sdf = Sdf2d::viewport(self.pos * self.rect_size);
@@ -45,10 +45,11 @@ live_design! {
                 sdf.box(0., 0., self.rect_size.x, self.rect_size.y, self.border_radius);
 
                 if self.selected > 0.0 {
-                    sdf.fill(KEYBOARD_FOCUS_OR_color_hover)
+                    sdf.fill(KEYBOARD_FOCUS_OR_COLOR_HOVER )
                 } else if self.hover > 0.0 {
-                    sdf.fill(KEYBOARD_FOCUS_OR_color_hover)
+                    sdf.fill(POINTER_FOCUS_OR_COLOR_HOVER)
                 } else {
+                    // Default state
                     sdf.fill(self.color)
                 }
                 return sdf.result
@@ -228,7 +229,7 @@ pub struct MentionableTextInput {
     #[rust] current_mention_start_index: Option<usize>,
     /// The set of users that were mentioned (at one point) in this text input.
     /// Due to characters being deleted/removed, this list is a *superset*
-    /// of possible users who may have been mentioned. 
+    /// of possible users who may have been mentioned.
     /// All of these mentions may not exist in the final text input content;
     /// this is just a list of users to search the final sent message for
     /// when adding in new mentions.
@@ -516,6 +517,7 @@ impl MentionableTextInput {
     fn close_mention_popup(&mut self, cx: &mut Cx) {
         self.current_mention_start_index = None;
         self.is_searching = false;
+
 
         self.cmd_text_input.view(id!(popup)).set_visible(cx, false);
         self.cmd_text_input.request_text_input_focus();

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -99,7 +99,8 @@ live_design! {
     pub COLOR_TEXT = #1C274C
 
     pub COLOR_TEXT_INPUT_IDLE = #d8d8d8
-
+    pub KEYBOARD_FOCUS_OR_COLOR_HOVER = #1C274C
+    pub POINTER_FOCUS_OR_COLOR_HOVER = #1C274C
 
     // A text input widget styled for Robrix.
     pub RobrixTextInput = <TextInput> {


### PR DESCRIPTION
1. Resolved the issue of two highlights being produced in the @ user list when using arrow keys and the mouse. #450 
>  Depends on this Makepad pull request [#707](https://github.com/makepad/makepad/pull/707)

2. Resolved the issue of the mouse being unable to click and select a user.  #457 


![mention](https://github.com/user-attachments/assets/0f08659c-ec80-4f55-b9b6-9bba67adafe5)

