### PR TITLE
Store newly-created wallets within Robrix's app data dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4663,6 +4663,7 @@ dependencies = [
  "makepad-widgets",
  "matrix-sdk",
  "matrix-sdk-ui",
+ "percent-encoding",
  "quinn",
  "rand 0.8.5",
  "rangemap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,15 +53,16 @@ bitflags = "2.6.0"
 indexmap = "2.6.0"
 blurhash = { version = "0.2.3", default-features = false }
 
+## Dependencies for TSP support.
 tsp_sdk = { git = "https://github.com/openwallet-foundation-labs/tsp.git", optional = true, features = ["async", "resolve"] }
 # tsp_sdk = { version = "0.8.0", optional = true, default-features = false, features = ["async", "resolve"] }
-quinn = { version = "0.11.8", default-features = false }
-
+quinn = { version = "0.11.8", default-features = false, optional = true }
+percent-encoding = { version = "2.3", optional = true }
 
 [features]
 default = []
 ## Enables experimental support for using TSP wallets.
-tsp = ["dep:tsp_sdk"]
+tsp = ["dep:tsp_sdk", "dep:quinn", "dep:percent-encoding"]
 
 ## Hides the command prompt console on Windows.
 hide_windows_console = []

--- a/src/persistence/tsp_state.rs
+++ b/src/persistence/tsp_state.rs
@@ -7,6 +7,13 @@ use crate::{app_data_dir, tsp::SavedTspState};
 
 const TSP_STATE_FILE_NAME: &str = "tsp_state.ron";
 
+const WALLETS_DIR_NAME: &str = "tsp_wallets";
+
+/// Returns the path to the persistent app data directory for TSP wallets.
+/// When Robrix creates a new TSP wallet, it will be saved in this directory.
+pub fn tsp_wallets_dir() -> std::path::PathBuf {
+    app_data_dir().join(WALLETS_DIR_NAME)
+}
 
 /// Loads the TSP state from persistent storage.
 pub async fn load_tsp_state() -> anyhow::Result<SavedTspState> {

--- a/src/tsp/tsp_settings_screen.rs
+++ b/src/tsp/tsp_settings_screen.rs
@@ -147,7 +147,7 @@ impl WalletState {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WalletStatus {
     Opened,
     NotFound,
@@ -210,7 +210,7 @@ impl Widget for TspSettingsScreen {
             };
 
             for (metadata, mut status_and_default) in (0..wallets.len()).filter_map(|i| wallets.get(i)) {
-                let item_live_id = LiveId::from_str(metadata.path.as_str());
+                let item_live_id = LiveId::from_str(metadata.url.as_url_unencoded());
                 let item = list.item(cx, item_live_id, live_id!(wallet_entry)).unwrap();
                 // Pass the wallet metadata in through Scope via props,
                 // and status/is_default via data.

--- a/src/tsp/wallet_entry/mod.rs
+++ b/src/tsp/wallet_entry/mod.rs
@@ -185,6 +185,7 @@ impl Widget for WalletEntry {
         if self.metadata.as_ref().is_none_or(|m| m != metadata) {
             self.metadata = Some(metadata.clone());
         }
+        log!("Drawing wallet entry for: {}, is_default: {}, status: {:?}", metadata.wallet_name, sd.is_default, sd.status);
 
         self.label(id!(wallet_name)).set_text(
             cx,
@@ -192,25 +193,29 @@ impl Widget for WalletEntry {
         );
         self.label(id!(wallet_path)).set_text(
             cx,
-            &metadata.path,
+            &metadata.url.as_url_unencoded()
         );
         // There is a weird makepad bug where if we re-style one instance of the
         // `set_default_wallet_button` in one WalletEntry, all other instances of that button
         // get their styling messed up in weird ways.
         // So, as a workaround, we just hide the button entirely and show a `is_default_label_view` instead.
 
-        let set_default_wallet_button = self.button(id!(set_default_wallet_button));
-        if sd.is_default {
-            self.view(id!(is_default_label_view)).set_visible(cx, true);
-            set_default_wallet_button.set_visible(cx, false);
-        }
-
-        if matches!(sd.status, WalletStatus::NotFound) {
-            self.label(id!(not_found_label_view)).set_visible(cx, true);
-            set_default_wallet_button.set_visible(cx, false);
-            self.button(id!(remove_wallet_button)).set_visible(cx, false);
-            self.button(id!(delete_wallet_button)).set_visible(cx, false);
-        }
+        self.view(id!(is_default_label_view)).set_visible(
+            cx,
+            sd.is_default
+        );
+        self.label(id!(not_found_label_view)).set_visible(
+            cx,
+            sd.status == WalletStatus::NotFound,
+        );
+        self.button(id!(set_default_wallet_button)).set_visible(
+            cx,
+            !sd.is_default && sd.status != WalletStatus::NotFound,
+        );
+        self.button(id!(delete_wallet_button)).set_visible(
+            cx,
+            sd.status != WalletStatus::NotFound,
+        );
 
         self.view.draw_walk(cx, scope, walk)
     }


### PR DESCRIPTION
Handle TSP wallet SQLite URLs properly

Fix drawing of WalletEntry to set all views on each draw, since a single WalletEntry may be reused and redrawn with different content.