### PR TITLE
Update Makepad to track the new `dev` branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,8 +2024,8 @@ dependencies = [
 
 [[package]]
 name = "makepad-derive-live"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2033,16 +2033,16 @@ dependencies = [
 
 [[package]]
 name = "makepad-derive-wasm-bridge"
-version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
 
 [[package]]
 name = "makepad-derive-widget"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2050,8 +2050,8 @@ dependencies = [
 
 [[package]]
 name = "makepad-draw"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2068,27 +2068,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "makepad-fonts-chinese-bold"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-chinese-bold-2"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-chinese-regular"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-chinese-regular-2"
+version = "1.0.1"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
+name = "makepad-fonts-emoji"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
+dependencies = [
+ "makepad-platform",
+]
+
+[[package]]
 name = "makepad-futures"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 
 [[package]]
 name = "makepad-futures-legacy"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 
 [[package]]
 name = "makepad-html"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-live-id",
 ]
 
 [[package]]
 name = "makepad-http"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2098,8 +2138,8 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 
 [[package]]
 name = "makepad-live-compiler"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2108,24 +2148,24 @@ dependencies = [
 
 [[package]]
 name = "makepad-live-id"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-live-id-macros",
 ]
 
 [[package]]
 name = "makepad-live-id-macros"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
 
 [[package]]
 name = "makepad-live-tokenizer"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2134,21 +2174,21 @@ dependencies = [
 
 [[package]]
 name = "makepad-math"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-micro-serde",
 ]
 
 [[package]]
 name = "makepad-micro-proc-macro"
-version = "0.4.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 
 [[package]]
 name = "makepad-micro-serde"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2156,21 +2196,21 @@ dependencies = [
 
 [[package]]
 name = "makepad-micro-serde-derive"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
 
 [[package]]
 name = "makepad-objc-sys"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 
 [[package]]
 name = "makepad-platform"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -2194,7 +2234,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2208,8 +2248,8 @@ dependencies = [
 
 [[package]]
 name = "makepad-shader-compiler"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2217,12 +2257,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 
 [[package]]
 name = "makepad-vector"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -2230,8 +2270,8 @@ dependencies = [
 
 [[package]]
 name = "makepad-wasm-bridge"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2239,11 +2279,16 @@ dependencies = [
 
 [[package]]
 name = "makepad-widgets"
-version = "0.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
+ "makepad-fonts-chinese-bold",
+ "makepad-fonts-chinese-bold-2",
+ "makepad-fonts-chinese-regular",
+ "makepad-fonts-chinese-regular-2",
+ "makepad-fonts-emoji",
  "makepad-html",
  "makepad-zune-jpeg",
  "makepad-zune-png",
@@ -2254,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2262,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2270,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=new_makepad_dev_robrix#a40690d1806fe6051ab650c1f87a935a15f79e9a"
+source = "git+https://github.com/makepad/makepad?branch=dev#ea18528d4d1d4668cf6db65a1d70160ab7e73410"
 dependencies = [
  "zune-core",
  "zune-inflate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ version = "0.0.1-pre-alpha-3"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev" }
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "new_makepad_dev_robrix" }
-# makepad-widgets = { path = "../makepad/widgets" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"


### PR DESCRIPTION
Remove our own fork, which is no longer needed.