### PR TITLE
Support creating and publishing a new TSP `did:web` identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4667,6 +4667,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "rangemap",
+ "reqwest",
  "robius-directories",
  "robius-location",
  "robius-open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,17 @@ tsp_sdk = { git = "https://github.com/openwallet-foundation-labs/tsp.git", optio
 # tsp_sdk = { version = "0.8.0", optional = true, default-features = false, features = ["async", "resolve"] }
 quinn = { version = "0.11.8", default-features = false, optional = true }
 percent-encoding = { version = "2.3", optional = true }
+## The following reqwest features were taken from the tsp_sdk's `Cargo.toml` file.
+## I'm not sure if all of them are actually needed.
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls-native-roots",
+    "json",
+    "stream",
+    "charset",
+    "http2",
+    "macos-system-configuration",
+] }
+
 
 [features]
 default = []

--- a/resources/icons/add_user.svg
+++ b/resources/icons/add_user.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 8.5V13.5M17.5 11H22.5M8 15H16C18.2091 15 20 16.7909 20 19V21H4V19C4 16.7909 5.79086 15 8 15ZM16 7C16 9.20914 14.2091 11 12 11C9.79086 11 8 9.20914 8 7C8 4.79086 9.79086 3 12 3C14.2091 3 16 4.79086 16 7Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -15,6 +15,7 @@ live_design! {
     use crate::settings::account_settings::AccountSettings;
     use link::tsp_link::TspSettingsScreen;
     use link::tsp_link::CreateWalletModal;
+    use link::tsp_link::CreateDidModal;
 
     // The main, top-level settings screen widget.
     pub SettingsScreen = {{SettingsScreen}} {
@@ -91,11 +92,16 @@ live_design! {
             }
         }
 
-        // We want the modal for creating a new TSP wallet to appear
-        // in front of the main settings content defined above.
+        // We want all modals to appear in front of the settings screen.
         create_wallet_modal = <Modal> {
             content: {
                 create_wallet_modal_inner = <CreateWalletModal> {}
+            }
+        }
+
+        create_did_modal = <Modal> {
+            content: {
+                create_did_modal_inner = <CreateDidModal> {}
             }
         }
 
@@ -146,19 +152,35 @@ impl Widget for SettingsScreen {
         #[cfg(feature = "tsp")]
         if let Event::Actions(actions) = event {
             use crate::shared::confirmation_modal::ConfirmationModalWidgetExt;
+            use crate::tsp::{
+                create_did_modal::CreateDidModalAction,
+                create_wallet_modal::CreateWalletModalAction,
+                wallet_entry::TspWalletEntryAction,
+            };
 
             for action in actions {
-                // Handle the create wallet modal being closed.
-                use crate::tsp::{create_wallet_modal::CreateWalletModalAction, wallet_entry::TspWalletEntryAction};
+                // Handle the create wallet modal being opened or closed.
                 match action.downcast_ref() {
                     Some(CreateWalletModalAction::Open) => {
-                        // Open the create wallet modal.
                         use crate::tsp::create_wallet_modal::CreateWalletModalWidgetExt;
                         self.view.create_wallet_modal(id!(create_wallet_modal_inner)).show(cx);
                         self.view.modal(id!(create_wallet_modal)).open(cx);
                     }
                     Some(CreateWalletModalAction::Close) => {
                         self.view.modal(id!(create_wallet_modal)).close(cx);
+                    }
+                    None => { }
+                }
+
+                // Handle the create DID modal being opened or closed.
+                match action.downcast_ref() {
+                    Some(CreateDidModalAction::Open) => {
+                        use crate::tsp::create_did_modal::CreateDidModalWidgetExt;
+                        self.view.create_did_modal(id!(create_did_modal_inner)).show(cx);
+                        self.view.modal(id!(create_did_modal)).open(cx);
+                    }
+                    Some(CreateDidModalAction::Close) => {
+                        self.view.modal(id!(create_did_modal)).close(cx);
                     }
                     None => { }
                 }

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -6,6 +6,7 @@ live_design! {
     use link::widgets::*;
 
     pub ICON_ADD_REACTION    = dep("crate://self/resources/icons/add_reaction.svg")
+    pub ICON_ADD_USER        = dep("crate://self/resources/icons/add_user.svg") // TODO: FIX
     pub ICON_ADD_WALLET      = dep("crate://self/resources/icons/add_wallet.svg")
     pub ICON_FORBIDDEN       = dep("crate://self/resources/icons/forbidden.svg")
     pub ICON_CHECKMARK       = dep("crate://self/resources/icons/checkmark.svg")
@@ -13,7 +14,7 @@ live_design! {
     pub ICON_COPY            = dep("crate://self/resources/icons/copy.svg")
     pub ICON_EDIT            = dep("crate://self/resources/icons/edit.svg")
     pub ICON_EXTERNAL_LINK   = dep("crate://self/resources/icons/external_link.svg")
-    pub ICON_IMPORT          = dep("crate://self/resources/icons/import.svg")
+    pub ICON_IMPORT          = dep("crate://self/resources/icons/import.svg") // TODO: FIX
     pub ICON_HTML_FILE       = dep("crate://self/resources/icons/html_file.svg")
     pub ICON_INFO            = dep("crate://self/resources/icons/info.svg")
     pub ICON_JUMP            = dep("crate://self/resources/icons/go_back.svg")

--- a/src/tsp/create_did_modal.rs
+++ b/src/tsp/create_did_modal.rs
@@ -1,8 +1,8 @@
-//! A modal dialog for creating a new TSP wallet.
+//! A modal dialog for creating a new TSP Decentralized Identity (DID).
 
 use makepad_widgets::*;
 
-use crate::{shared::styles::*, tsp::{self, TspWalletMetadata}};
+use crate::{shared::styles::*, tsp};
 
 
 live_design! {
@@ -15,7 +15,7 @@ live_design! {
     use crate::shared::helpers::*;
     use crate::shared::icon_button::RobrixIconButton;
 
-    pub CreateWalletModal = {{CreateWalletModal}} {
+    pub CreateDidModal = {{CreateDidModal}} {
         width: Fit
         height: Fit
 
@@ -45,11 +45,11 @@ live_design! {
                         color: #000
                         wrap: Word
                     }
-                    text: "Create New TSP Wallet"
+                    text: "Create New Identity (DID)"
                 }
             }
 
-            <RoundedView> {
+            <View> {
                 width: 350,
                 height: Fit,
                 spacing: 15,
@@ -60,10 +60,9 @@ live_design! {
                 show_bg: true
                 draw_bg: {
                     color: (COLOR_SECONDARY)
-                    border_radius: 4.0
                 }
 
-                wallet_name_input = <RobrixTextInput> {
+                username_input = <RobrixTextInput> {
                     width: Fill,
                     height: Fit,
                     padding: 10,
@@ -71,10 +70,10 @@ live_design! {
                         text_style: <REGULAR_TEXT>{font_size: 12},
                         color: #000
                     }
-                    empty_text: "Wallet Name",
+                    empty_text: "Identity Username",
                 }
 
-                password_input = <RobrixTextInput> {
+                alias_input = <RobrixTextInput> {
                     width: Fill,
                     height: Fit,
                     padding: 10,
@@ -82,31 +81,77 @@ live_design! {
                         text_style: <REGULAR_TEXT>{font_size: 12},
                         color: #000
                     }
-                    is_password: true,
-                    empty_text: "Wallet Password",
+                    empty_text: "Enter an alias (optional)",
                 }
 
-                confirm_password_input = <RobrixTextInput> {
-                    width: Fill,
-                    height: Fit,
-                    padding: 10,
-                    draw_text: {
-                        text_style: <REGULAR_TEXT>{font_size: 12},
-                        color: #000
+                did_type_radio_buttons = <View> {
+                    spacing: (THEME_SPACE_2)
+                    width: Fit, height: Fit,
+                    did_web   = <RadioButtonFlat> {
+                        text: "Web"
+                        animator: { active = { default: on } }
                     }
-                    is_password: true,
-                    empty_text: "Confirm Wallet Password",
+                    did_webvh = <RadioButtonFlat> {
+                        text: "WebVH"
+                        animator: { disabled = { default: on } }
+                    }
+                    did_peer  = <RadioButtonFlat> {
+                        text: "Peer",
+                        animator: { disabled = { default: on } }
+                    }
                 }
 
                 <View> {
                     width: Fill, height: Fit
                     flow: Down
 
-                    wallet_file_name_input = <RobrixTextInput> {
+                    server_input = <RobrixTextInput> {
                         width: Fill, height: Fit,
                         flow: Right, // do not wrap
                         padding: {top: 3, bottom: 3}
-                        empty_text: "my_wallet_file",
+                        empty_text: "p.teaspoon.world",
+                        draw_text: {
+                            text_style: <REGULAR_TEXT>{font_size: 10.0}
+                        }
+                    }
+
+                    <View> {
+                        width: Fill,
+                        height: Fit,
+                        flow: Right,
+                        padding: {top: 5, left: 2, right: 2, bottom: 2}
+                        spacing: 0.0,
+                        align: {x: 0.5, y: 0.5} // center horizontally and vertically
+
+                        left_line = <LineH> {
+                            draw_bg: { color: #C8C8C8 }
+                        }
+
+                        <Label> {
+                            width: Fit, height: Fit
+                            padding:  0
+                            draw_text: {
+                                color: #777777
+                                text_style: <REGULAR_TEXT>{font_size: 9}
+                            }
+                            text: "Intermediary server domain"
+                        }
+
+                        right_line = <LineH> {
+                            draw_bg: { color: #C8C8C8 }
+                        }
+                    }
+                }
+
+                <View> {
+                    width: Fill, height: Fit
+                    flow: Down
+
+                    did_server_input = <RobrixTextInput> {
+                        width: Fill, height: Fit,
+                        flow: Right, // do not wrap
+                        padding: {top: 3, bottom: 3}
+                        empty_text: "did.teaspoon.world",
                         draw_text: {
                             text_style: <REGULAR_TEXT>{font_size: 10.0}
                         }
@@ -131,7 +176,7 @@ live_design! {
                                 color: #777777
                                 text_style: <REGULAR_TEXT>{font_size: 9}
                             }
-                            text: "Wallet File Name (optional)"
+                            text: "DID server domain"
                         }
 
                         right_line = <LineH> {
@@ -183,7 +228,7 @@ live_design! {
                         border_color: (COLOR_FG_ACCEPT_GREEN),
                         color: (COLOR_BG_ACCEPT_GREEN)
                     }
-                    text: "Create Wallet"
+                    text: "Create DID"
                     draw_text:{
                         color: (COLOR_FG_ACCEPT_GREEN),
                     }
@@ -207,9 +252,9 @@ live_design! {
 }
 
 /// Actions emitted by other widgets to instruct the main settings screen
-/// to open or close the `CreateWalletModal`.
+/// to open or close the `CreateDidModal`.
 #[derive(Clone, Copy, Debug)]
-pub enum CreateWalletModalAction {
+pub enum CreateDidModalAction {
     /// The settings screen should open the modal.
     Open,
     /// The settings screen should close the modal.
@@ -217,27 +262,27 @@ pub enum CreateWalletModalAction {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-enum CreateWalletModalState {
-    /// Waiting for the user to enter wallet details.
+enum CreateDidModalState {
+    /// Waiting for the user to enter identity details.
     #[default]
     WaitingForUserInput,
-    /// Waiting for the wallet to be created.
-    WaitingForWalletCreation,
-    /// The wallet was created successfully.
-    WalletCreated,
-    /// An error occurred while creating the wallet.
-    WalletCreationError,
+    /// Waiting for the identity to be created.
+    WaitingForIdentityCreation,
+    /// The identity was created successfully.
+    IdentityCreated,
+    /// An error occurred while creating the identity.
+    IdentityCreationError,
 }
 
 
 #[derive(Live, LiveHook, Widget)]
-pub struct CreateWalletModal {
+pub struct CreateDidModal {
     #[deref] view: View,
-    #[rust] state: CreateWalletModalState,
+    #[rust] state: CreateDidModalState,
     #[rust] is_showing_error: bool,
 }
 
-impl Widget for CreateWalletModal {
+impl Widget for CreateDidModal {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
@@ -248,7 +293,7 @@ impl Widget for CreateWalletModal {
     }
 }
 
-impl WidgetMatchEvent for CreateWalletModal {
+impl WidgetMatchEvent for CreateDidModal {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         let accept_button = self.view.button(id!(accept_button));
         let cancel_button = self.view.button(id!(cancel_button));
@@ -259,10 +304,10 @@ impl WidgetMatchEvent for CreateWalletModal {
             actions.iter().any(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)))
         {
             // If the modal was dismissed by clicking outside of it, we MUST NOT emit
-            // a `CreateWalletModalAction::Close` action, as that would cause
+            // a `CreateDidModalAction::Close` action, as that would cause
             // an infinite action feedback loop.
             if cancel_clicked {
-                cx.action(CreateWalletModalAction::Close);
+                cx.action(CreateDidModalAction::Close);
             }
 
             // TODO: if possible, cancel the wallet creation request if it's still pending.
@@ -270,10 +315,10 @@ impl WidgetMatchEvent for CreateWalletModal {
             return;
         }
 
-        let wallet_name_input = self.view.text_input(id!(wallet_name_input));
-        let wallet_file_name_input = self.view.text_input(id!(wallet_file_name_input));
-        let password_input = self.view.text_input(id!(password_input));
-        let confirm_password_input = self.view.text_input(id!(confirm_password_input));
+        let username_input = self.view.text_input(id!(username_input));
+        let alias_input = self.view.text_input(id!(alias_input));
+        let server_input = self.view.text_input(id!(server_input));
+        let did_server_input = self.view.text_input(id!(did_server_input));
         let status_label = self.view.label(id!(status_label));
 
         // Handle clicking the accept button.
@@ -281,70 +326,54 @@ impl WidgetMatchEvent for CreateWalletModal {
         if accept_button.clicked(actions) {
             match self.state {
                 // If the modal is in the "final" state, just close the modal.
-                CreateWalletModalState::WalletCreated => {
-                    self.state = CreateWalletModalState::WaitingForUserInput;
-                    cx.action(CreateWalletModalAction::Close);
+                CreateDidModalState::IdentityCreated => {
+                    self.state = CreateDidModalState::WaitingForUserInput;
+                    cx.action(CreateDidModalAction::Close);
                 }
 
-                CreateWalletModalState::WaitingForUserInput => {
-                    let wallet_name = wallet_name_input.text();
-                    let password = password_input.text();
-                    let confirm_password = confirm_password_input.text();
+                CreateDidModalState::WaitingForUserInput => {
+                    let username = username_input.text();
 
                     // Check to ensure that the user has entered all required fields.
-                    if password.is_empty() || confirm_password.is_empty() {
+                    if username.is_empty() {
                         self.is_showing_error = true;
                         status_label.apply_over(cx, live!(
-                            text: "Please enter a wallet password.",
-                            draw_text: {
-                                color: (COLOR_FG_DANGER_RED),
-                            },
-                        ));
-                    } else if password != confirm_password {
-                        self.is_showing_error = true;
-                        status_label.apply_over(cx, live!(
-                            text: "Passwords do not match.",
-                            draw_text: {
-                                color: (COLOR_FG_DANGER_RED),
-                            },
-                        ));
-                    } else if wallet_name.is_empty() {
-                        self.is_showing_error = true;
-                        status_label.apply_over(cx, live!(
-                            text: "Please enter a wallet name.",
+                            text: "Please enter a DID username.",
                             draw_text: {
                                 color: (COLOR_FG_DANGER_RED),
                             },
                         ));
                     } else {
-                        let url = tsp::TspWalletSqliteUrl::from_wallet_file_name(
-                            match wallet_file_name_input.text() {
-                                empty if empty.is_empty() => wallet_file_name_input.empty_text(),
-                                non_empty => tsp::sanitize_wallet_name(&non_empty),
-                            }
-                            .as_str()
-                        );
-                        let metadata = TspWalletMetadata {
-                            wallet_name,
-                            url,
-                            password,
+                        let alias = match alias_input.text().trim() {
+                            empty if empty.is_empty() => None,
+                            non_empty => Some(non_empty.to_string()),
                         };
-                        // Submit the wallet creation request to the TSP async worker thread.
-                        tsp::submit_tsp_request(tsp::TspRequest::CreateWallet { metadata }).unwrap();
-                        self.state = CreateWalletModalState::WaitingForWalletCreation;
+                        let server = match server_input.text() {
+                            empty if empty.is_empty() => server_input.empty_text(),
+                            non_empty => non_empty,
+                        };
+                        let did_server = match did_server_input.text() {
+                            empty if empty.is_empty() => did_server_input.empty_text(),
+                            non_empty => non_empty,
+                        };
+
+                        // Submit the identity creation request to the TSP async worker thread.
+                        tsp::submit_tsp_request(tsp::TspRequest::CreateDid { username, alias, server, did_server }).unwrap();
+
+                        self.state = CreateDidModalState::WaitingForIdentityCreation;
                         self.is_showing_error = false;
                         status_label.apply_over(cx, live!(
-                            text: "Waiting for wallet to be created...",
+                            text: "Waiting for identity to be created and published...",
                             draw_text: {
                                 color: (COLOR_ACTIVE_PRIMARY_DARKER),
                             },
                         ));
                         accept_button.set_enabled(cx, false);
-                        cancel_button.set_enabled(cx, false); // TODO: support canceling the wallet creation request?
-                        wallet_name_input.set_is_read_only(cx, true);
-                        wallet_file_name_input.set_is_read_only(cx, true);
-                        password_input.set_is_read_only(cx, true);
-                        confirm_password_input.set_is_read_only(cx, true);
+                        cancel_button.set_enabled(cx, false); // TODO: support canceling the identity creation request?
+                        username_input.set_is_read_only(cx, true);
+                        alias_input.set_is_read_only(cx, true);
+                        server_input.set_is_read_only(cx, true);
+                        did_server_input.set_is_read_only(cx, true);
                     }
 
                     needs_redraw = true;
@@ -355,18 +384,19 @@ impl WidgetMatchEvent for CreateWalletModal {
         }
 
 
-        // Clear the error message if the user changes any of the input fields.
+        // If the user changes any of the input fields, clear the error message
+        // and reset the accept button to its default state.
         if self.is_showing_error {
-            if wallet_name_input.changed(actions).is_some()
-                || wallet_file_name_input.changed(actions).is_some()
-                || password_input.changed(actions).is_some()
-                || confirm_password_input.changed(actions).is_some()
+            if username_input.changed(actions).is_some()
+                || alias_input.changed(actions).is_some()
+                || server_input.changed(actions).is_some()
+                || did_server_input.changed(actions).is_some()
             {
                 self.is_showing_error = false;
                 self.view.label(id!(status_label)).set_text(cx, "");
-                self.state = CreateWalletModalState::WaitingForUserInput;
+                self.state = CreateDidModalState::WaitingForUserInput;
                 accept_button.apply_over(cx, live!(
-                    text: "Create Wallet",
+                    text: "Create DID",
                     enabled: true,
                     draw_text: {
                         color: (COLOR_FG_ACCEPT_GREEN),
@@ -376,23 +406,12 @@ impl WidgetMatchEvent for CreateWalletModal {
             }
         }
 
-        // If the wallet name is changed, update the path's empty text to show
-        // a sanitized version of the wallet name.
-        if let Some(name) = wallet_name_input.changed(actions) {
-            wallet_file_name_input.set_empty_text(cx, tsp::sanitize_wallet_name(&name));
-        }
-
         for action in actions {
             match action.downcast_ref() {
-                // Handle the wallet creation success action.
-                Some(tsp::TspWalletAction::CreateWalletSuccess { metadata, is_default }) => {
-                    self.state = CreateWalletModalState::WalletCreated;
+                Some(tsp::TspWalletAction::DidCreationResult(Ok(did)))=> {
+                    self.state = CreateDidModalState::IdentityCreated;
                     self.is_showing_error = false;
-                    let message = if *is_default {
-                        format!("Wallet \"{}\" created successfully and set as the default.", metadata.wallet_name)
-                    } else {
-                        format!("Wallet \"{}\" created successfully.", metadata.wallet_name)
-                    };
+                    let message = format!("Successfully created and published DID: \"{}\"", did);
                     status_label.apply_over(cx, live!(
                         text: (message),
                         draw_text: {
@@ -413,13 +432,15 @@ impl WidgetMatchEvent for CreateWalletModal {
                         },
                     ));
                     cancel_button.set_visible(cx, false);
+                    needs_redraw = true;
                 }
 
-                // Handle the wallet creation error action.
-                Some(tsp::TspWalletAction::CreateWalletError { error, .. }) => {
-                    self.state = CreateWalletModalState::WalletCreationError;
+                // Upon an error, update the status label and disable the accept button.
+                // Re-enable the input fields so the user can change the input values to try again.
+                Some(tsp::TspWalletAction::DidCreationResult(Err(e)))=> {
+                    self.state = CreateDidModalState::IdentityCreationError;
                     self.is_showing_error = true;
-                    let message = format!("Failed to create wallet: {error}.");
+                    let message = format!("Failed to create DID: {e}");
                     status_label.apply_over(cx, live!(
                         text: (message),
                         draw_text: {
@@ -428,10 +449,11 @@ impl WidgetMatchEvent for CreateWalletModal {
                     ));
                     accept_button.set_enabled(cx, false);
                     cancel_button.set_enabled(cx, true);
-                    wallet_name_input.set_is_read_only(cx, false);
-                    wallet_file_name_input.set_is_read_only(cx, false);
-                    password_input.set_is_read_only(cx, false);
-                    confirm_password_input.set_is_read_only(cx, false);
+                    username_input.set_is_read_only(cx, false);
+                    alias_input.set_is_read_only(cx, false);
+                    server_input.set_is_read_only(cx, false);
+                    did_server_input.set_is_read_only(cx, false);
+                    needs_redraw = true;
                 }
 
                 _ => { }
@@ -444,12 +466,12 @@ impl WidgetMatchEvent for CreateWalletModal {
     }
 }
 
-impl CreateWalletModal {
+impl CreateDidModal {
     pub fn show(&mut self, cx: &mut Cx) {
-        self.state = CreateWalletModalState::WaitingForUserInput;
+        self.state = CreateDidModalState::WaitingForUserInput;
         let accept_button = self.view.button(id!(accept_button));
         let cancel_button = self.view.button(id!(cancel_button));
-        accept_button.set_text(cx, "Create Wallet");
+        accept_button.set_text(cx, "Create DID");
         cancel_button.set_text(cx, "Cancel");
         accept_button.reset_hover(cx);
         cancel_button.reset_hover(cx);
@@ -458,17 +480,17 @@ impl CreateWalletModal {
         accept_button.set_visible(cx, true);
         cancel_button.set_visible(cx, true);
         // TODO: return buttons to their default state/appearance
-        self.view.text_input(id!(wallet_name_input)).set_is_read_only(cx, false);
-        self.view.text_input(id!(wallet_file_name_input)).set_is_read_only(cx, false);
-        self.view.text_input(id!(password_input)).set_is_read_only(cx, false);
-        self.view.text_input(id!(confirm_password_input)).set_is_read_only(cx, false);
+        self.view.text_input(id!(username_input)).set_is_read_only(cx, false);
+        self.view.text_input(id!(alias_input)).set_is_read_only(cx, false);
+        self.view.text_input(id!(server_input)).set_is_read_only(cx, false);
+        self.view.text_input(id!(did_server_input)).set_is_read_only(cx, false);
         self.view.label(id!(status_label)).set_text(cx, "");
         self.is_showing_error = false;
         self.view.redraw(cx);        
     }
 }
 
-impl CreateWalletModalRef {
+impl CreateDidModalRef {
     pub fn show(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.show(cx);

--- a/src/tsp/tsp_settings_screen.rs
+++ b/src/tsp/tsp_settings_screen.rs
@@ -1,6 +1,6 @@
 use makepad_widgets::*;
 
-use crate::{shared::popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, tsp::{create_wallet_modal::CreateWalletModalAction, tsp_state_ref, TspWalletAction, TspWalletEntry, TspWalletMetadata}};
+use crate::{shared::popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, tsp::{create_did_modal::CreateDidModalAction, create_wallet_modal::CreateWalletModalAction, tsp_state_ref, TspWalletAction, TspWalletEntry, TspWalletMetadata}};
 
 live_design! {
     link tsp_enabled
@@ -73,6 +73,27 @@ live_design! {
             flow: RightWrap,
             align: {y: 0.5},
             spacing: 10
+
+            create_did_button = <RobrixIconButton> {
+                width: Fit, height: Fit,
+                padding: 10,
+                margin: {left: 5},
+
+                draw_bg: {
+                    border_color: (COLOR_FG_ACCEPT_GREEN),
+                    color: (COLOR_BG_ACCEPT_GREEN),
+                    border_radius: 5
+                }
+                draw_icon: {
+                    svg_file: (ICON_ADD_USER)
+                    color: (COLOR_FG_ACCEPT_GREEN),
+                }
+                icon_walk: {width: 21, height: Fit, margin: 0}
+                draw_text: {
+                    color: (COLOR_FG_ACCEPT_GREEN),
+                }
+                text: "Create New Identity (DID)"
+            }
 
             create_wallet_button = <RobrixIconButton> {
                 width: Fit, height: Fit,
@@ -306,12 +327,17 @@ impl MatchEvent for TspSettingsScreen {
                 }
 
                 Some(TspWalletAction::CreateWalletError { .. }) // handled in the CreateWalletModal
+                | Some(TspWalletAction::DidCreationResult(_)) // handled in the CreateDidModal
                 | None => { }
             }
         }
 
         if self.view.button(id!(create_wallet_button)).clicked(actions) {
             cx.action(CreateWalletModalAction::Open);
+        }
+
+        if self.view.button(id!(create_did_button)).clicked(actions) {
+            cx.action(CreateDidModalAction::Open);
         }
 
         if self.view.button(id!(import_wallet_button)).clicked(actions) {

--- a/src/tsp_dummy/mod.rs
+++ b/src/tsp_dummy/mod.rs
@@ -54,4 +54,8 @@ live_design! {
     pub CreateWalletModal = <View> {
         visible: false,
     }
+
+    pub CreateDidModal = <View> {
+        visible: false,
+    }
 }


### PR DESCRIPTION
Not yet complete, some icons and UI elements are still not formatted properly, e.g., the radio buttons and the add_user SVG

TODO: convert all unwrap/expect/panic to return results such that we can handle them and show popup notifications on the UI side.