### PR TITLE
Properly save/restore the state of the EditingPane

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2716,7 +2716,7 @@ struct SavedState {
     message_input_state: TextInputState,
     /// The event that the user is currently replying to, if any.
     replying_to: Option<(EventTimelineItem, RepliedToInfo)>,
-    /// The state of the `EditingPane`, if any.
+    /// The state of the `EditingPane`, if any message was being edited.
     editing_pane_state: Option<EditingPaneState>,
 }
 


### PR DESCRIPTION
Previously, we were re-using the `show_editing_pane()` function to act as a "restore state" function, but that has some issues. Now we have a dedicated save/restore function pair, and we also make sure to reset the state of the EditingPane if there was no pre-existing saved state to be restored.