### PR TITLE
Use a common Timestamp widget for all events

### DIFF
--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -282,7 +282,7 @@ impl RoomPreviewContent {
             self.view.label(id!(room_name)).set_text(cx, name);
         }
         if let Some((ts, msg)) = room_info.latest.as_ref() {
-            if let Some(human_readable_date) = relative_format(ts) {
+            if let Some(human_readable_date) = relative_format(*ts) {
                 self.view
                     .label(id!(timestamp))
                     .set_text(cx, &human_readable_date);

--- a/src/home/room_read_receipt.rs
+++ b/src/home/room_read_receipt.rs
@@ -39,12 +39,11 @@ live_design! {
         width: Fit,
         height: 15.0,
         plus_template: <Label> {
-            // a big of negative padding to center the label text wrt the avatar
-            padding: {top: -0.5, bottom: 0, left: 0, right: 0},
+            padding: 0,
             flow: Right, // do not wrap
             draw_text: {
                 color: #x0,
-                text_style: <TITLE_TEXT>{ font_size: 11}
+                text_style: <TITLE_TEXT>{ font_size: 10}
             }
             text: ""
         }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -12,7 +12,7 @@ use matrix_sdk::{room::RoomMember, ruma::{
             AudioMessageEventContent, CustomEventContent, EmoteMessageEventContent, FileMessageEventContent, FormattedBody, ImageMessageEventContent, KeyVerificationRequestEventContent, LocationMessageEventContent, MessageFormat, MessageType, NoticeMessageEventContent, RoomMessageEventContent, ServerNoticeMessageEventContent, TextMessageEventContent, VideoMessageEventContent
         }, ImageInfo, MediaSource
     },
-    sticker::StickerEventContent, Mentions}, matrix_uri::MatrixId, uint, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId
+    sticker::StickerEventContent, Mentions}, matrix_uri::MatrixId, uint, EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedMxcUri, OwnedRoomId
 }, OwnedServerName};
 use matrix_sdk_ui::timeline::{
     self, EventTimelineItem, InReplyToDetails, MemberProfileChange, RepliedToInfo, RoomMembershipChange, TimelineDetails, TimelineEventItemId, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem
@@ -23,7 +23,7 @@ use crate::{
         user_profile::{AvatarState, ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     }, shared::{
-        avatar::AvatarWidgetRefExt, callout_tooltip::TooltipAction, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::enqueue_popup_notification, styles::COLOR_DANGER_RED, text_or_image::{TextOrImageRef, TextOrImageWidgetRefExt}, typing_animation::TypingAnimationWidgetExt
+        avatar::AvatarWidgetRefExt, callout_tooltip::TooltipAction, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::enqueue_popup_notification, styles::COLOR_DANGER_RED, text_or_image::{TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt, typing_animation::TypingAnimationWidgetExt
     }, sliding_sync::{get_client, submit_async_request, take_timeline_endpoints, BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineRequestSender, UserPowerLevels}, utils::{self, room_name_or_id, unix_time_millis_to_datetime, ImageFormat, MEDIA_THUMBNAIL_FORMAT}
 };
 use crate::home::event_reaction_list::ReactionListWidgetRefExt;
@@ -49,6 +49,7 @@ live_design! {
     use crate::shared::helpers::*;
     use crate::shared::avatar::Avatar;
     use crate::shared::text_or_image::TextOrImage;
+    use crate::shared::timestamp::*;
     use crate::shared::html_or_plaintext::*;
     use crate::shared::icon_button::*;
     use crate::shared::typing_animation::TypingAnimation;
@@ -78,17 +79,6 @@ live_design! {
     FillerY = <View> {width: Fill}
 
     FillerX = <View> {height: Fill}
-
-    Timestamp = <Label> {
-        width: Fit, height: Fit
-        flow: Right, // do not wrap
-        padding: 0,
-        draw_text: {
-            text_style: <TIMESTAMP_TEXT_STYLE> {},
-            color: (TIMESTAMP_TEXT_COLOR)
-        }
-        text: " "
-    }
 
     REACTION_TEXT_COLOR = #4c00b0
 
@@ -317,10 +307,7 @@ live_design! {
                     // }
                 }
                 timestamp = <Timestamp> {
-                    padding: { top: 2.3 }
-                }
-                datestamp = <Timestamp> {
-                    padding: { top: 3.0 }
+                    margin: { top: 3.9 }
                 }
             }
             content = <View> {
@@ -379,7 +366,7 @@ live_design! {
                 height: Fit,
                 flow: Down,
                 timestamp = <Timestamp> {
-                    margin: {top: 1.5}
+                    margin: {top: 2.5}
                 }
             }
             content = <View> {
@@ -459,16 +446,11 @@ live_design! {
             align: {y: 0.5}
 
             left_container = <View> {
-                align: {x: 0.5, y: 0.5}
+                align: {x: 0.5, y: 0}
                 width: 70.0,
                 height: Fit
 
-                timestamp = <Timestamp> {
-                    draw_text: {
-                        text_style: <TIMESTAMP_TEXT_STYLE> {},
-                        color: (TIMESTAMP_TEXT_COLOR)
-                    }
-                }
+                timestamp = <Timestamp> { }
             }
 
             avatar = <Avatar> {
@@ -1287,7 +1269,7 @@ impl Widget for RoomScreen {
                         }
                         TimelineItemKind::Virtual(VirtualTimelineItem::DateDivider(millis)) => {
                             let item = list.item(cx, item_id, live_id!(DateDivider));
-                            let text = unix_time_millis_to_datetime(millis)
+                            let text = unix_time_millis_to_datetime(*millis)
                                 // format the time as a shortened date (Sat, Sept 5, 2021)
                                 .map(|dt| format!("{}", dt.date_naive().format("%a %b %-d, %Y")))
                                 .unwrap_or_else(|| format!("{:?}", millis));
@@ -2270,7 +2252,6 @@ impl RoomScreen {
             replying_to: tl.replying_to.clone(),
             editing_event,
         };
-        log!("Saving TimelineUiState for room {}: {:?}", tl.room_id, state);
         tl.saved_state = state;
         // Store this Timeline's `TimelineUiState` in the global map of states.
         TIMELINE_STATES.lock().unwrap().insert(tl.room_id.clone(), tl);
@@ -3325,17 +3306,8 @@ fn populate_message_view(
     });
 
     // Set the timestamp.
-    if let Some(dt) = unix_time_millis_to_datetime(&ts_millis) {
-        // format as AM/PM 12-hour time
-        item.label(id!(profile.timestamp))
-            .set_text(cx, &format!("{}", dt.time().format("%l:%M %P")));
-        if !use_compact_view {
-            item.label(id!(profile.datestamp))
-                .set_text(cx, &format!("{}", dt.date_naive()));
-        }
-    } else {
-        item.label(id!(profile.timestamp))
-            .set_text(cx, &format!("{}", ts_millis.get()));
+    if let Some(dt) = unix_time_millis_to_datetime(ts_millis) {
+        item.timestamp(id!(profile.timestamp)).set_date_time(cx, dt);
     }
 
     (item, new_drawn_status)
@@ -3934,12 +3906,9 @@ fn populate_small_state_event(
             event_tl_item.event_id(),
         );
         // Draw the timestamp as part of the profile.
-        set_timestamp(
-            cx,
-            &item,
-            id!(left_container.timestamp),
-            event_tl_item.timestamp(),
-        );
+        if let Some(dt) = unix_time_millis_to_datetime(event_tl_item.timestamp()) {
+            item.timestamp(id!(left_container.timestamp)).set_date_time(cx, dt);
+        }
         new_drawn_status.profile_drawn = profile_drawn;
         username
     });
@@ -3957,23 +3926,6 @@ fn populate_small_state_event(
     )
 }
 
-/// Sets the text of the `Label` at the given `item`'s live ID path
-/// to a typical 12-hour AM/PM timestamp format.
-fn set_timestamp(
-    cx: &mut Cx,
-    item: &WidgetRef,
-    live_id_path: &[LiveId],
-    timestamp: MilliSecondsSinceUnixEpoch,
-) {
-    if let Some(dt) = unix_time_millis_to_datetime(&timestamp) {
-        // format as AM/PM 12-hour time
-        item.label(live_id_path)
-            .set_text(cx, &format!("{}", dt.time().format("%l:%M %P")));
-    } else {
-        item.label(live_id_path)
-            .set_text(cx, &format!("{}", timestamp.get()));
-    }
-}
 
 /// Returns the display name of the sender of the given `event_tl_item`, if available.
 fn get_profile_display_name(event_tl_item: &EventTimelineItem) -> Option<String> {

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -12,6 +12,7 @@ pub mod popup_list;
 pub mod room_filter_input_bar;
 pub mod styles;
 pub mod text_or_image;
+pub mod timestamp;
 pub mod typing_animation;
 pub mod unread_badge;
 pub mod verification_badge;
@@ -24,6 +25,7 @@ pub fn live_design(cx: &mut Cx) {
     icon_button::live_design(cx);
     unread_badge::live_design(cx);
     collapsible_header::live_design(cx);
+    timestamp::live_design(cx);
     room_filter_input_bar::live_design(cx);
     avatar::live_design(cx);
     text_or_image::live_design(cx);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,7 +92,7 @@ pub fn load_png_or_jpg(img: &ImageRef, cx: &mut Cx, data: &[u8]) -> Result<(), I
 }
 
 
-pub fn unix_time_millis_to_datetime(millis: &MilliSecondsSinceUnixEpoch) -> Option<DateTime<Local>> {
+pub fn unix_time_millis_to_datetime(millis: MilliSecondsSinceUnixEpoch) -> Option<DateTime<Local>> {
     let millis: i64 = millis.get().into();
     Local.timestamp_millis_opt(millis).single()
 }
@@ -123,7 +123,7 @@ pub fn room_name_or_id(
 ///
 /// # Returns:
 /// - `Option<String>` representing the human-readable time or `None` if formatting fails.
-pub fn relative_format(millis: &MilliSecondsSinceUnixEpoch) -> Option<String> {
+pub fn relative_format(millis: MilliSecondsSinceUnixEpoch) -> Option<String> {
     let datetime = unix_time_millis_to_datetime(millis)?;
 
     // Calculate the time difference between now and the given timestamp


### PR DESCRIPTION
The new timestamp widget now shows a custom tooltip upon hover with the full date/time info, so we can now also remove the datestamp beneath the timestamp for non-condensed messages.

TODO: timestamps aren't horizontally aligned in all event types. The SmallStateEvent's timestamps are slightly to the right of the timestamps displaying for a message.