### PR TITLE
Implement feature to properly remove a TSP wallet from Robrix

### DIFF
--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -1,4 +1,4 @@
-//! A simpel modal that displays basic confirmation (yes/no) dialog.
+//! A simple modal that displays basic confirmation (yes/no) dialog.
 
 use std::borrow::Cow;
 
@@ -125,8 +125,19 @@ pub enum ConfirmationModalAction {
 }
 
 /// Defines the content and behavior of a confirmation modal.
+///
+/// Only the title and body text are required.
+/// Everything else can be left as default values like so:
+/// ```rust,no_run
+/// let content = ConfirmationModalContent {
+///     title_text: "Confirm deletion".into()
+///     body_text: "Are you sure you want to delete this file?".into()
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Default)]
-pub struct ConfirmationModalBuilder {
+#[allow(clippy::type_complexity)]
+pub struct ConfirmationModalContent {
     /// The title text of the modal, shown at the top.
     pub title_text: Cow<'static, str>,
     /// The body text of the modal, shown below the title and above the buttons.
@@ -142,9 +153,9 @@ pub struct ConfirmationModalBuilder {
     /// A callback to be called when the cancel button is clicked.
     pub on_cancel_clicked: Option<Box<dyn FnOnce(&mut Cx)>>,
 }
-impl std::fmt::Debug for ConfirmationModalBuilder {
+impl std::fmt::Debug for ConfirmationModalContent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConfirmationModalBuilder")
+        f.debug_struct("ConfirmationModalContent")
             .field("title", &self.title_text)
             .field("body", &self.body_text)
             .field("accept_button", &self.accept_button_text)
@@ -159,7 +170,7 @@ impl std::fmt::Debug for ConfirmationModalBuilder {
 #[derive(Live, LiveHook, Widget)]
 pub struct ConfirmationModal {
     #[deref] view: View,
-    #[rust] content: ConfirmationModalBuilder,
+    #[rust] content: ConfirmationModalContent,
 }
 
 impl Widget for ConfirmationModal {
@@ -214,12 +225,12 @@ impl WidgetMatchEvent for ConfirmationModal {
 }
 
 impl ConfirmationModal {
-    pub fn show(&mut self, cx: &mut Cx, builder: ConfirmationModalBuilder) {
-        self.content = builder;
-        self.apply_builder_content(cx);
+    pub fn show(&mut self, cx: &mut Cx, content: ConfirmationModalContent) {
+        self.content = content  ;
+        self.apply_content(cx);
     }
 
-    fn apply_builder_content(&mut self, cx: &mut Cx) {
+    fn apply_content(&mut self, cx: &mut Cx) {
         self.view.label(id!(title)).set_text(cx, &self.content.title_text);
         self.view.label(id!(body)).set_text(cx, &self.content.body_text);
         self.view.button(id!(accept_button)).set_text(
@@ -240,9 +251,10 @@ impl ConfirmationModal {
 }
 
 impl ConfirmationModalRef {
-    pub fn show(&self, cx: &mut Cx, builder: ConfirmationModalBuilder) {
+    /// Shows the confirmation modal with the given content.
+    pub fn show(&self, cx: &mut Cx, content: ConfirmationModalContent) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.show(cx, builder);
+        inner.show(cx, content);
     }
 
     /// Returns `Some(bool)` if this modal was closed by one of the given `actions`.

--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -1,0 +1,259 @@
+//! A simpel modal that displays basic confirmation (yes/no) dialog.
+
+use std::borrow::Cow;
+
+use makepad_widgets::*;
+
+
+live_design! {
+    use link::theme::*;
+    use link::widgets::*;
+
+    use crate::shared::styles::*;
+    use crate::shared::helpers::*;
+    use crate::shared::icon_button::RobrixIconButton;
+
+    pub ConfirmationModal = {{ConfirmationModal}} {
+        width: Fit
+        height: Fit
+
+        <RoundedView> {
+            width: 400
+            height: Fit
+            align: {x: 0.5}
+            flow: Down
+            padding: {top: 30, right: 40, bottom: 20, left: 40}
+
+            show_bg: true
+            draw_bg: {
+                color: (COLOR_PRIMARY)
+                border_radius: 4
+            }
+
+            title_view = <View> {
+                width: Fill,
+                height: Fit,
+                padding: {top: 0, bottom: 25}
+                align: {x: 0.5, y: 0.0}
+
+                title = <Label> {
+                    flow: RightWrap,
+                    draw_text: {
+                        text_style: <TITLE_TEXT>{font_size: 13},
+                        color: #000
+                        wrap: Word
+                    }
+                }
+            }
+
+            body_view = <View> {
+                width: Fill, height: Fit
+                align: {x: 0.5, y: 0.0}
+
+                body = <Label> {
+                    width: Fill, height: Fit
+                    flow: RightWrap,
+                    draw_text: {
+                        text_style: <REGULAR_TEXT>{font_size: 11.5},
+                        color: #000
+                        wrap: Word
+                    }
+                }
+            }
+
+            buttons_view = <View> {
+                width: Fill, height: Fit
+                flow: Right,
+                padding: {top: 20, bottom: 20}
+                margin: {right: -15}
+                align: {x: 1.0, y: 0.5}
+                spacing: 20
+
+                cancel_button = <RobrixIconButton> {
+                    width: 120,
+                    align: {x: 0.5, y: 0.5}
+                    padding: 15,
+                    draw_icon: {
+                        svg_file: (ICON_FORBIDDEN)
+                        color: (COLOR_FG_DANGER_RED),
+                    }
+                    icon_walk: {width: 16, height: 16, margin: {left: -2, right: -1} }
+    
+                    draw_bg: {
+                        border_color: (COLOR_FG_DANGER_RED),
+                        color: (COLOR_BG_DANGER_RED)
+                    }
+                    text: "Cancel"
+                    draw_text:{
+                        color: (COLOR_FG_DANGER_RED),
+                    }
+                }
+
+                accept_button = <RobrixIconButton> {
+                    width: 120
+                    align: {x: 0.5, y: 0.5}
+                    padding: 15,
+                    draw_icon: {
+                        svg_file: (ICON_CHECKMARK)
+                        color: (COLOR_FG_ACCEPT_GREEN),
+                    }
+                    icon_walk: {width: 16, height: 16, margin: {left: -2, right: -1} }
+
+                    draw_bg: {
+                        border_color: (COLOR_FG_ACCEPT_GREEN),
+                        color: (COLOR_BG_ACCEPT_GREEN)
+                    }
+                    text: "Confirm"
+                    draw_text:{
+                        color: (COLOR_FG_ACCEPT_GREEN),
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Widget actions emitted by the ConfirmationModal.
+#[derive(Clone, Copy, Debug, DefaultNone)]
+pub enum ConfirmationModalAction {
+    /// Emitted by this modal when it should be closed after the user clicked a button.
+    ///
+    /// The contained boolean indicates whether the user clicked the
+    /// accept button (true) or cancel button (false).
+    Close(bool),
+    None
+}
+
+/// Defines the content and behavior of a confirmation modal.
+#[derive(Default)]
+pub struct ConfirmationModalBuilder {
+    /// The title text of the modal, shown at the top.
+    pub title_text: Cow<'static, str>,
+    /// The body text of the modal, shown below the title and above the buttons.
+    pub body_text: Cow<'static, str>,
+    /// The text for the accept button.
+    /// If `None`, the button's default text of "Confirm" will be shown.
+    pub accept_button_text: Option<Cow<'static, str>>,
+    /// The text for the cancel button.
+    /// If `None`, the button's default text of "Cancel" will be shown.
+    pub cancel_button_text: Option<Cow<'static, str>>,
+    /// A callback to be called when the accept button is clicked.
+    pub on_accept_clicked: Option<Box<dyn FnOnce(&mut Cx)>>,
+    /// A callback to be called when the cancel button is clicked.
+    pub on_cancel_clicked: Option<Box<dyn FnOnce(&mut Cx)>>,
+}
+impl std::fmt::Debug for ConfirmationModalBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConfirmationModalBuilder")
+            .field("title", &self.title_text)
+            .field("body", &self.body_text)
+            .field("accept_button", &self.accept_button_text)
+            .field("cancel_button", &self.cancel_button_text)
+            .field("on_accept_clicked", &self.on_accept_clicked.is_some())
+            .field("on_cancel_clicked", &self.on_cancel_clicked.is_some())
+            .finish()
+    }
+}
+
+
+#[derive(Live, LiveHook, Widget)]
+pub struct ConfirmationModal {
+    #[deref] view: View,
+    #[rust] content: ConfirmationModalBuilder,
+}
+
+impl Widget for ConfirmationModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for ConfirmationModal {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
+        let accept_button = self.view.button(id!(accept_button));
+        let cancel_button = self.view.button(id!(cancel_button));
+
+        // Handle canceling/closing the modal.
+        let cancel_clicked = cancel_button.clicked(actions);
+        if cancel_clicked ||
+            actions.iter().any(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)))
+        {
+            // If the modal was dismissed by clicking outside of it, we MUST NOT emit
+            // a `ConfirmationModalAction::Close` action, as that would cause
+            // an infinite action feedback loop.
+            if cancel_clicked {
+                cx.widget_action(
+                    self.widget_uid(),
+                    &scope.path,
+                    ConfirmationModalAction::Close(false),
+                );
+            }
+            if let Some(on_cancel_clicked) = self.content.on_cancel_clicked.take() {
+                on_cancel_clicked(cx);
+            }
+            return;
+        }
+
+        // If the accept button was clicked, emit the action and call the on_accept callback.
+        if accept_button.clicked(actions) {
+            if let Some(on_accept_clicked) = self.content.on_accept_clicked.take() {
+                on_accept_clicked(cx);
+            }
+            cx.widget_action(
+                self.widget_uid(),
+                &scope.path,
+                ConfirmationModalAction::Close(true),
+            );
+        }
+    }
+}
+
+impl ConfirmationModal {
+    pub fn show(&mut self, cx: &mut Cx, builder: ConfirmationModalBuilder) {
+        self.content = builder;
+        self.apply_builder_content(cx);
+    }
+
+    fn apply_builder_content(&mut self, cx: &mut Cx) {
+        self.view.label(id!(title)).set_text(cx, &self.content.title_text);
+        self.view.label(id!(body)).set_text(cx, &self.content.body_text);
+        self.view.button(id!(accept_button)).set_text(
+            cx,
+            self.content.accept_button_text.as_deref().unwrap_or("Confirm"),
+        );
+        self.view.button(id!(cancel_button)).set_text(
+            cx,
+            self.content.cancel_button_text.as_deref().unwrap_or("Cancel"),
+        );
+
+        self.view.button(id!(cancel_button)).reset_hover(cx);
+        self.view.button(id!(accept_button)).reset_hover(cx);
+        self.view.button(id!(accept_button)).set_enabled(cx, true);
+        self.view.button(id!(cancel_button)).set_enabled(cx, true);
+        self.view.redraw(cx);
+    }
+}
+
+impl ConfirmationModalRef {
+    pub fn show(&self, cx: &mut Cx, builder: ConfirmationModalBuilder) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.show(cx, builder);
+    }
+
+    /// Returns `Some(bool)` if this modal was closed by one of the given `actions`.
+    ///
+    /// If `true`, the user clicked the accept button; if `false`, the user clicked the cancel button.
+    /// See [`ConfirmationModalAction::Close`] for more.
+    pub fn closed(&self, actions: &Actions) -> Option<bool> {
+        if let ConfirmationModalAction::Close(accepted) = actions.find_widget_action(self.widget_uid()).cast_ref() {
+            Some(*accepted)
+        } else {
+            None
+        }
+    }
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -3,6 +3,7 @@ use makepad_widgets::Cx;
 pub mod avatar;
 pub mod callout_tooltip;
 pub mod collapsible_header;
+pub mod confirmation_modal;
 pub mod helpers;
 pub mod html_or_plaintext;
 pub mod icon_button;
@@ -38,4 +39,5 @@ pub fn live_design(cx: &mut Cx) {
     callout_tooltip::live_design(cx);
     mentionable_text_input::live_design(cx);
     restore_status_view::live_design(cx);
+    confirmation_modal::live_design(cx);
 }

--- a/src/tsp/wallet_entry/mod.rs
+++ b/src/tsp/wallet_entry/mod.rs
@@ -1,8 +1,10 @@
 
+use std::cell::RefCell;
+
 use makepad_widgets::*;
 
 use crate::{
-    shared::popup_list::{enqueue_popup_notification, PopupItem, PopupKind},
+    shared::{confirmation_modal::ConfirmationModalBuilder, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}},
     tsp::{submit_tsp_request, tsp_settings_screen::{WalletStatus, WalletStatusAndDefault}, TspRequest, TspWalletMetadata}
 };
 
@@ -159,12 +161,21 @@ impl Widget for WalletEntry {
                 submit_tsp_request(TspRequest::SetDefaultWallet(metadata.clone())).unwrap();
             }
             if self.view.button(id!(remove_wallet_button)).clicked(actions) {
-                // TODO: Implement the remove wallet feature.
-                enqueue_popup_notification(PopupItem {
-                    message: "Remove wallet feature is not yet implemented.".to_string(),
-                    auto_dismissal_duration: None,
-                    kind: PopupKind::Warning,
-                });
+                let metadata_clone = metadata.clone();
+                let confirmation_modal_content = ConfirmationModalBuilder {
+                    title_text: "Remove Wallet".into(),
+                    body_text: format!(
+                        "Are you sure you want to remove the wallet \"{}\" \
+                        from the list?\n\nThis won't delete the actual wallet file.",
+                        metadata.wallet_name
+                    ).into(),
+                    accept_button_text: Some("Remove".into()),
+                    on_accept_clicked: Some(Box::new(move |_cx| {
+                        submit_tsp_request(TspRequest::RemoveWallet(metadata_clone)).unwrap();
+                    })),
+                    ..Default::default()
+                };
+                cx.action(TspWalletEntryAction::ShowConfirmationModal(RefCell::new(Some(confirmation_modal_content))));
             }
             if self.view.button(id!(delete_wallet_button)).clicked(actions) {
                 // TODO: Implement the delete wallet feature.
@@ -185,7 +196,6 @@ impl Widget for WalletEntry {
         if self.metadata.as_ref().is_none_or(|m| m != metadata) {
             self.metadata = Some(metadata.clone());
         }
-        log!("Drawing wallet entry for: {}, is_default: {}, status: {:?}", metadata.wallet_name, sd.is_default, sd.status);
 
         self.label(id!(wallet_name)).set_text(
             cx,
@@ -219,4 +229,18 @@ impl Widget for WalletEntry {
 
         self.view.draw_walk(cx, scope, walk)
     }
+}
+
+
+/// Actions related to a single TSP wallet.
+///
+/// These are NOT widget actions, just regular actions.
+#[derive(Debug)]
+pub enum TspWalletEntryAction {
+    /// Show a confirmation modal for an action related to a TSP wallet entry.
+    ///
+    /// The content is wrapped in a `RefCell` to ensure that only one entity handles it
+    /// and that that one entity can take ownership of the builder object,
+    /// which avoids having to clone it.
+    ShowConfirmationModal(RefCell<Option<ConfirmationModalBuilder>>),
 }

--- a/src/tsp/wallet_entry/mod.rs
+++ b/src/tsp/wallet_entry/mod.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use makepad_widgets::*;
 
 use crate::{
-    shared::{confirmation_modal::ConfirmationModalBuilder, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}},
+    shared::{confirmation_modal::ConfirmationModalContent, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}},
     tsp::{submit_tsp_request, tsp_settings_screen::{WalletStatus, WalletStatusAndDefault}, TspRequest, TspWalletMetadata}
 };
 
@@ -162,7 +162,7 @@ impl Widget for WalletEntry {
             }
             if self.view.button(id!(remove_wallet_button)).clicked(actions) {
                 let metadata_clone = metadata.clone();
-                let confirmation_modal_content = ConfirmationModalBuilder {
+                let content = ConfirmationModalContent {
                     title_text: "Remove Wallet".into(),
                     body_text: format!(
                         "Are you sure you want to remove the wallet \"{}\" \
@@ -175,7 +175,7 @@ impl Widget for WalletEntry {
                     })),
                     ..Default::default()
                 };
-                cx.action(TspWalletEntryAction::ShowConfirmationModal(RefCell::new(Some(confirmation_modal_content))));
+                cx.action(TspWalletEntryAction::ShowConfirmationModal(RefCell::new(Some(content))));
             }
             if self.view.button(id!(delete_wallet_button)).clicked(actions) {
                 // TODO: Implement the delete wallet feature.
@@ -240,7 +240,7 @@ pub enum TspWalletEntryAction {
     /// Show a confirmation modal for an action related to a TSP wallet entry.
     ///
     /// The content is wrapped in a `RefCell` to ensure that only one entity handles it
-    /// and that that one entity can take ownership of the builder object,
+    /// and that that one entity can take ownership of the content object,
     /// which avoids having to clone it.
-    ShowConfirmationModal(RefCell<Option<ConfirmationModalBuilder>>),
+    ShowConfirmationModal(RefCell<Option<ConfirmationModalContent>>),
 }


### PR DESCRIPTION
Add general-purpose confirmation modal that can be used for any arbitrary action that requires showing an "are you sure" modal.