### PR TITLE
Fix Rust 1.78 clippy warn.

### DIFF
--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -217,6 +217,7 @@ pub type OnMediaFetchedFn = fn(
 
 
 /// The set of requests for async work that can be made to the worker thread.
+#[allow(clippy::large_enum_variant)]
 pub enum MatrixRequest {
     /// Request from the login screen to log in with the given credentials.
     Login(LoginRequest),
@@ -2544,8 +2545,7 @@ async fn spawn_sso_server(
                 }
                 Uri::new(&sso_url).open().map_err(|err| {
                     Error::UnknownError(
-                        Box::new(io::Error::new(
-                            io::ErrorKind::Other,
+                        Box::new(io::Error::other(
                             format!("Unable to open SSO login url. Error: {:?}", err),
                         ))
                         .into(),


### PR DESCRIPTION
This pr would fix clippy warn for the new clippy warn standards added in Rust 1.78.

Note: The warn `std::io::Error::other` is actually fixed, **but i just disable clippy warn for large varient of the enum `MatrixRequest`**