### PR TITLE
Save the replying_to state somewhere & hide the reply preview view when editing an existed message

### DIFF
--- a/src/home/editing_pane.rs
+++ b/src/home/editing_pane.rs
@@ -564,7 +564,6 @@ impl EditingPane {
     /// Hides the editing pane with animation.
     fn hide_with_animator(&mut self, cx: &mut Cx) {
         self.animator_play(cx, id!(panel.hide));
-        self.redraw(cx);
     }
 
     /// Hides the editing pane immediately without animation.
@@ -619,7 +618,7 @@ impl EditingPaneRef {
     }
 
     /// Hides the editing pane immediately without animation.
-    pub fn force_hide(&self, cx: &mut Cx) {
+    pub fn hide(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.hide(cx);
     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2354,7 +2354,7 @@ impl RoomScreen {
         if let Some(editing_event) = editing_event.take() {
             self.show_editing_pane(cx, editing_event, tl_state.room_id.clone());
         } else {
-            self.editing_pane(id!(editing_pane)).force_hide(cx);
+            self.editing_pane(id!(editing_pane)).hide(cx);
             self.on_hide_editing_pane(cx);
         }
     }


### PR DESCRIPTION
Fix #488 