### PR TITLE
Fix recent bug where RoomsList global in `Cx` wasn't being set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "accessory"
@@ -2017,7 +2017,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-platform",
 ]
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-platform",
 ]
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-platform",
 ]
@@ -2086,7 +2086,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-platform",
 ]
@@ -2094,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-emoji"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-platform",
 ]
@@ -2102,17 +2102,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2120,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2131,7 +2131,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2141,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2149,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -2175,12 +2175,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2189,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2197,12 +2197,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "makepad-platform"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "bitflags 2.9.0",
  "hilog-sys",
@@ -2226,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2249,12 +2249,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "makepad-vector"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2272,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -3891,7 +3891,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#836d042c4519148fd37e13375a5cf9b3d86c6c5d"
+source = "git+https://github.com/makepad/makepad?branch=dev#d6fb5b8014bb0a77bcbb44a0903863d8c39a7f9d"
 
 [[package]]
 name = "semver"

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -280,37 +280,40 @@ pub struct InviteScreen {
 
 impl Widget for InviteScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        // Currently, a Signal event is only used to tell this widget
+        // to check if the room has been loaded from the homeserver yet.
         if let Event::Signal = event {
             if let (false, Some(room_id), true) = (self.is_loaded, &self.room_id, cx.has_global::<RoomsListRef>()) {
                 let rooms_list_ref = cx.get_global::<RoomsListRef>();
+                let restore_status_label = self.view.label(id!(restore_status_label));
                 if !rooms_list_ref.is_room_loaded(room_id) {
                     let status_text = if rooms_list_ref.all_known_rooms_loaded() {
                         self.all_rooms_loaded = true;
                         format!(
-                            "Room {:?} was not found in the homeserver's list of all rooms.",
+                            "An invite to room \"{}\" was not found in the homeserver's list of all rooms.\n\n\
+                             You may close this screen.",
                             self.room_name.as_deref().unwrap_or_else(|| room_id.as_str())
                         )
                     } else {
                         String::from("[Placeholder for Loading Spinner]\n\
                          Waiting for this room to be loaded from the homeserver")
                     };
-                    self.view
-                        .label(id!(restore_status_label))
-                        .set_text(cx, &status_text);
+                    restore_status_label.set_text(cx, &status_text);
                     return;
                 } else {
                     self.set_displayed_invite(cx, room_id.clone(), self.room_name.clone());
                 }
             }
         }
-        
+
         self.view.handle_event(cx, event, scope);
 
         let orig_state = self.invite_state;
 
         // Handle button clicks to accept or decline the invite
         if let Event::Actions(actions) = event {
-            // Handle actions related to restoring the previously-saved state of rooms.
+            // First, we quickly loop over the actions up front to handle the case
+            // where this room was restored and has now been successfully loaded from the homeserver.
             for action in actions {
                 if let Some(RoomsPanelRestoreAction::Success(room_id)) = action.downcast_ref() {
                     if self.room_id.as_ref().is_some_and(|inner_room_id| inner_room_id == room_id) {

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -2,7 +2,7 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
 use std::collections::HashMap;
 
-use crate::{app::{AppState, AppStateAction, SelectedRoom}, home::rooms_list::RoomsListWidgetExt, utils::room_name_or_id};
+use crate::{app::{AppState, AppStateAction, SelectedRoom}, utils::room_name_or_id};
 use super::{invite_screen::InviteScreenWidgetRefExt, room_screen::RoomScreenWidgetRefExt, rooms_list::RoomsListAction};
 
 live_design! {
@@ -31,10 +31,10 @@ live_design! {
                 b: main
             }
 
-            // Not really a tab, but it needs to be one to be used in the dock
+            // This is a "fixed" tab with no header that cannot be closed.
             rooms_sidebar_tab = Tab {
                 name: "" // show no tab header
-                kind: rooms_sidebar
+                kind: rooms_sidebar // this template is defined below.
             }
 
             main = Tabs{tabs:[home_tab], selected:0}
@@ -80,8 +80,8 @@ pub struct MainDesktopUI {
     /// Boolean to indicate if we've drawn the MainDesktopUi previously in the desktop view.
     ///
     /// When switching mobile view to desktop, we need to restore the rooms panel state.
-    /// If it is false, we will post an action to load the dock from the saved dock state.
-    /// If it is true, we will do nothing.
+    /// If false, this widget emits an action to load the dock from the saved dock state.
+    /// If true, this widget proceeds to draw the desktop UI as normal.
     #[rust]
     drawn_previously: bool,
 }
@@ -99,7 +99,6 @@ impl Widget for MainDesktopUI {
             if !app_state.saved_dock_state.open_rooms.is_empty() {
                 cx.action(MainDesktopUiAction::LoadDockFromAppState);
             }
-            cx.set_global(self.view.rooms_list(id!(rooms_list)));
             self.drawn_previously = true;
         }
         self.view.draw_walk(cx, scope, walk)

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -618,7 +618,7 @@ live_design! {
                     text_style: <REGULAR_TEXT>{font_size: 11}
                     wrap: Word,
                 }
-                text: ""
+                text: "Waiting for this room to be loaded from the homeserver",
             }
 
             keyboard_view = <KeyboardView> {
@@ -853,31 +853,34 @@ impl Widget for RoomScreen {
         let user_profile_sliding_pane = self.user_profile_sliding_pane(id!(user_profile_sliding_pane));
         let loading_pane = self.loading_pane(id!(loading_pane));
 
-        // Currently, a Signal event is only used to tell this widget
-        // that its timeline events have been updated in the background.
+        // Currently, a Signal event is only used to tell this widget:
+        // 1. to check if the room has been loaded from the homeserver yet, or
+        // 2. that its timeline events have been updated in the background.
         if let Event::Signal = event {
             if let (false, Some(room_id), true) = (self.is_loaded, &self.room_id, cx.has_global::<RoomsListRef>()) {
                 let rooms_list_ref = cx.get_global::<RoomsListRef>();
+                let restore_status_label = self.view.label(id!(restore_status_label));
                 if !rooms_list_ref.is_room_loaded(room_id) {
                     let status_text = if rooms_list_ref.all_known_rooms_loaded() {
                         self.all_rooms_loaded = true;
                         format!(
-                            "Room {} was not found in the homeserver's list of all rooms.",
+                            "Room \"{}\" was not found in the homeserver's list of all rooms.\n\n\
+                             You may close this screen.",
                             self.room_name
                         )
                     } else {
                         String::from("[Placeholder for Loading Spinner]\n\
                          Waiting for this room to be loaded from the homeserver")
                     };
-                    self.view
-                        .label(id!(restore_status_label))
-                        .set_text(cx, &status_text);
+                    restore_status_label.set_text(cx, &status_text);
                     return;
                 } else {
                     self.is_loaded = true;
                     self.all_rooms_loaded = true;
+                    restore_status_label.set_text(cx, "");
                 }
             }
+
             self.process_timeline_updates(cx, &portal_list);
 
             // Ideally we would do this elsewhere on the main thread, because it's not room-specific,
@@ -1250,6 +1253,7 @@ impl Widget for RoomScreen {
             // If return DrawStep::done() inside self.view.draw_walk, turtle will misalign and panic.
             return DrawStep::done();
         }
+
 
         let room_screen_widget_uid = self.widget_uid();
         while let Some(subview) = self.view.draw_walk(cx, scope, walk).step() {
@@ -2278,6 +2282,14 @@ impl RoomScreen {
             (new_tl_state, true)
         };
 
+        if cx.has_global::<RoomsListRef>() {
+            let rooms_list_ref = cx.get_global::<RoomsListRef>();
+            self.is_loaded = rooms_list_ref.is_room_loaded(&room_id);
+            if self.is_loaded {
+                self.view.label(id!(restore_status_label)).set_text(cx, "");
+            }
+        }
+
         // Subscribe to typing notices, but hide the typing notice view initially.
         self.view(id!(typing_notice)).set_visible(cx, false);
         submit_async_request(
@@ -2286,8 +2298,10 @@ impl RoomScreen {
                 subscribe: true,
             }
         );
-
+        // Subscribe to own user read receipts, so that we can update the read marker
+        // and properly send read receipts when the user scrolls through the timeline.
         submit_async_request(MatrixRequest::SubscribeToOwnUserReadReceiptsChanged { room_id: room_id.clone(), subscribe: true });
+
         // Kick off a back pagination request for this room. This is "urgent",
         // because we want to show the user some messages as soon as possible
         // when they first open the room, and there might not be any messages yet.

--- a/src/home/rooms_sidebar.rs
+++ b/src/home/rooms_sidebar.rs
@@ -9,6 +9,8 @@
 
 use makepad_widgets::*;
 
+use crate::home::rooms_list::RoomsListWidgetExt;
+
 live_design! {
     use link::theme::*;
     use link::shaders::*;
@@ -20,7 +22,7 @@ live_design! {
 
     use crate::home::rooms_list::RoomsList;
 
-    pub RoomsSideBar = <AdaptiveView> {
+    pub RoomsSideBar = {{RoomsSideBar}}<AdaptiveView> {
         Desktop = <View> {
             padding: {top: 20, left: 10, right: 10}
             flow: Down, spacing: 10
@@ -79,5 +81,35 @@ live_design! {
                 rooms_list = <RoomsList> {}
             }
         }
+    }
+}
+
+/// A simple wrapper around `AdaptiveView` that contains several global singleton widgets.
+///
+/// * In the mobile view, it serves as the root view of the StackNavigation,
+///   showing the title label, the search bar, and the RoomsList.
+/// * In the desktop view, it is a permanent tab in the dock,
+///   showing only the title label and the RoomsList
+///   (because the search bar is at the top of the HomeScreen).
+#[derive(Live, Widget)]
+pub struct RoomsSideBar {
+    #[deref] view: AdaptiveView,
+}
+
+impl LiveHook for RoomsSideBar {
+    fn after_new_from_doc(&mut self, cx: &mut Cx) {
+        // Here we set the global singleton for the RoomsList widget,
+        // which is used to access the list of rooms from anywhere in the app.
+        Cx::set_global(cx, self.view.rooms_list(id!(rooms_list)));
+    }
+}
+
+impl Widget for RoomsSideBar {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
     }
 }


### PR DESCRIPTION
We now set the RoomsList global one time upon the creation of the `RoomsSideBar` widget, which is shared across all views (both Desktop and Mobile) and is always initialized and visible.

Closes #472