### PR TITLE
Use a `Fit`-height `FlatList` widget for the wallet list

### DIFF
--- a/src/tsp/tsp_settings_screen.rs
+++ b/src/tsp/tsp_settings_screen.rs
@@ -1,5 +1,3 @@
-use std::ops::DerefMut;
-
 use makepad_widgets::*;
 
 use crate::{shared::popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, tsp::{create_wallet_modal::CreateWalletModalAction, tsp_state_ref, TspWalletAction, TspWalletEntry, TspWalletMetadata}};
@@ -55,18 +53,17 @@ live_design! {
                 border_radius: 4.0,
             }
 
-            wallet_list = <PortalList> {
+            wallet_list = <FlatList> {
                 width: Fill,
-                height: 200,
+                height: Fit,
                 spacing: 0.0
                 flow: Down,
 
+                grab_key_focus: true,
+                drag_scrolling: true,
+                scroll_bars: { show_scroll_x: false, show_scroll_y: false },
+
                 wallet_entry = <WalletEntry> { }
-                empty = <View> { }
-                bottom_filler = <View> {
-                    width: Fill,
-                    height: 100.0,
-                }
             }
         }
 
@@ -126,7 +123,11 @@ struct WalletState {
 }
 impl WalletState {
     fn is_empty(&self) -> bool {
-        self.active_wallet.is_none() && self.other_wallets.is_empty()
+        self.len() == 0
+    }
+
+    fn len(&self) -> usize {
+        self.active_wallet.is_some() as usize + self.other_wallets.len()
     }
 
     fn get(&self, index: usize) -> Option<(&TspWalletMetadata, WalletStatusAndDefault)> {
@@ -198,38 +199,23 @@ impl Widget for TspSettingsScreen {
         self.view.view(id!(no_wallets_label)).set_visible(cx, is_wallets_empty);
 
         while let Some(subview) = self.view.draw_walk(cx, scope, walk).step() {
-            // Here, we only need to handle drawing the portal list.
-            let portal_list_ref = subview.as_portal_list();
-            let Some(mut list_ref) = portal_list_ref.borrow_mut() else {
-                error!("!!! TspSettingsScreen::draw_walk(): BUG: expected a PortalList widget, but got something else");
+            // Here, we only need to handle drawing the wallet list.
+            let flat_list_ref = subview.as_flat_list();
+            let Some(mut list) = flat_list_ref.borrow_mut() else {
+                error!("!!! TspSettingsScreen::draw_walk(): BUG: expected a FlatList widget, but got something else");
                 continue;
             };
             let Some(wallets) = self.wallets.as_ref() else {
                 return DrawStep::done();
             };
-            let portal_list_height = if is_wallets_empty { 0.0 } else { 200.0 };
-            // Hide the list if there are no wallets
-            list_ref.apply_over(cx, live!(
-                height: (portal_list_height),
-            ));
 
-            // Set the portal list's range based on the number of timeline items.
-            let last_item_id = wallets.active_wallet.is_some() as usize + wallets.other_wallets.len();
-            let list = list_ref.deref_mut();
-            list.set_item_range(cx, 0, last_item_id);
-
-            while let Some(item_id) = list.next_visible_item(cx) {
-                if let Some((metadata, mut status_and_default)) = wallets.get(item_id) {
-                    let item = list.item(cx, item_id, live_id!(wallet_entry));
-                    // Pass the wallet metadata in through Scope via props,
-                    // and status/is_default via data.
-                    let mut scope = Scope::with_data_props(&mut status_and_default, metadata);
-                    item.draw_all(cx, &mut scope);
-                } else {
-                    list.item(cx, item_id, live_id!(bottom_filler))
-                        .draw_all(cx, scope);
-                }
-                
+            for (metadata, mut status_and_default) in (0..wallets.len()).filter_map(|i| wallets.get(i)) {
+                let item_live_id = LiveId::from_str(metadata.path.as_str());
+                let item = list.item(cx, item_live_id, live_id!(wallet_entry)).unwrap();
+                // Pass the wallet metadata in through Scope via props,
+                // and status/is_default via data.
+                let mut scope = Scope::with_data_props(&mut status_and_default, metadata);
+                item.draw_all(cx, &mut scope);
             }
         }
         DrawStep::done()


### PR DESCRIPTION
The previous approach of using a `PortalList` was more difficult than necessary, because `PortalList`s are intended for huge/infinite lists in which you only draw the items shown on screen.