### PR TITLE
Add confirmation modal for accepting/rejecting a room invite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,8 +163,8 @@ keyword_idents_2024 = "forbid"
 non_ascii_idents = "forbid"
 non_local_definitions = "forbid"
 unsafe_op_in_unsafe_fn = "forbid"
-
-unexpected_cfgs = "warn"
+## The list of `cfg` options that are explicitly allowed when building Robrix.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(log_room_list_diffs)', 'cfg(log_timeline_diffs)'] }
 unnameable_types = "warn"
 unused_import_braces = "warn"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -313,8 +313,8 @@ impl MatchEvent for App {
 
             // Handle actions needed to open/close the join/leave room modal.
             match action.downcast_ref() {
-                Some(JoinLeaveRoomModalAction::Open(typ)) => {
-                    self.ui.join_leave_room_modal(id!(join_leave_modal_inner)).set_kind(cx, typ.clone());
+                Some(JoinLeaveRoomModalAction::Open(kind)) => {
+                    self.ui.join_leave_room_modal(id!(join_leave_modal_inner)).set_kind(cx, kind.clone());
                     self.ui.modal(id!(join_leave_modal)).open(cx);
                     continue;
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -318,8 +318,10 @@ impl MatchEvent for App {
                     self.ui.modal(id!(join_leave_modal)).open(cx);
                     continue;
                 }
-                Some(JoinLeaveRoomModalAction::Close { .. } ) => {
-                    self.ui.modal(id!(join_leave_modal)).close(cx);
+                Some(JoinLeaveRoomModalAction::Close { was_internal, .. }) => {
+                    if *was_internal {
+                        self.ui.modal(id!(join_leave_modal)).close(cx);
+                    }
                     continue;
                 }
                 _ => {}

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -302,15 +302,12 @@ impl Widget for InviteScreen {
                     _ => {}
                 }
 
-                match action.downcast_ref() {
-                    Some(JoinLeaveRoomModalAction::Close { was_canceled }) => {
-                        // If the modal was canceled, we reset the invite state to waiting for user input.
-                        if *was_canceled {
-                            self.invite_state = InviteState::WaitingOnUserInput;
-                        }
-                        continue;
+                if let Some(JoinLeaveRoomModalAction::Close { was_canceled }) = action.downcast_ref() {
+                    // If the modal was canceled, we reset the invite state to waiting for user input.
+                    if *was_canceled {
+                        self.invite_state = InviteState::WaitingOnUserInput;
                     }
-                    _ => {}
+                    continue;
                 }
             }
         }

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -4,12 +4,13 @@
 //! but it only shows a simple summary of a room the current user has been invited to,
 //! with buttons to accept or decline the invitation.
 
+use std::ops::Deref;
 use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
 
-use crate::{shared::{avatar::AvatarWidgetRefExt, popup_list::enqueue_popup_notification}, sliding_sync::{submit_async_request, MatrixRequest}, utils};
+use crate::{join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, room::{BasicRoomDetails, RoomPreviewAvatar}, shared::{avatar::AvatarWidgetRefExt, popup_list::enqueue_popup_notification}, sliding_sync::{submit_async_request, MatrixRequest}, utils};
 
-use super::rooms_list::{InviteState, InviterInfo, RoomPreviewAvatar};
+use super::rooms_list::{InviteState, InviterInfo};
 
 
 live_design! {
@@ -169,11 +170,16 @@ live_design! {
     }
 }
 
-struct InviteScreenInfo {
-    pub room_id: OwnedRoomId,
-    pub room_name: Option<String>,
-    pub room_avatar: RoomPreviewAvatar,
+#[derive(Clone, Debug)]
+pub struct InviteDetails {
+    pub room_info: BasicRoomDetails,
     pub inviter: Option<InviterInfo>,
+}
+impl Deref for InviteDetails {
+    type Target = BasicRoomDetails;
+    fn deref(&self) -> &Self::Target {
+        &self.room_info
+    }
 }
 
 /// Actions sent from the backend task as a result of a [`MatrixRequest::JoinRoom`].
@@ -191,7 +197,7 @@ pub enum JoinRoomAction {
 }
 
 /// Actions sent from the backend task as a result of a [`MatrixRequest::LeaveRoom`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum LeaveRoomAction {
     /// The user has successfully left the room.
     Left {
@@ -200,7 +206,7 @@ pub enum LeaveRoomAction {
     /// There was an error attempting to leave the room.
     Failed {
         room_id: OwnedRoomId,
-        error: String,
+        error: matrix_sdk::Error,
     }
 }
 
@@ -211,7 +217,12 @@ pub struct InviteScreen {
     #[deref] view: View,
 
     #[rust] invite_state: InviteState,
-    #[rust] info: Option<InviteScreenInfo>,
+    #[rust] info: Option<InviteDetails>,
+    /// Whether a JoinLeaveRoomModal dialog has been displayed
+    /// to allow the user to confirm their join/reject action.
+    /// This is used to prevent showing multiple popup notifications
+    /// (one from the JoinLeaveRoomModal, and one from this invite screen).
+    #[rust] has_shown_confirmation: bool,
 }
 
 impl Widget for InviteScreen {
@@ -223,47 +234,81 @@ impl Widget for InviteScreen {
         // Handle button clicks to accept or decline the invite
         if let Event::Actions(actions) = event {
             let Some(info) = self.info.as_ref() else { return; };
-            if self.view.button(id!(cancel_button)).clicked(actions) {
+            if let Some(modifiers) = self.view.button(id!(cancel_button)).clicked_modifiers(actions) {
                 self.invite_state = InviteState::WaitingForLeaveResult;
-                submit_async_request(MatrixRequest::LeaveRoom {
-                    room_id: info.room_id.clone(),
-                });
+                if modifiers.shift {
+                    submit_async_request(MatrixRequest::LeaveRoom {
+                        room_id: info.room_id.clone(),
+                    });
+                    self.has_shown_confirmation = false;
+                } else {
+                    cx.action(JoinLeaveRoomModalAction::Open(
+                        JoinLeaveModalKind::RejectInvite(info.clone())
+                    ));
+                    self.has_shown_confirmation = true;
+                }
             }
-            if self.view.button(id!(accept_button)).clicked(actions) {
+            if let Some(modifiers) = self.view.button(id!(accept_button)).clicked_modifiers(actions) {
                 self.invite_state = InviteState::WaitingForJoinResult;
-                submit_async_request(MatrixRequest::JoinRoom {
-                    room_id: info.room_id.clone(),
-                });
+                if modifiers.shift {
+                    submit_async_request(MatrixRequest::JoinRoom {
+                        room_id: info.room_id.clone(),
+                    });
+                    self.has_shown_confirmation = false;
+                } else {
+                    cx.action(JoinLeaveRoomModalAction::Open(
+                        JoinLeaveModalKind::AcceptInvite(info.clone())
+                    ));
+                    self.has_shown_confirmation = true;
+                }
             }
 
             for action in actions {
                 match action.downcast_ref() {
                     Some(JoinRoomAction::Joined { room_id }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::WaitingForJoinedRoom;
-                        enqueue_popup_notification("Successfully joined room.".into());
+                        if !self.has_shown_confirmation {
+                            enqueue_popup_notification("Successfully joined room.".into());
+                        }
+                        continue;
                     }
                     Some(JoinRoomAction::Failed { room_id, error }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::WaitingOnUserInput;
-                        let msg = match error {
-                            // The below is a stupid hack to workaround `WrongRoomState` being private.
-                            // We get the string representation of the error and then search for the "got" state.
-                            matrix_sdk::Error::WrongRoomState(wrs) if wrs.to_string().contains(", got: Joined") => {
-                                String::from("Failed to join room: it has already been joined.")
-                            }
-                            _ => format!("Failed to join room: {error}"),
-                        };
-                        enqueue_popup_notification(msg);
+                        if !self.has_shown_confirmation {
+                            let msg = utils::join_leave_error_to_string(error, info.room_name.as_deref(), true, true)
+                                .unwrap_or_else(|| format!("Failed to join room: {error}"));
+                            enqueue_popup_notification(msg);
+                        }
+                        continue;
                     }
                     _ => {}
                 }
+
                 match action.downcast_ref() {
                     Some(LeaveRoomAction::Left { room_id }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::RoomLeft;
-                        enqueue_popup_notification("Successfully rejected invite.".into());
+                        if !self.has_shown_confirmation {
+                            enqueue_popup_notification("Successfully rejected invite.".into());
+                        }
+                        continue;
                     }
                     Some(LeaveRoomAction::Failed { room_id, error }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::WaitingOnUserInput;
-                        enqueue_popup_notification(format!("Failed to reject invite: {error}"));
+                        if !self.has_shown_confirmation {
+                            enqueue_popup_notification(format!("Failed to reject invite: {error}"));
+                        }
+                        continue;
+                    }
+                    _ => {}
+                }
+
+                match action.downcast_ref() {
+                    Some(JoinLeaveRoomModalAction::Close { was_canceled }) => {
+                        // If the modal was canceled, we reset the invite state to waiting for user input.
+                        if *was_canceled {
+                            self.invite_state = InviteState::WaitingOnUserInput;
+                        }
+                        continue;
                     }
                     _ => {}
                 }
@@ -320,7 +365,7 @@ impl Widget for InviteScreen {
         else {
             (false, "You have been invited to join:")
         };
-        inviter_view.set_visible(cx, is_visible);        
+        inviter_view.set_visible(cx, is_visible);
         self.view.label(id!(invite_message)).set_text(cx, invite_text);
 
         // Second, populate the room info, if we have it.
@@ -347,7 +392,7 @@ impl Widget for InviteScreen {
             info.room_name.as_deref().unwrap_or_else(|| info.room_id.as_str()),
         );
 
-        // The buttons don't need to be manually populated, as their content is static.
+        // Third, set the buttons' text based on the invite state.
         let cancel_button = self.view.button(id!(cancel_button));
         let accept_button = self.view.button(id!(accept_button));
         match self.invite_state {
@@ -394,13 +439,16 @@ impl InviteScreen {
             .borrow()
             .get(&room_id)
         {
-            self.info = Some(InviteScreenInfo {
-                room_id,
-                room_name: invite.room_name.clone(),
-                room_avatar: invite.room_avatar.clone(),
+            self.info = Some(InviteDetails {
+                room_info: BasicRoomDetails {
+                    room_id: room_id.clone(),
+                    room_name: invite.room_name.clone(),
+                    room_avatar: invite.room_avatar.clone(),
+                },
                 inviter: invite.inviter_info.clone(),
             });
             self.invite_state = invite.invite_state;
+            self.has_shown_confirmation = false;
             self.redraw(cx);
         }
     }

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -301,9 +301,10 @@ impl Widget for InviteScreen {
                     _ => {}
                 }
 
-                if let Some(JoinLeaveRoomModalAction::Close { was_canceled }) = action.downcast_ref() {
-                    // If the modal was canceled, we reset the invite state to waiting for user input.
-                    if *was_canceled {
+                if let Some(JoinLeaveRoomModalAction::Close { successful, .. }) = action.downcast_ref() {
+                    // If the modal didn't result in a successful join/leave,
+                    // then we must reset the invite state to waiting for user input.
+                    if !*successful {
                         self.invite_state = InviteState::WaitingOnUserInput;
                     }
                     continue;

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -275,8 +275,7 @@ impl Widget for InviteScreen {
                     Some(JoinRoomAction::Failed { room_id, error }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::WaitingOnUserInput;
                         if !self.has_shown_confirmation {
-                            let msg = utils::join_leave_error_to_string(error, info.room_name.as_deref(), true, true)
-                                .unwrap_or_else(|| format!("Failed to join room: {error}"));
+                            let msg = utils::stringify_join_leave_error(error, info.room_name.as_deref(), true, true);
                             enqueue_popup_notification(msg);
                         }
                         continue;

--- a/src/home/room_preview.rs
+++ b/src/home/room_preview.rs
@@ -2,14 +2,13 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
 
 use crate::{
-    shared::{
+    room::RoomPreviewAvatar, shared::{
         avatar::AvatarWidgetExt,
         html_or_plaintext::HtmlOrPlaintextWidgetExt, unread_badge::UnreadBadgeWidgetExt as _,
-    },
-    utils::{self, relative_format},
+    }, utils::{self, relative_format}
 };
 
-use super::rooms_list::{InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomPreviewAvatar, RoomsListScopeProps};
+use super::rooms_list::{InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListScopeProps};
 live_design! {
     use link::theme::*;
     use link::shaders::*;

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -422,11 +422,13 @@ impl RoomsList {
                 }
                 RoomsListUpdate::RemoveRoom { room_id, new_state: _ } => {
                     if let Some(_removed) = self.all_joined_rooms.remove(&room_id) {
+                        log!("Removed room {room_id} from the list of all joined rooms");
                         self.displayed_joined_rooms.iter()
                             .position(|r| r == &room_id)
                             .map(|index| self.displayed_joined_rooms.remove(index));
                     }
                     else if let Some(_removed) = self.invited_rooms.borrow_mut().remove(&room_id) {
+                        log!("Removed room {room_id} from the list of all invited rooms");
                         self.displayed_invited_rooms.iter()
                             .position(|r| r == &room_id)
                             .map(|index| self.displayed_invited_rooms.remove(index));
@@ -441,7 +443,7 @@ impl RoomsList {
                     //       if it is currently being displayed,
                     //       and also ensure that the room's TimelineUIState is preserved
                     //       and saved (if the room has not been left),
-                    //       and also that it's MediaCache instance is put into a special state
+                    //       and also that its MediaCache instance is put into a special state
                     //       where its internal update sender gets replaced upon next usage
                     //       (that is, upon the next time that same room is opened by the user).
                 }

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -304,7 +304,14 @@ pub struct RoomsList {
     /// This is a strict subset of the rooms in `all_invited_rooms`, and should be determined
     /// by applying the `display_filter` to the set of `all_invited_rooms`.
     #[rust] displayed_invited_rooms: Vec<OwnedRoomId>,
-    #[rust(true)] is_invited_rooms_header_expanded: bool,
+    #[rust(false)] is_invited_rooms_header_expanded: bool,
+
+    /// The list of direct rooms currently displayed in the UI, in order from top to bottom.
+    /// This is a strict subset of the rooms present in `all_joined_rooms`,
+    /// and should be determined by applying the `display_filter && is_direct`
+    /// to the set of `all_joined_rooms`.
+    #[rust] displayed_direct_rooms: Vec<OwnedRoomId>,
+    #[rust(false)] is_direct_rooms_header_expanded: bool,
 
     /// The list of regular (non-direct) joined rooms currently displayed in the UI,
     /// in order from top to bottom.
@@ -315,13 +322,6 @@ pub struct RoomsList {
     /// **Direct rooms are excluded** from this; they are in `displayed_direct_rooms`.
     #[rust] displayed_regular_rooms: Vec<OwnedRoomId>,
     #[rust(true)] is_regular_rooms_header_expanded: bool,
-
-    /// The list of direct rooms currently displayed in the UI, in order from top to bottom.
-    /// This is a strict subset of the rooms present in `all_joined_rooms`,
-    /// and should be determined by applying the `display_filter && is_direct`
-    /// to the set of `all_joined_rooms`.
-    #[rust] displayed_direct_rooms: Vec<OwnedRoomId>,
-    #[rust(false)] is_direct_rooms_header_expanded: bool,
 
     /// The latest status message that should be displayed in the bottom status label.
     #[rust] status: String,

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -4,7 +4,7 @@ use makepad_widgets::*;
 use matrix_sdk::{ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch, OwnedRoomAliasId, OwnedRoomId, OwnedUserId}, RoomState};
 use crate::{
     app::{AppState, SelectedRoom},
-    room::room_display_filter::{FilterableRoom, RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria, SortFn},
+    room::{room_display_filter::{FilterableRoom, RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria, SortFn}, RoomPreviewAvatar},
     shared::{collapsible_header::{CollapsibleHeaderAction, CollapsibleHeaderWidgetRefExt, HeaderCategory},
     jump_to_bottom_button::UnreadMessageCount, room_filter_input_bar::RoomFilterAction},
     sliding_sync::{submit_async_request, MatrixRequest, PaginationDirection},
@@ -247,6 +247,15 @@ pub struct InviterInfo {
     pub display_name: Option<String>,
     pub avatar: Option<Arc<[u8]>>,
 }
+impl std::fmt::Debug for InviterInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InviterInfo")
+            .field("user_id", &self.user_id)
+            .field("display_name", &self.display_name)
+            .field("avatar?", &self.avatar.is_some())
+            .finish()
+    }
+}
 
 /// The state of a pending invite.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -264,18 +273,6 @@ pub enum InviteState {
     /// The invite was declined and the room was successfully left.
     /// This should result in the InviteScreen being closed.
     RoomLeft,
-}
-
-
-#[derive(Clone, Debug)]
-pub enum RoomPreviewAvatar {
-    Text(String),
-    Image(Arc<[u8]>),
-}
-impl Default for RoomPreviewAvatar {
-    fn default() -> Self {
-        RoomPreviewAvatar::Text(String::new())
-    }
 }
 
 
@@ -477,7 +474,7 @@ impl RoomsList {
             }
         }
         if num_updates > 0 {
-            log!("RoomsList: processed {} updates to the list of all rooms", num_updates);
+            // log!("RoomsList: processed {} updates to the list of all rooms", num_updates);
             self.redraw(cx);
         }
     }

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -139,8 +139,10 @@ pub enum JoinLeaveModalKind {
     /// The user wants to reject an invite to a room.
     RejectInvite(InviteDetails),
     /// The user wants to join a room that they have not joined yet.
+    #[allow(unused)]
     JoinRoom(BasicRoomDetails),
     /// The user wants to leave an already-joined room.
+    #[allow(unused)]
     LeaveRoom(BasicRoomDetails),
 }
 impl JoinLeaveModalKind {
@@ -265,7 +267,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                     }
                 }
 
-                self.view.label(id!(title)).set_text(cx, &title);
+                self.view.label(id!(title)).set_text(cx, title);
                 self.view.label(id!(description)).set_text(cx, &description);
                 self.view.label(id!(tip)).set_text(cx, "");
                 accept_button.set_text(cx, accept_button_text);
@@ -324,7 +326,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                             popup_msg = "Successfully left room.".into();
                         }
                     }
-                    self.view.label(id!(title)).set_text(cx, &title);
+                    self.view.label(id!(title)).set_text(cx, title);
                     self.view.label(id!(description)).set_text(cx, &description);
                     enqueue_popup_notification(popup_msg);
                     accept_button.set_enabled(cx, true);
@@ -430,7 +432,7 @@ impl JoinLeaveRoomModal {
             }
         }
 
-        self.view.label(id!(title)).set_text(cx, &title);
+        self.view.label(id!(title)).set_text(cx, title);
         self.view.label(id!(description)).set_text(cx, &description);
         self.view.label(id!(tip)).set_text(cx, &format!(
             "Tip: hold Shift when clicking the \"{tip_button}\" button to bypass this prompt.",

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -292,8 +292,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                 }
                 Some(JoinRoomAction::Failed { room_id, error }) if room_id == kind.room_id() => {
                     self.view.label(id!(title)).set_text(cx, "Error joining room!");
-                    let msg = utils::join_leave_error_to_string(error, kind.room_name(), true, false)
-                        .unwrap_or_else(|| format!("Failed to join room: {error}"));
+                    let msg = utils::stringify_join_leave_error(error, kind.room_name(), true, false);
                     self.view.label(id!(description)).set_text(cx, &msg);
                     enqueue_popup_notification(msg);
                     accept_button.set_enabled(cx, true);
@@ -341,20 +340,12 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                     match kind {
                         JoinLeaveModalKind::AcceptInvite(_) | JoinLeaveModalKind::RejectInvite(_) => {
                             title = "Error rejecting invite!";
-                            description = utils::join_leave_error_to_string(error, kind.room_name(), false, true)
-                                .unwrap_or_else(|| format!(
-                                    "Failed to reject invite to \"{}\".",
-                                    room_name_or_id(kind.room_name(), room_id),
-                                ));
+                            description = utils::stringify_join_leave_error(error, kind.room_name(), false, true);
                             popup_msg = "Failed to reject invite.".into();
                         }
                         JoinLeaveModalKind::JoinRoom(_) | JoinLeaveModalKind::LeaveRoom(_) => {
                             title = "Error leaving room!";
-                            description = utils::join_leave_error_to_string(error, kind.room_name(), false, true)
-                                .unwrap_or_else(|| format!(
-                                    "Failed to leave \"{}\": {error}",
-                                    room_name_or_id(kind.room_name(), room_id),
-                                ));
+                            description = utils::stringify_join_leave_error(error, kind.room_name(), false, false);
                             popup_msg = "Failed to leave room.".into();
                         }
                     }
@@ -388,7 +379,7 @@ impl JoinLeaveRoomModal {
         cx: &mut Cx,
         kind: JoinLeaveModalKind,
     ) {
-        log!("Initializing JoinLeaveRoomModal with kind: {kind:?}");
+        log!("Showing JoinLeaveRoomModal for {kind:?}");
         let title: &str;
         let description: String;
         let tip_button: &str;

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -1,0 +1,463 @@
+use makepad_widgets::*;
+use matrix_sdk::ruma::OwnedRoomId;
+
+use crate::{home::invite_screen::{InviteDetails, JoinRoomAction, LeaveRoomAction}, room::BasicRoomDetails, shared::popup_list::enqueue_popup_notification, sliding_sync::{submit_async_request, MatrixRequest}, utils::{self, room_name_or_id}};
+
+live_design! {
+    use link::theme::*;
+    use link::widgets::*;
+
+    use crate::shared::styles::*;
+    use crate::shared::icon_button::RobrixIconButton;
+
+    pub JoinLeaveRoomModal = {{JoinLeaveRoomModal}} {
+        width: Fit
+        height: Fit
+
+        <RoundedView> {
+            flow: Down
+            width: 400
+            height: Fit
+            padding: {top: 25, right: 40, bottom: 20, left: 40}
+            spacing: 10
+
+            show_bg: true
+            draw_bg: {
+                color: #fff
+                border_radius: 3.0
+            }
+
+            title_view = <View> {
+                width: Fill,
+                height: Fit,
+                padding: {top: 0, bottom: 20}
+                align: {x: 0.5, y: 0.0}
+
+                title = <Label> {
+                    flow: RightWrap,
+                    draw_text: {
+                        text_style: <TITLE_TEXT>{font_size: 13},
+                        color: #000
+                    }
+                }
+            }
+
+            body = <View> {
+                width: Fill,
+                height: Fit,
+                flow: Down,
+
+                description = <Label> {
+                    width: Fill
+                    draw_text: {
+                        text_style: <REGULAR_TEXT>{
+                            font_size: 11.5,
+                        },
+                        color: #000
+                        wrap: Word
+                    }
+                }
+
+                <View> {
+                    width: Fill, height: Fit
+                    flow: Right,
+                    padding: {top: 20, bottom: 20}
+                    align: {x: 1.0, y: 0.5}
+                    spacing: 20
+
+                    cancel_button = <RobrixIconButton> {
+                        align: {x: 0.5, y: 0.5}
+                        padding: 15,
+                        draw_icon: {
+                            svg_file: (ICON_BLOCK_USER)
+                            color: (COLOR_DANGER_RED),
+                        }
+                        icon_walk: {width: 16, height: 16, margin: {left: -2, right: -1} }
+        
+                        draw_bg: {
+                            border_color: (COLOR_DANGER_RED),
+                            color: #fff0f0 // light red
+                        }
+                        text: "Cancel"
+                        draw_text:{
+                            color: (COLOR_DANGER_RED),
+                        }
+                    }
+
+                    accept_button = <RobrixIconButton> {
+                        align: {x: 0.5, y: 0.5}
+                        padding: 15,
+                        draw_icon: {
+                            svg_file: (ICON_CHECKMARK)
+                            color: (COLOR_ACCEPT_GREEN),
+                        }
+                        icon_walk: {width: 16, height: 16, margin: {left: -2, right: -1} }
+
+                        draw_bg: {
+                            border_color: (COLOR_ACCEPT_GREEN),
+                            color: #f0fff0 // light green
+                        }
+                        text: "Yes"
+                        draw_text:{
+                            color: (COLOR_ACCEPT_GREEN),
+                        }
+                    }
+                }
+
+                tip = <Label> {
+                    padding: 0,
+                    width: Fill,
+                    height: Fit,
+                    flow: RightWrap,
+                    align: {x: 0.5}
+                    draw_text: {
+                        text_style: <REGULAR_TEXT>{
+                            font_size: 9,
+                        },
+                        color: #A,
+                        wrap: Word
+                    }
+                    text: "Tip: hold Shift when clicking a button to bypass this prompt."
+                }
+            }
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct JoinLeaveRoomModal {
+    #[deref] view: View,
+    #[rust] kind: Option<JoinLeaveModalKind>,
+    #[rust] is_final: bool,
+}
+
+/// Kinds of content that can be shown and handled by the [`JoinLeaveRoomModal`].
+#[derive(Clone, Debug)]
+pub enum JoinLeaveModalKind {
+    /// The user wants to accept an invite to join a new room.
+    AcceptInvite(InviteDetails),
+    /// The user wants to reject an invite to a room.
+    RejectInvite(InviteDetails),
+    /// The user wants to join a room that they have not joined yet.
+    JoinRoom(BasicRoomDetails),
+    /// The user wants to leave an already-joined room.
+    LeaveRoom(BasicRoomDetails),
+}
+impl JoinLeaveModalKind {
+    pub fn room_id(&self) -> &OwnedRoomId {
+        match self {
+            JoinLeaveModalKind::AcceptInvite(invite) => &invite.room_id,
+            JoinLeaveModalKind::RejectInvite(invite) => &invite.room_id,
+            JoinLeaveModalKind::JoinRoom(room) => &room.room_id,
+            JoinLeaveModalKind::LeaveRoom(room) => &room.room_id,
+        }
+    }
+
+    pub fn room_name(&self) -> Option<&str> {
+        match self {
+            JoinLeaveModalKind::AcceptInvite(invite) => invite.room_name.as_deref(),
+            JoinLeaveModalKind::RejectInvite(invite) => invite.room_name.as_deref(),
+            JoinLeaveModalKind::JoinRoom(room) => room.room_name.as_deref(),
+            JoinLeaveModalKind::LeaveRoom(room) => room.room_name.as_deref(),
+        }
+    }
+}
+
+/// Actions handled by the parent widget of the [`JoinLeaveRoomModal`].
+#[derive(Clone, Debug, DefaultNone)]
+pub enum JoinLeaveRoomModalAction {
+    /// The modal should be opened by its parent widget
+    Open(JoinLeaveModalKind),
+    /// The modal requested its parent widget to close.
+    Close {
+        /// Whether the modal was canceled (aborted) by clicking the cancel button,
+        /// or if it was closed after completing a full sequence.
+        was_canceled: bool,
+    },
+    None,
+}
+
+
+impl Widget for JoinLeaveRoomModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for JoinLeaveRoomModal {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        let accept_button = self.view.button(id!(accept_button));
+        let cancel_button = self.view.button(id!(cancel_button));
+
+        if cancel_button.clicked(actions) {
+            // Inform the parent widget to close this modal.
+            cx.action(JoinLeaveRoomModalAction::Close { was_canceled: true });
+            self.reset_state();
+            return;
+        }
+
+        let Some(kind) = self.kind.as_ref() else { return };
+
+        let mut needs_redraw = false;
+        if accept_button.clicked(actions) {
+            if self.is_final {
+                cx.action(JoinLeaveRoomModalAction::Close { was_canceled: false });
+                self.reset_state();
+                return;
+            }
+            else {
+                let title: &str;
+                let description: String;
+                let accept_button_text: &str;
+                match kind {
+                    JoinLeaveModalKind::AcceptInvite(invite) => {
+                        title = "Accepting this invite...";
+                        description = format!(
+                            "Accepting an invitation to join \"{}\".\n\n\
+                            Waiting for confirmation from the homeserver...",
+                            room_name_or_id(invite.room_name.as_ref(), &invite.room_id),
+                        );
+                        accept_button_text = "Joining...";
+                        submit_async_request(MatrixRequest::JoinRoom {
+                            room_id: invite.room_id.clone(),
+                        });
+                    }
+                    JoinLeaveModalKind::RejectInvite(invite) => {
+                        title = "Rejecting this invite...";
+                        description = format!(
+                            "Rejecting an invitation to join \"{}\".\n\n\
+                            Waiting for confirmation from the homeserver...",
+                            room_name_or_id(invite.room_name.as_ref(), &invite.room_id),
+                        );
+                        accept_button_text = "Rejecting...";
+                        submit_async_request(MatrixRequest::LeaveRoom {
+                            room_id: invite.room_id.clone(),
+                        });
+                    }
+                    JoinLeaveModalKind::JoinRoom(room) => {
+                        title = "Joining this room...";
+                        description = format!(
+                            "Joining \"{}\".\n\n\
+                            Waiting for confirmation from the homeserver...",
+                            room_name_or_id(room.room_name.as_ref(), &room.room_id),
+                        );
+                        accept_button_text = "Joining...";
+                        submit_async_request(MatrixRequest::JoinRoom {
+                            room_id: room.room_id.clone(),
+                        });
+                    }
+                    JoinLeaveModalKind::LeaveRoom(room) => {
+                        title = "Leaving this room...";
+                        description = format!(
+                            "Leaving \"{}\".\n\n\
+                            Waiting for confirmation from the homeserver...",
+                            room_name_or_id(room.room_name.as_ref(), &room.room_id),
+                        );
+                        accept_button_text = "Leaving...";
+                        submit_async_request(MatrixRequest::LeaveRoom {
+                            room_id: room.room_id.clone(),
+                        });
+                    }
+                }
+
+                self.view.label(id!(title)).set_text(cx, &title);
+                self.view.label(id!(description)).set_text(cx, &description);
+                self.view.label(id!(tip)).set_text(cx, "");
+                accept_button.set_text(cx, accept_button_text);
+                accept_button.set_enabled(cx, false);
+                needs_redraw = true;
+            }
+        }
+
+        for action in actions {
+            match action.downcast_ref() {
+                Some(JoinRoomAction::Joined { room_id }) if room_id == kind.room_id() => {
+                    enqueue_popup_notification("Successfully joined room.".into());
+                    self.view.label(id!(title)).set_text(cx, "Joined room!");
+                    self.view.label(id!(description)).set_text(cx, &format!(
+                        "Successfully joined \"{}\".",
+                        room_name_or_id(kind.room_name(), room_id),
+                    ));
+                    accept_button.set_enabled(cx, true);
+                    accept_button.set_text(cx, "Okay"); // TODO: set color to blue (like login button)
+                    cancel_button.set_visible(cx, false);
+                    self.is_final = true;
+                }
+                Some(JoinRoomAction::Failed { room_id, error }) if room_id == kind.room_id() => {
+                    self.view.label(id!(title)).set_text(cx, "Error joining room!");
+                    let msg = utils::join_leave_error_to_string(error, kind.room_name(), true, false)
+                        .unwrap_or_else(|| format!("Failed to join room: {error}"));
+                    self.view.label(id!(description)).set_text(cx, &msg);
+                    enqueue_popup_notification(msg);
+                    accept_button.set_enabled(cx, true);
+                    accept_button.set_text(cx, "Okay"); // TODO: set color to blue (like login button)
+                    cancel_button.set_visible(cx, false);
+                    self.is_final = true;
+                }
+                _ => {}
+            }
+            match action.downcast_ref() {
+                Some(LeaveRoomAction::Left { room_id }) if room_id == kind.room_id() => {
+                    let title: &str;
+                    let description: String;
+                    let popup_msg: String;
+                    match kind {
+                        JoinLeaveModalKind::AcceptInvite(_) | JoinLeaveModalKind::RejectInvite(_) => {
+                            title = "Rejected invite!";
+                            description = format!(
+                                "Successfully rejected invite to \"{}\".",
+                                room_name_or_id(kind.room_name(), room_id),
+                            );
+                            popup_msg = "Successfully rejected invite.".into();
+                        }
+                        JoinLeaveModalKind::JoinRoom(_) | JoinLeaveModalKind::LeaveRoom(_) => {
+                            title = "Left room!";
+                            description = format!(
+                                "Successfully left \"{}\".",
+                                room_name_or_id(kind.room_name(), room_id),
+                            );
+                            popup_msg = "Successfully left room.".into();
+                        }
+                    }
+                    self.view.label(id!(title)).set_text(cx, &title);
+                    self.view.label(id!(description)).set_text(cx, &description);
+                    enqueue_popup_notification(popup_msg);
+                    accept_button.set_enabled(cx, true);
+                    accept_button.set_text(cx, "Okay"); // TODO: set color to blue (like login button)
+                    cancel_button.set_visible(cx, false);
+                    self.is_final = true;
+                }
+                Some(LeaveRoomAction::Failed { room_id, error }) if room_id == kind.room_id() => {
+                    let title: &str;
+                    let description: String;
+                    let popup_msg: String;
+                    match kind {
+                        JoinLeaveModalKind::AcceptInvite(_) | JoinLeaveModalKind::RejectInvite(_) => {
+                            title = "Error rejecting invite!";
+                            description = utils::join_leave_error_to_string(error, kind.room_name(), false, true)
+                                .unwrap_or_else(|| format!(
+                                    "Failed to reject invite to \"{}\".",
+                                    room_name_or_id(kind.room_name(), room_id),
+                                ));
+                            popup_msg = "Failed to reject invite.".into();
+                        }
+                        JoinLeaveModalKind::JoinRoom(_) | JoinLeaveModalKind::LeaveRoom(_) => {
+                            title = "Error leaving room!";
+                            description = utils::join_leave_error_to_string(error, kind.room_name(), false, true)
+                                .unwrap_or_else(|| format!(
+                                    "Failed to leave \"{}\": {error}",
+                                    room_name_or_id(kind.room_name(), room_id),
+                                ));
+                            popup_msg = "Failed to leave room.".into();
+                        }
+                    }
+
+                    self.view.label(id!(title)).set_text(cx, title);
+                    self.view.label(id!(description)).set_text(cx, &description);
+                    enqueue_popup_notification(popup_msg);
+                    accept_button.set_enabled(cx, true);
+                    accept_button.set_text(cx, "Okay"); // TODO: set color to blue (like login button)
+                    cancel_button.set_visible(cx, false);
+                    self.is_final = true;
+                }
+                _ => {}
+            }
+        }
+
+        if needs_redraw {
+            self.redraw(cx);
+        }
+    }
+}
+
+impl JoinLeaveRoomModal {
+    fn reset_state(&mut self) {
+        self.kind = None;
+        self.is_final = false;
+    }
+
+    fn set_kind(
+        &mut self,
+        cx: &mut Cx,
+        kind: JoinLeaveModalKind,
+    ) {
+        log!("Initializing JoinLeaveRoomModal with kind: {kind:?}");
+        let title: &str;
+        let description: String;
+        let tip_button: &str;
+
+        match &kind {
+            JoinLeaveModalKind::AcceptInvite(invite) => {
+                title = "Accept this invite?";
+                description = format!(
+                    "Are you sure you want to accept this invite to join \"{}\"?",
+                    room_name_or_id(invite.room_name.as_ref(), &invite.room_id),
+                );
+                tip_button = "Join";
+            }
+            JoinLeaveModalKind::RejectInvite(invite) => {
+                title = "Reject this invite?";
+                description = format!(
+                    "Are you sure you want to reject this invite to join \"{}\"?\n\n\
+                    If this is a private room, you won't be able to join this room \
+                    without being re-invited to it.",
+                    room_name_or_id(invite.room_name.as_ref(), &invite.room_id)
+                );
+                tip_button = "Reject";
+            }
+            JoinLeaveModalKind::JoinRoom(room) => {
+                title = "Join this room?";
+                description = format!(
+                    "Are you sure you want to join \"{}\"?",
+                    room_name_or_id(room.room_name.as_ref(), &room.room_id)
+                );
+                tip_button = "Join";
+            }
+            JoinLeaveModalKind::LeaveRoom(room) => {
+                title = "Leave this room?";
+                description = format!(
+                    "Are you sure you want to leave \"{}\"?\n\n\
+                    If this is a private room, you won't be able to join this room \
+                    without being re-invited to it.",
+                    room_name_or_id(room.room_name.as_ref(), &room.room_id)
+                );
+                tip_button = "Leave";
+            }
+        }
+
+        self.view.label(id!(title)).set_text(cx, &title);
+        self.view.label(id!(description)).set_text(cx, &description);
+        self.view.label(id!(tip)).set_text(cx, &format!(
+            "Tip: hold Shift when clicking the \"{tip_button}\" button to bypass this prompt.",
+        ));
+
+        let accept_button = self.button(id!(accept_button));
+        let cancel_button = self.button(id!(cancel_button));
+        accept_button.set_text(cx, "Yes");
+        accept_button.set_enabled(cx, true);
+        accept_button.set_visible(cx, true);
+        cancel_button.set_text(cx, "Cancel");
+        cancel_button.set_enabled(cx, true);
+        cancel_button.set_visible(cx, true);
+
+        self.kind = Some(kind);
+        self.is_final = false;
+    }
+}
+
+impl JoinLeaveRoomModalRef {
+    pub fn set_kind(
+        &self,
+        cx: &mut Cx,
+        kind: JoinLeaveModalKind,
+    ) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_kind(cx, kind);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod home;
 mod profile;
 /// A modal/dialog popup for interactive verification of users/devices.
 mod verification_modal;
+/// A modal/dialog popup for joining/leaving rooms, including confirming invite accept/reject.
+mod join_leave_room_modal;
 /// Shared UI components.
 pub mod shared;
 /// Generating text previews of timeline events/messages.

--- a/src/room/mod.rs
+++ b/src/room/mod.rs
@@ -1,4 +1,6 @@
+use std::sync::Arc;
 use makepad_widgets::Cx;
+use matrix_sdk::ruma::OwnedRoomId;
 
 pub mod room_input_bar;
 pub mod room_member_manager;
@@ -6,4 +8,32 @@ pub mod room_display_filter;
 
 pub fn live_design(cx: &mut Cx) {
     room_input_bar::live_design(cx)
+}
+
+/// Basic details about a room, used for displaying a preview of it.
+#[derive(Clone, Debug)]
+pub struct BasicRoomDetails {
+    pub room_id: OwnedRoomId,
+    pub room_name: Option<String>,
+    pub room_avatar: RoomPreviewAvatar,
+}
+
+
+#[derive(Clone)]
+pub enum RoomPreviewAvatar {
+    Text(String),
+    Image(Arc<[u8]>),
+}
+impl Default for RoomPreviewAvatar {
+    fn default() -> Self {
+        RoomPreviewAvatar::Text(String::new())
+    }
+}
+impl std::fmt::Debug for RoomPreviewAvatar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RoomPreviewAvatar::Text(text) => f.debug_tuple("Text").field(text).finish(),
+            RoomPreviewAvatar::Image(_) => f.debug_tuple("Image").finish(),
+        }
+    }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2016,9 +2016,9 @@ pub struct BackwardsPaginateUntilEventRequest {
 }
 
 /// Whether to enable verbose logging of all timeline diff updates.
-const LOG_TIMELINE_DIFFS: bool = false;
+const LOG_TIMELINE_DIFFS: bool = cfg!(log_timeline_diffs);
 /// Whether to enable verbose logging of all room list service diff updates.
-const LOG_ROOM_LIST_DIFFS: bool = true;
+const LOG_ROOM_LIST_DIFFS: bool = cfg!(log_room_list_diffs);
 
 /// A per-room async task that listens for timeline updates and sends them to the UI thread.
 ///

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -29,11 +29,11 @@ use std::{cmp::{max, min}, collections::{BTreeMap, BTreeSet}, ops::Not, path:: P
 use std::io;
 use crate::{
     app_data_dir, avatar_cache::AvatarUpdate, event_preview::text_preview_of_timeline_item, home::{
-        invite_screen::{JoinRoomAction, LeaveRoomAction}, room_screen::TimelineUpdate, rooms_list::{self, enqueue_rooms_list_update, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomPreviewAvatar, RoomsListUpdate}
+        invite_screen::{JoinRoomAction, LeaveRoomAction}, room_screen::TimelineUpdate, rooms_list::{self, enqueue_rooms_list_update, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate}
     }, login::login_screen::LoginAction, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistent_state::{self, ClientSessionPersisted}, profile::{
         user_profile::{AvatarState, UserProfile},
         user_profile_cache::{enqueue_user_profile_update, UserProfileUpdate},
-    }, shared::{html_or_plaintext::MatrixLinkPillState, jump_to_bottom_button::UnreadMessageCount, popup_list::enqueue_popup_notification}, utils::{self, AVATAR_THUMBNAIL_FORMAT}, verification::add_verification_event_handlers_and_sync_client
+    }, room::RoomPreviewAvatar, shared::{html_or_plaintext::MatrixLinkPillState, jump_to_bottom_button::UnreadMessageCount, popup_list::enqueue_popup_notification}, utils::{self, AVATAR_THUMBNAIL_FORMAT}, verification::add_verification_event_handlers_and_sync_client
 };
 
 #[derive(Parser, Debug, Default)]
@@ -595,14 +595,16 @@ async fn async_worker(
                             }
                             Err(e) => {
                                 error!("Error leaving room {room_id}: {e:?}");
-                                LeaveRoomAction::Failed { room_id, error: e.to_string() }
+                                LeaveRoomAction::Failed { room_id, error: e }
                             }
                         }
                     } else {
                         error!("BUG: client could not get room with ID {room_id}");
                         LeaveRoomAction::Failed {
                             room_id,
-                            error: String::from("Client couldn't locate room to leave it."),
+                            error: matrix_sdk::Error::UnknownError(
+                                String::from("Client couldn't locate room to join it.").into()
+                            ),
                         }
                     };
                     Cx::post_action(result_action);

--- a/src/verification_modal.rs
+++ b/src/verification_modal.rs
@@ -139,8 +139,7 @@ impl Widget for VerificationModal {
 }
 
 impl WidgetMatchEvent for VerificationModal {
-    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        let widget_uid = self.widget_uid();
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         let accept_button = self.button(id!(accept_button));
         let cancel_button = self.button(id!(cancel_button));
 
@@ -159,13 +158,13 @@ impl WidgetMatchEvent for VerificationModal {
             // a `VerificationModalAction::Close` action, as that would cause
             // an infinite action feedback loop.
             if !modal_dismissed {
-                cx.widget_action(widget_uid, &scope.path, VerificationModalAction::Close);
+                cx.action(VerificationModalAction::Close);
             }
         }
 
         if accept_button.clicked(actions) {
             if self.is_final {
-                cx.widget_action(widget_uid, &scope.path, VerificationModalAction::Close);
+                cx.action(VerificationModalAction::Close);
                 self.reset_state();
             } else {
                 if let Some(state) = self.state.as_ref() {


### PR DESCRIPTION
This modal can also be used for joining or leaving any room, not just invited ones, but we don't yet have a UI to bring that up yet.