### PR TITLE
Display when a message has been edited, beneath its timestamp

### DIFF
--- a/src/home/edited_indicator.rs
+++ b/src/home/edited_indicator.rs
@@ -1,0 +1,142 @@
+//! An indicator that is shown nearby a message that has been edited.
+//!
+//! This widget is basically just a clickable label that shows the text "(edited)"
+//! with an underline to indicate that it is clickable.
+//! Upon hover, it shows a tooltip with the date and time when the message was edited.
+//!
+//! On click, this widget opens a scrollabel modal dialog that shows the full edit history
+//! of the message, including all previous content versions and their timestamps.
+
+use chrono::{DateTime, Local};
+use makepad_widgets::*;
+use matrix_sdk_ui::timeline::EventTimelineItem;
+
+use crate::{shared::callout_tooltip::TooltipAction, utils::unix_time_millis_to_datetime};
+
+live_design! {
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+
+    use crate::shared::styles::*;
+
+    pub EDITED_INDICATOR_FONT_SIZE  = 9.5
+    pub EDITED_INDICATOR_FONT_COLOR = #666666
+
+    pub EditedIndicator = {{EditedIndicator}} {
+        width: Fit, height: Fit
+        flow: Right,
+        padding: 0,
+        margin: 0,
+
+        // visible: false, // default to hidden
+        my_label = <Label> {
+            width: Fit, height: Fit
+            flow: Right, // do not wrap
+            padding: 0,
+            margin: 0,
+            draw_text: {
+                text_style: <TIMESTAMP_TEXT_STYLE> { font_size: 10 },
+                // color: #x0,
+                color: (COLOR_ROBRIX_PURPLE),
+            }
+            text = "(edited)",
+        }
+        // edit_html = <Html> {
+        //     width: Fit, height: Fit
+        //     flow: Right, // do not wrap
+        //     padding: 0,
+
+        //     font_size: (EDITED_INDICATOR_FONT_SIZE),
+        //     font_color: (EDITED_INDICATOR_FONT_COLOR),
+        //     draw_normal: { color: (EDITED_INDICATOR_FONT_COLOR) },
+        //     draw_block: {
+        //         line_color: (MESSAGE_TEXT_COLOR)
+        //     }
+        //     body = "<u>(edited)</u>",
+        // }
+    }
+}
+
+/// A interactive label that indicates a message has been edited.
+#[derive(Live, LiveHook, Widget)]
+pub struct EditedIndicator {
+    #[deref] view: View,
+
+    #[rust] latest_edit_ts: DateTime<Local>,
+}
+
+impl Widget for EditedIndicator {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+
+        let area = self.view.area();
+        let should_hover_in = match event.hits(cx, area) {
+            Hit::FingerLongPress(_)
+            | Hit::FingerHoverOver(..) // TODO: remove once CalloutTooltip bug is fixed
+            | Hit::FingerHoverIn(..) => true,
+            Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() => {
+                log!("todo: show edit history.");
+                false
+            },
+            Hit::FingerHoverOut(_) => {
+                cx.widget_action(self.widget_uid(), &scope.path, TooltipAction::HoverOut);
+                false
+            }
+            _ => false,
+        };
+        if should_hover_in {
+            // TODO: use pure_rust_locales crate to format the time based on the chosen Locale.
+            let locale_extended_fmt_en_us= "%a %b %-d, %Y, %r";
+            cx.widget_action(
+                self.widget_uid(),
+                &scope.path,
+                TooltipAction::HoverIn {
+                    widget_rect: area.rect(cx),
+                    text: format!("Last edited {}", self.latest_edit_ts.format(locale_extended_fmt_en_us)),
+                    bg_color: None,
+                    text_color: None,
+                },
+            );
+        }
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl EditedIndicator {
+    pub fn set_latest_edit(&mut self, cx: &mut Cx, event_tl_item: &EventTimelineItem) {
+        log!("set_latest_edit called for EditedIndicator, event ID: {:?}", event_tl_item.event_id());
+        if let Some(aste) = event_tl_item
+            .latest_edit_json()
+            .and_then(|json| json.deserialize().ok())
+        {
+            log!("Latest edit found: {:?}", aste);
+            if let Some(ts) = unix_time_millis_to_datetime(aste.origin_server_ts()) {
+                log!("Setting latest edit timestamp to: {:?}", ts);
+                self.latest_edit_ts = ts;
+            }
+        }
+        self.label(id!(my_label)).set_text(cx, "(edited)");
+        self.visible = true;
+        self.redraw(cx);
+    }
+}
+
+impl EditedIndicatorRef {
+    pub fn set_latest_edit(&self, cx: &mut Cx, event_tl_item: &EventTimelineItem) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_latest_edit(cx, event_tl_item);
+        }
+    }
+}
+
+
+/// Actions emitted by an `EditedIndicator` widget.
+#[derive(Clone, Debug, DefaultNone)]
+pub enum EditedIndicatorAction {
+    ShowEditHistory,
+    None,
+}

--- a/src/home/editing_pane.rs
+++ b/src/home/editing_pane.rs
@@ -299,9 +299,9 @@ impl Widget for EditingPane {
 
 
             if self.button(id!(accept_button)).clicked(actions)
-                || edit_text_input.key_down_unhandled(actions).is_some_and(|ke| {
-                    ke.key_code == KeyCode::ReturnKey && ke.modifiers.is_primary()
-                })
+                || edit_text_input.returned(actions).is_some_and(
+                    |(_text, modifiers)| modifiers.is_primary()
+                )
             {
                 let edited_text = edit_text_input.text().trim().to_string();
                 let edited_content = match info.event_tl_item.content() {
@@ -517,15 +517,15 @@ impl EditingPane {
         self.button(id!(cancel_button)).reset_hover(cx);
 
         // Set the text input's cursor to the end and give it key focus.
+        let inner_text_input = edit_text_input.text_input_ref();
         let text_len = edit_text_input.text().len();
-        edit_text_input.text_input(id!(text_input)).set_cursor(
+        inner_text_input.set_cursor(
             cx,
             Cursor { index: text_len, prefer_next_row: false },
             false,
         );
-        edit_text_input.text_input(id!(text_input)).set_key_focus(cx);
-
         self.animator_play(cx, id!(panel.show));
+        inner_text_input.set_key_focus(cx);
         self.redraw(cx);
     }
 

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -1,5 +1,6 @@
 use makepad_widgets::Cx;
 
+pub mod edited_indicator;
 pub mod editing_pane;
 pub mod home_screen;
 pub mod invite_screen;
@@ -24,6 +25,7 @@ pub fn live_design(cx: &mut Cx) {
     location_preview::live_design(cx);
     rooms_list::live_design(cx);
     room_preview::live_design(cx);
+    edited_indicator::live_design(cx);
     editing_pane::live_design(cx);
     new_message_context_menu::live_design(cx);
     invite_screen::live_design(cx);

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3365,7 +3365,6 @@ fn populate_message_view(
         item.timestamp(id!(profile.timestamp)).set_date_time(cx, dt);
         item.timestamp(id!(profile.timestamp2)).set_date_time(cx, dt);
     }
-    
 
     if message.is_edited() {
         log!("Message {item_id} is edited, setting latest edit indicator");

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -281,9 +281,10 @@ live_design! {
         // A preview of the earlier message that this message was in reply to.
         replied_to_message = <RepliedToMessage> {
             flow: Right
-            margin: { bottom: 5.0, top: 10.0 }
+            margin: { bottom: 3, top: 10 }
             replied_to_message_content = {
                 margin: { left: 29 }
+                padding: { bottom: 10 }
             }
         }
 
@@ -291,7 +292,7 @@ live_design! {
             width: Fill,
             height: Fit
             flow: Right,
-            padding: 10.0,
+            padding: {top: 0, bottom: 10, left: 10, right: 10},
 
             profile = <View> {
                 align: {x: 0.5, y: 0.0} // centered horizontally, top aligned
@@ -300,8 +301,8 @@ live_design! {
                 margin: {top: 4.5, right: 10}
                 flow: Down,
                 avatar = <Avatar> {
-                    width: 50.,
-                    height: 50.
+                    width: 48.,
+                    height: 48.
                     // draw_bg: {
                     //     fn pixel(self) -> vec4 {
                     //         let sdf = Sdf2d::viewport(self.pos * self.rect_size);
@@ -314,21 +315,9 @@ live_design! {
                     // }
                 }
                 timestamp = <Timestamp> {
-                    margin: { top: 3.9 }
+                    margin: { top: 5.9 }
                 }
-                // post_tl_label = <Label> {
-                //     width: Fit, height: Fit
-                //     flow: Right, // do not wrap
-                //     padding: 0,
-                //     draw_text: {
-                //         text_style: <TIMESTAMP_TEXT_STYLE> {},
-                //         color: (TIMESTAMP_TEXT_COLOR)
-                //     }
-                //     text = "Label2",
-                // }
-                edited_indicator = <EditedIndicator> {
-                    margin: { top: 5 }
-                }
+                edited_indicator = <EditedIndicator> {}
             }
             content = <View> {
                 width: Fill,
@@ -1080,7 +1069,7 @@ impl Widget for RoomScreen {
                         let room_id = tl.room_id.clone();
                         self.show_editing_pane(cx, latest_sent_msg, room_id);
                     } else {
-                        enqueue_popup_notification(PopupItem { message: "No recent message available to edit.".to_string(), auto_dismissal_duration: None });
+                        enqueue_popup_notification(PopupItem { message: "No recent message available to edit.".to_string(), auto_dismissal_duration: Some(3.0) });
                     }
                 }
             }
@@ -3374,7 +3363,9 @@ fn populate_message_view(
     // Set the timestamp.
     if let Some(dt) = unix_time_millis_to_datetime(ts_millis) {
         item.timestamp(id!(profile.timestamp)).set_date_time(cx, dt);
+        item.timestamp(id!(profile.timestamp2)).set_date_time(cx, dt);
     }
+    
 
     if message.is_edited() {
         log!("Message {item_id} is edited, setting latest edit indicator");

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -300,7 +300,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                 Some(JoinRoomAction::Joined { room_id }) if room_id == kind.room_id() => {
                     enqueue_popup_notification(PopupItem{
                         message: "Successfully joined room.".into(), 
-                        auto_dismissal_duration:None
+                        auto_dismissal_duration: Some(3.0),
                     });
                     self.view.label(id!(title)).set_text(cx, "Joined room!");
                     self.view.label(id!(description)).set_text(cx, &format!(
@@ -355,7 +355,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                     }
                     self.view.label(id!(title)).set_text(cx, title);
                     self.view.label(id!(description)).set_text(cx, &description);
-                    enqueue_popup_notification(PopupItem { message: popup_msg, auto_dismissal_duration: None });
+                    enqueue_popup_notification(PopupItem { message: popup_msg, auto_dismissal_duration: Some(3.0) });
                     accept_button.set_enabled(cx, true);
                     accept_button.set_text(cx, "Okay"); // TODO: set color to blue (like login button)
                     cancel_button.set_visible(cx, false);

--- a/src/shared/mentionable_text_input.rs
+++ b/src/shared/mentionable_text_input.rs
@@ -523,6 +523,13 @@ impl MentionableTextInputRef {
         }
     }
 
+    /// Returns a reference to the inner `TextInput` widget.
+    pub fn text_input_ref(&self) -> TextInputRef {
+        self.borrow()
+            .map(|inner| inner.cmd_text_input.text_input_ref())
+            .unwrap_or_default()
+    }
+
     /// Sets the room members for this text input
     pub fn set_room_members(&self, members: Arc<Vec<RoomMember>>) {
         if let Some(mut inner) = self.borrow_mut() {

--- a/src/shared/popup_list.rs
+++ b/src/shared/popup_list.rs
@@ -113,7 +113,7 @@ live_design! {
                         instance border_size: 1.0,
                         instance progress_bar_color: (COLOR_AVATAR_BG_IDLE),
                         instance progress_bar_background_color: (COLOR_DISABLE_GRAY),
-                        instance display_progress_bar: 1.0
+                        instance display_progress_bar: 1.0 // only thing that should be an instance
                         uniform anim_time: 0.0,
                         uniform anim_duration: 2.0,
                         fn pixel(self) -> vec4 {

--- a/src/shared/popup_list.rs
+++ b/src/shared/popup_list.rs
@@ -113,7 +113,7 @@ live_design! {
                         instance border_size: 1.0,
                         instance progress_bar_color: (COLOR_AVATAR_BG_IDLE),
                         instance progress_bar_background_color: (COLOR_DISABLE_GRAY),
-                        instance display_progress_bar: 1.0 // only thing that should be an instance
+                        instance display_progress_bar: 1.0 // TODO: this is the only thing that should be an `instance`
                         uniform anim_time: 0.0,
                         uniform anim_duration: 2.0,
                         fn pixel(self) -> vec4 {


### PR DESCRIPTION
Closes #507.

Upon hover, the `EditedIndicator` will show the exact time/date of the most recent edit.

The feature to show the full edit history upon click is not yet impl'd.