### PR TITLE
Store tokio Runtime instance as a single object not wrapped in Arc

### DIFF
--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1156,7 +1156,7 @@ async fn async_worker(
 
 
 /// The single global Tokio runtime that is used by all async tasks.
-static TOKIO_RUNTIME: OnceLock<Arc<tokio::runtime::Runtime>> = OnceLock::new();
+static TOKIO_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 /// The sender used by [`submit_async_request`] to send requests to the async worker thread.
 /// Currently there is only one, but it can be cloned if we need more concurrent senders.
@@ -1179,7 +1179,7 @@ pub fn block_on_async_with_timeout<T>(
     timeout: Option<Duration>,
     async_future: impl Future<Output = T>,
 ) -> Result<T, Elapsed> {
-    let rt = TOKIO_RUNTIME.get_or_init(|| Arc::new(tokio::runtime::Runtime::new().unwrap()));
+    let rt = TOKIO_RUNTIME.get_or_init(|| tokio::runtime::Runtime::new().unwrap());
     if let Some(timeout) = timeout {
         rt.block_on(async {
             tokio::time::timeout(timeout, async_future).await
@@ -1193,10 +1193,10 @@ pub fn block_on_async_with_timeout<T>(
 /// The primary initialization routine for starting the Matrix client sync
 /// and the async tokio runtime.
 ///
-/// Returns a reference to the Tokio runtime that is used to run async background tasks.
-pub fn start_matrix_tokio() -> Result<Arc<tokio::runtime::Runtime>> {
+/// Returns a handle to the Tokio runtime that is used to run async background tasks.
+pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
     // Create a Tokio runtime, and save it in a static variable to ensure it isn't dropped.
-    let rt = TOKIO_RUNTIME.get_or_init(|| Arc::new(tokio::runtime::Runtime::new().unwrap()));
+    let rt = TOKIO_RUNTIME.get_or_init(|| tokio::runtime::Runtime::new().unwrap());
 
     // Create a channel to be used between UI thread(s) and the async worker thread.
     let (sender, receiver) = tokio::sync::mpsc::unbounded_channel::<MatrixRequest>();
@@ -1267,7 +1267,7 @@ pub fn start_matrix_tokio() -> Result<Arc<tokio::runtime::Runtime>> {
         }
     });
 
-    Ok(Arc::clone(rt))
+    Ok(rt.handle().clone())
 }
 
 

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1,7 +1,7 @@
 // Ignore clippy warnings in `DeRon` macro derive bodies.
 #![allow(clippy::question_mark)]
 
-use std::{borrow::Cow, ops::Deref, path::Path, sync::{Arc, Mutex, OnceLock}};
+use std::{borrow::Cow, ops::Deref, path::Path, sync::{Mutex, OnceLock}};
 
 use anyhow::anyhow;
 use makepad_widgets::{makepad_micro_serde::*, *};
@@ -242,7 +242,7 @@ pub struct SavedTspState {
 }
 
 
-pub fn tsp_init(rt: Arc<tokio::runtime::Runtime>) -> anyhow::Result<()> {
+pub fn tsp_init(rt_handle: tokio::runtime::Handle) -> anyhow::Result<()> {
     CryptoProvider::install_default(aws_lc_rs::default_provider())
         .map_err(|_| anyhow!("BUG: default CryptoProvider was already set."))?;
 
@@ -250,9 +250,8 @@ pub fn tsp_init(rt: Arc<tokio::runtime::Runtime>) -> anyhow::Result<()> {
     let (sender, receiver) = tokio::sync::mpsc::unbounded_channel::<TspRequest>();
     TSP_REQUEST_SENDER.set(sender).expect("BUG: TSP_REQUEST_SENDER already set!");
 
-    let rt2 = rt.clone();
     // Start a high-level async task that will start and monitor all other tasks.
-    let _monitor = rt.spawn(async move {
+    let _monitor = rt_handle.spawn(async move {
         // First, run the inner TSP initialization logic to load prior TSP state.
         match inner_tsp_init().await {
             Ok(()) => log!("TSP state initialized successfully."),
@@ -270,7 +269,7 @@ pub fn tsp_init(rt: Arc<tokio::runtime::Runtime>) -> anyhow::Result<()> {
         }
 
         // Spawn the actual async worker thread.
-        let mut tsp_worker_join_handle = rt2.spawn(async_tsp_worker(receiver));
+        let mut tsp_worker_join_handle = Handle::current().spawn(async_tsp_worker(receiver));
 
         // TODO: start the main loop that drives the TSP SDK's receiver handler,
         //       e.g., to process incoming requests from other TSP instances.


### PR DESCRIPTION
This makes it easier to clean up, which is needed for PR #432. We now pass out `Handle`s instead of strong references to the runtime itself, which is fine because we do want to be able to drop the runtime and forcibly shutdown all background async tasks.