### PR TITLE
Add infrastructure for verifying other users via TSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -4552,7 +4553,7 @@ dependencies = [
  "getrandom 0.2.15",
  "libc",
  "spin",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4645,6 +4646,7 @@ name = "robrix"
 version = "0.0.1-pre-alpha-3"
 dependencies = [
  "anyhow",
+ "aws-lc-rs",
  "bitflags 2.9.0",
  "blurhash",
  "bytesize",
@@ -4963,7 +4965,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6288,6 +6290,12 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6115,7 +6115,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tsp_sdk"
 version = "0.8.1"
-source = "git+https://github.com/openwallet-foundation-labs/tsp.git#d24e3ea7214069dcfc991c69c8e3e7795e221efa"
+source = "git+https://github.com/openwallet-foundation-labs/tsp.git#8ab2cbc643834e92c64a0891d2eb8117817a27b9"
 dependencies = [
  "aries-askar",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ blurhash = { version = "0.2.3", default-features = false }
 tsp_sdk = { git = "https://github.com/openwallet-foundation-labs/tsp.git", optional = true, features = ["async", "resolve"] }
 # tsp_sdk = { version = "0.8.0", optional = true, default-features = false, features = ["async", "resolve"] }
 quinn = { version = "0.11.8", default-features = false, optional = true }
+## We only include this such that we can specify the prebuilt-nasm features,
+## which is required to build this on Windows x86_64 without having to install NASM separately.
+aws-lc-rs ={ version = "1.13", optional = true, features = ["prebuilt-nasm"] }
 percent-encoding = { version = "2.3", optional = true }
 ## The following reqwest features were taken from the tsp_sdk's `Cargo.toml` file.
 ## I'm not sure if all of them are actually needed.
@@ -73,7 +76,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 [features]
 default = []
 ## Enables experimental support for using TSP wallets.
-tsp = ["dep:tsp_sdk", "dep:quinn", "dep:percent-encoding"]
+tsp = ["dep:tsp_sdk", "dep:quinn", "dep:aws-lc-rs", "dep:percent-encoding"]
 
 ## Hides the command prompt console on Windows.
 hide_windows_console = []

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1128,11 +1128,15 @@ impl Widget for RoomScreen {
         let is_pane_shown: bool;
         if loading_pane.is_currently_shown(cx) {
             is_pane_shown = true;
-            loading_pane.handle_event(cx, event, scope);
+            if is_interactive_hit {
+                loading_pane.handle_event(cx, event, scope);
+            }
         }
         else if user_profile_sliding_pane.is_currently_shown(cx) {
             is_pane_shown = true;
-            user_profile_sliding_pane.handle_event(cx, event, scope);
+            if is_interactive_hit {
+                user_profile_sliding_pane.handle_event(cx, event, scope);
+            }
         }
         else {
             is_pane_shown = false;

--- a/src/persistence/tsp_state.rs
+++ b/src/persistence/tsp_state.rs
@@ -3,10 +3,14 @@
 // Ignore clippy warnings in `DeRon` macro derive bodies.
 #![allow(clippy::question_mark)]
 
-use makepad_widgets::{makepad_micro_serde::*, *};
+use std::collections::BTreeMap;
+
+use makepad_widgets::*;
+use matrix_sdk::ruma::OwnedUserId;
+use serde::{Deserialize, Serialize};
 use crate::{app_data_dir, tsp::TspWalletMetadata};
 
-const TSP_STATE_FILE_NAME: &str = "tsp_state.ron";
+const TSP_STATE_FILE_NAME: &str = "tsp_state.json";
 
 const WALLETS_DIR_NAME: &str = "tsp_wallets";
 
@@ -20,7 +24,7 @@ pub fn tsp_wallets_dir() -> std::path::PathBuf {
 /// The TSP state that is saved to persistent storage.
 ///
 /// It contains metadata about all wallets that have been created or imported.
-#[derive(Clone, Default, Debug, DeRon, SerRon)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct SavedTspState {
     /// All wallets that have been created or imported into Robrix.
     ///
@@ -28,11 +32,19 @@ pub struct SavedTspState {
     pub wallets: Vec<TspWalletMetadata>,
     /// The index of the default wallet in `wallets`, if any.
     pub default_wallet: Option<usize>,
+    /// The default VID selected by the current user as the
+    /// public-facing identity for sending and receiving TSP messages.
+    /// This must be stored/present in the default wallet.
+    pub default_vid: Option<String>,
+    /// Known associations between other Matrix user IDs and their TSP DIDs.
+    pub associations: BTreeMap<OwnedUserId, String>,
 }
 impl SavedTspState {
     /// Returns true if this TSP state has any content.
     pub fn has_content(&self) -> bool {
-        !self.wallets.is_empty() || self.default_wallet.is_some()
+        !self.wallets.is_empty()
+            || self.default_wallet.is_some()
+            || self.default_vid.is_some()
     }
 }
 
@@ -46,19 +58,20 @@ pub async fn load_tsp_state() -> anyhow::Result<SavedTspState> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(SavedTspState::default()),
         Err(e) => return Err(e.into())
     };
-    SavedTspState::deserialize_ron(&content)
-        .map_err(|e| anyhow::Error::msg(e.msg))
+    serde_json::from_str(&content)
+        .map_err(anyhow::Error::msg)
 }
 
 /// Asynchronously save the current TSP state to persistent storage.
 pub async fn save_tsp_state_async(tsp_state: SavedTspState) -> anyhow::Result<()> {
     let path = app_data_dir().join(TSP_STATE_FILE_NAME);
     if tsp_state.has_content() {
-        tokio::fs::write(path, tsp_state.serialize_ron()).await?;
+        tokio::fs::write(path, serde_json::to_string(&tsp_state)?).await?;
     } else {
         // If the TSP state is empty, we must delete the existing file
         // such that we don't leave behind stale data.
-        tokio::fs::remove_file(path).await?;
+        // Ignore errors: if it doesn't exist or can't be removed, nothing we can do.
+        let _ = tokio::fs::remove_file(path).await;
     }
     log!("Successfully saved TSP state to persistent storage.");
     Ok(())

--- a/src/persistence/tsp_state.rs
+++ b/src/persistence/tsp_state.rs
@@ -46,6 +46,11 @@ impl SavedTspState {
             || self.default_wallet.is_some()
             || self.default_vid.is_some()
     }
+
+    pub fn num_wallets(&self) -> usize {
+        self.default_wallet.is_some() as usize
+            + self.wallets.len()
+    }
 }
 
 

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -111,15 +111,18 @@ live_design! {
     use crate::shared::avatar::*;
     use crate::shared::icon_button::*;
 
+    use link::tsp_link::TspVerifyUser;
+
     ICON_DOUBLE_CHAT = dep("crate://self/resources/icons/double_chat.svg")
 
     UserProfileView = <ScrollXYView> {
         width: Fill,
         height: Fill,
         align: {x: 0.5, y: 0},
-        padding: {left: 15., right: 15., top: 15.}
+        padding: {left: 15, right: 15, top: 15, bottom: 50}
         spacing: 20,
         flow: Down,
+        cursor: Default,
 
         show_bg: true,
         draw_bg: {
@@ -212,7 +215,7 @@ live_design! {
             width: Fill, height: Fit
             flow: Down,
             spacing: 10,
-            padding: {left: 10., right: 10, bottom: 50}
+            padding: {left: 10., right: 10, bottom: 10}
 
             <Label> {
                 width: Fill, height: Fit
@@ -290,6 +293,10 @@ live_design! {
                 }
             }
         }
+
+        // A view that allows the user to verify a new DID and associate it
+        // with a particular Matrix User ID.
+        tsp_verify_user = <TspVerifyUser> { }
     }
 
 
@@ -475,7 +482,7 @@ impl Widget for UserProfileSlidingPane {
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
                 Hit::FingerDown(_fde) => {
-                    cx.set_key_focus(area);
+                    // cx.set_key_focus(area);
                     false
                 }
                 Hit::FingerUp(fue) if fue.is_over => {
@@ -676,6 +683,14 @@ impl UserProfileSlidingPane {
                 info.avatar_state = AvatarState::Loaded(data);
             }
         }
+        
+        // If TSP is enabled, populate the TSP verification info for this user.
+        #[cfg(feature = "tsp")] {
+            use crate::tsp::verify_user::TspVerifyUserWidgetExt;
+            self.view.tsp_verify_user(id!(tsp_verify_user))
+                .show(_cx, info.user_id.clone());
+        }
+
         self.info = Some(info);
     }
 

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -313,8 +313,9 @@ live_design! {
             visible: false,
             show_bg: true
             draw_bg: {
+                uniform bg_color: #000000BB
                 fn pixel(self) -> vec4 {
-                    return vec4(0., 0., 0., 0.7)
+                    return self.bg_color;
                 }
             }
         }
@@ -355,13 +356,23 @@ live_design! {
                     redraw: true,
                     from: {all: Forward {duration: 0.4}}
                     ease: ExpDecay {d1: 0.80, d2: 0.97}
-                    apply: {main_content = { width: 300, draw_bg: {opacity: 1.0} }}
+                    apply: {
+                        main_content = { margin: {right: 0} },
+                        bg_view = {
+                            draw_bg: { bg_color: #000000BB }
+                        }
+                    }
                 }
                 hide = {
                     redraw: true,
                     from: {all: Forward {duration: 0.5}}
                     ease: ExpDecay {d1: 0.80, d2: 0.97}
-                    apply: {main_content = { width: 0, draw_bg: {opacity: 0.0} }}
+                    apply: {
+                        main_content = { margin: {right: -300} },
+                        bg_view = {
+                            draw_bg: { bg_color: #x00000000 }
+                        }
+                    }
                 }
             }
         }

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -493,7 +493,7 @@ impl Widget for UserProfileSlidingPane {
             || match event.hits_with_capture_overload(cx, area, true) {
                 Hit::KeyUp(key) => key.key_code == KeyCode::Escape,
                 Hit::FingerDown(_fde) => {
-                    // cx.set_key_focus(area);
+                    cx.set_key_focus(area);
                     false
                 }
                 Hit::FingerUp(fue) if fue.is_over => {

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -90,38 +90,9 @@ live_design! {
             text: "Your Display Name:"
         }
 
-        display_name_input = <RobrixTextInput> {
+        display_name_input = <SimpleTextInput> {
             margin: {top: 3, left: 5, right: 5, bottom: 8},
-            padding: 10,
             width: 216, height: Fit
-            flow: RightWrap,
-            draw_bg: {
-                color: (COLOR_SECONDARY)
-                border_radius: 2.0
-                border_size: 1.0
-
-                // TODO: determine these other colors below
-                color_hover: (COLOR_PRIMARY)
-                color_focus: (COLOR_PRIMARY)
-                color_down: (COLOR_PRIMARY)
-                color_empty: (COLOR_SECONDARY)
-                color_disabled: (COLOR_BG_DISABLED)
-
-                border_color: (COLOR_SECONDARY)
-                border_color_hover: (COLOR_ACTIVE_PRIMARY)
-                border_color_focus: (COLOR_ACTIVE_PRIMARY_DARKER)
-                border_color_down: (COLOR_ACTIVE_PRIMARY_DARKER)
-                border_color_disabled: (COLOR_FG_DISABLED)
-
-                border_color_2: (COLOR_SECONDARY)
-                border_color_2_hover: (COLOR_ACTIVE_PRIMARY)
-                border_color_2_focus: (COLOR_ACTIVE_PRIMARY_DARKER)
-                border_color_2_down: (COLOR_ACTIVE_PRIMARY_DARKER)
-                border_color_2_disabled: (COLOR_FG_DISABLED)
-            }
-            draw_text: {
-                wrap: Word,
-            }
             empty_text: "Add a display name..."
         }
 

--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -84,7 +84,7 @@ live_design! {
                         color: (COLOR_BG_DANGER_RED)
                     }
                     text: "Cancel"
-                    draw_text:{
+                    draw_text: {
                         color: (COLOR_FG_DANGER_RED),
                     }
                 }
@@ -104,7 +104,7 @@ live_design! {
                         color: (COLOR_BG_ACCEPT_GREEN)
                     }
                     text: "Confirm"
-                    draw_text:{
+                    draw_text: {
                         color: (COLOR_FG_ACCEPT_GREEN),
                     }
                 }

--- a/src/shared/restore_status_view.rs
+++ b/src/shared/restore_status_view.rs
@@ -14,7 +14,6 @@ live_design! {
     use crate::shared::styles::*;
 
     pub RestoreStatusView = {{RestoreStatusView}} {
-        visible: false,
         width: Fill, height: Fill,
         flow: Down,
         align: {x: 0.5, y: 0.5},
@@ -91,8 +90,7 @@ impl RestoreStatusViewRef {
     ///
     /// The `room_name` parameter is used to fill in the room name in the error message.
     pub fn set_content(&self, cx: &mut Cx, all_rooms_loaded: bool, room_name: &str) {
-        let Some(mut inner) = self.borrow_mut() else { return };
-        inner.view.set_visible(cx, true);
+        let Some(inner) = self.borrow() else { return };      
         let restore_status_spinner = inner.view.view(id!(restore_status_spinner));
         let restore_status_label = inner.view.label(id!(restore_status_label));
         if all_rooms_loaded {

--- a/src/shared/restore_status_view.rs
+++ b/src/shared/restore_status_view.rs
@@ -14,6 +14,7 @@ live_design! {
     use crate::shared::styles::*;
 
     pub RestoreStatusView = {{RestoreStatusView}} {
+        visible: false,
         width: Fill, height: Fill,
         flow: Down,
         align: {x: 0.5, y: 0.5},
@@ -90,7 +91,8 @@ impl RestoreStatusViewRef {
     ///
     /// The `room_name` parameter is used to fill in the room name in the error message.
     pub fn set_content(&self, cx: &mut Cx, all_rooms_loaded: bool, room_name: &str) {
-        let Some(inner) = self.borrow() else { return };      
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.view.set_visible(cx, true);
         let restore_status_spinner = inner.view.view(id!(restore_status_spinner));
         let restore_status_label = inner.view.label(id!(restore_status_label));
         if all_rooms_loaded {

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -199,30 +199,63 @@ live_design! {
             uniform color_empty_focus: #B,
 
             fn get_color(self) -> vec4 {
-                return
+                return mix(
                     mix(
                         mix(
                             mix(
+                                self.color,
                                 mix(
-                                    self.color,
-                                    mix(
-                                        self.color_hover,
-                                        self.color_down,
-                                        self.down
-                                    ),
-                                    self.hover
+                                    self.color_hover,
+                                    self.color_down,
+                                    self.down
                                 ),
-                                self.color_focus,
-                                self.focus
+                                self.hover
                             ),
-                            self.color_empty,
-                            self.empty
+                            self.color_focus,
+                            self.focus
                         ),
-                        self.color_disabled,
-                        self.disabled
-                    )
+                        self.color_empty,
+                        self.empty
+                    ),
+                    self.color_disabled,
+                    self.disabled
+                )
             }
         }
+    }
+
+    pub SimpleTextInput = <RobrixTextInput> {
+        padding: 10,
+        width: Fill, height: Fit
+        flow: RightWrap,
+        draw_bg: {
+            color: (COLOR_SECONDARY)
+            border_radius: 2.0
+            border_size: 1.0
+
+            // TODO: determine these other colors below
+            color_hover: (COLOR_PRIMARY)
+            color_focus: (COLOR_PRIMARY)
+            color_down: (COLOR_PRIMARY)
+            color_empty: (COLOR_SECONDARY)
+            color_disabled: (COLOR_BG_DISABLED)
+
+            border_color: (COLOR_SECONDARY)
+            border_color_hover: (COLOR_ACTIVE_PRIMARY)
+            border_color_focus: (COLOR_ACTIVE_PRIMARY_DARKER)
+            border_color_down: (COLOR_ACTIVE_PRIMARY_DARKER)
+            border_color_disabled: (COLOR_FG_DISABLED)
+
+            border_color_2: (COLOR_SECONDARY)
+            border_color_2_hover: (COLOR_ACTIVE_PRIMARY)
+            border_color_2_focus: (COLOR_ACTIVE_PRIMARY_DARKER)
+            border_color_2_down: (COLOR_ACTIVE_PRIMARY_DARKER)
+            border_color_2_disabled: (COLOR_FG_DISABLED)
+        }
+        draw_text: {
+            wrap: Word,
+        }
+        empty_text: "Add a display name..."
     }
 }
 

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2285,7 +2285,8 @@ async fn timeline_subscriber_handler(
     let mut found_target_event_id: Option<(usize, OwnedEventId)> = None;
 
     loop { tokio::select! {
-        // we must check for new requests before handling new timeline updates.
+        // we should check for new requests before handling new timeline updates,
+        // because the request might influence how we handle a timeline update.
         biased;
 
         // Handle updates to the current backwards pagination requests.

--- a/src/tsp/create_did_modal.rs
+++ b/src/tsp/create_did_modal.rs
@@ -416,7 +416,7 @@ impl WidgetMatchEvent for CreateDidModal {
 
         for action in actions {
             match action.downcast_ref() {
-                Some(tsp::TspWalletAction::DidCreationResult(Ok(did)))=> {
+                Some(tsp::TspIdentityAction::DidCreationResult(Ok(did)))=> {
                     self.state = CreateDidModalState::IdentityCreated;
                     self.is_showing_error = false;
                     let message = format!("Successfully created and published DID: \"{}\"", did);
@@ -445,7 +445,7 @@ impl WidgetMatchEvent for CreateDidModal {
 
                 // Upon an error, update the status label and disable the accept button.
                 // Re-enable the input fields so the user can change the input values to try again.
-                Some(tsp::TspWalletAction::DidCreationResult(Err(e)))=> {
+                Some(tsp::TspIdentityAction::DidCreationResult(Err(e)))=> {
                     self.state = CreateDidModalState::IdentityCreationError;
                     self.is_showing_error = true;
                     let message = format!("Failed to create DID: {e}");

--- a/src/tsp/create_did_modal.rs
+++ b/src/tsp/create_did_modal.rs
@@ -366,7 +366,7 @@ impl WidgetMatchEvent for CreateDidModal {
                             alias,
                             server,
                             did_server
-                        }).unwrap();
+                        });
 
                         self.state = CreateDidModalState::WaitingForIdentityCreation;
                         self.is_showing_error = false;

--- a/src/tsp/create_wallet_modal.rs
+++ b/src/tsp/create_wallet_modal.rs
@@ -329,7 +329,7 @@ impl WidgetMatchEvent for CreateWalletModal {
                             password,
                         };
                         // Submit the wallet creation request to the TSP async worker thread.
-                        tsp::submit_tsp_request(tsp::TspRequest::CreateWallet { metadata }).unwrap();
+                        tsp::submit_tsp_request(tsp::TspRequest::CreateWallet { metadata });
                         self.state = CreateWalletModalState::WaitingForWalletCreation;
                         self.is_showing_error = false;
                         status_label.apply_over(cx, live!(

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1149,6 +1149,8 @@ impl TspWalletSqliteUrl {
     pub fn to_url_encoded(&self) -> Cow<'_, str> {
         const DELIMITER_ABS: &str = ":///";
         const DELIMITER_REG: &str = "://";
+        const SEPARATOR: &str = "/";
+        const SEPARATOR_PE: &str = "%2F";
 
         let try_encode = |delim: &str| -> Option<String> {
             if let Some(idx) = self.0.find(delim) {
@@ -1158,6 +1160,9 @@ impl TspWalletSqliteUrl {
                 for component in Path::new(after).components() {
                     log!("### Got path component: {component:?}, as_os_str(): {}", component.as_os_str().to_string_lossy());
                     match component {
+                        std::path::Component::Prefix(prefix) => {
+                            after_encoded = format!("{}{}{}", after_encoded, SEPARATOR, prefix.as_os_str().to_string_lossy());
+                        }
                         std::path::Component::RootDir => {
                             // ignore, since we manually add '/' between components.
                         }
@@ -1166,10 +1171,10 @@ impl TspWalletSqliteUrl {
                                 p.as_encoded_bytes(),
                                 percent_encoding::NON_ALPHANUMERIC
                             );
-                            after_encoded = format!("{}/{}", after_encoded, percent_encoded);
+                            after_encoded = format!("{}{}{}", after_encoded, SEPARATOR_PE, percent_encoded);
                         }
                         other => {
-                            after_encoded = format!("{}/{}", after_encoded, other.as_os_str().to_string_lossy());
+                            after_encoded = format!("{}{}{}", after_encoded, SEPARATOR_PE, other.as_os_str().to_string_lossy());
                         }
                     }
                 }

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1185,7 +1185,6 @@ impl TspWalletSqliteUrl {
                 let after  = self.0.get((idx + delim.len()) ..).unwrap_or("");
                 let mut after_encoded = String::new();
                 for component in Path::new(after).components() {
-                    log!("### Got path component: {component:?}, as_os_str(): {}", component.as_os_str().to_string_lossy());
                     match component {
                         std::path::Component::Prefix(prefix) => {
                             // Windows drive prefixes must not be percent-encoded.

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1022,11 +1022,8 @@ async fn respond_to_did_association_request(
     wallet_db: &AsyncSecureStore,
     accepted: bool,
 ) -> Result<(), anyhow::Error> {
-    if wallet_db.has_verified_vid(&details.initiating_vid)? {
-        anyhow::bail!("Verification requestor's initiating DID {} already exists in your wallet.", details.initiating_vid);
-    }
     wallet_db.verify_vid(&details.initiating_vid, Some(details.initiating_user_id.to_string())).await?;
-    log!("Verification requestor's initiating DID {} was verified and added to your wallet.", details.initiating_vid);
+    log!("Verification requester's initiating DID {} was verified and added to your wallet.", details.initiating_vid);
 
     let response_msg = TspMessage::VerificationResponse {
         details: details.clone(),

--- a/src/tsp/mod.rs
+++ b/src/tsp/mod.rs
@@ -1149,7 +1149,10 @@ impl TspWalletSqliteUrl {
     pub fn to_url_encoded(&self) -> Cow<'_, str> {
         const DELIMITER_ABS: &str = ":///";
         const DELIMITER_REG: &str = "://";
+        /// SQLite requires Unix-style path separators.
         const SEPARATOR: &str = "/";
+        /// The percent-encoded version of the separator,
+        /// which can be used everywhere except for prefixes.
         const SEPARATOR_PE: &str = "%2F";
 
         let try_encode = |delim: &str| -> Option<String> {
@@ -1161,10 +1164,11 @@ impl TspWalletSqliteUrl {
                     log!("### Got path component: {component:?}, as_os_str(): {}", component.as_os_str().to_string_lossy());
                     match component {
                         std::path::Component::Prefix(prefix) => {
+                            // Windows drive prefixes must not be percent-encoded.
                             after_encoded = format!("{}{}{}", after_encoded, SEPARATOR, prefix.as_os_str().to_string_lossy());
                         }
                         std::path::Component::RootDir => {
-                            // ignore, since we manually add '/' between components.
+                            // ignore, since we already manually add '/' between components.
                         }
                         std::path::Component::Normal(p) => {
                             let percent_encoded = percent_encoding::percent_encode(

--- a/src/tsp/tsp_settings_screen.rs
+++ b/src/tsp/tsp_settings_screen.rs
@@ -334,7 +334,7 @@ impl MatchEvent for TspSettingsScreen {
         // | Some(TspWalletAction::SentDidAssociationRequest { .. }) // handled in the TspVerifyUser widget
         // | Some(TspWalletAction::ErrorSendingDidAssociationRequest { .. }) // handled in the TspVerifyUser widget
         // | Some(TspWalletAction::ReceivedDidAssociationResponse { .. }) // handled in the TspVerifyUser widget
-        // | Some(TspWalletAction::ReceivedDidAssociationRequest(_)) // handled in the TspVerifyUser widget
+        // | Some(TspWalletAction::ReceivedDidAssociationRequest(_)) // handled in the TspVerificationModal widget
         // | Some(TspWalletAction::ReceiveLoopError { .. }) // handled in the top-level app
 
         if self.view.button(id!(create_wallet_button)).clicked(actions) {

--- a/src/tsp/tsp_settings_screen.rs
+++ b/src/tsp/tsp_settings_screen.rs
@@ -278,7 +278,7 @@ impl MatchEvent for TspSettingsScreen {
                         // The user should then select another wallet as the default.
                         enqueue_popup_notification(PopupItem {
                             message: String::from("The default wallet was removed.\n\n\
-                                TSP wallet-related features will not work properly until you set a default wallet."),
+                                TSP features will not work properly until you set a default wallet."),
                             auto_dismissal_duration: None,
                             kind: PopupKind::Warning,
                         });

--- a/src/tsp/tsp_settings_screen.rs
+++ b/src/tsp/tsp_settings_screen.rs
@@ -327,10 +327,15 @@ impl MatchEvent for TspSettingsScreen {
                 }
 
                 Some(TspWalletAction::CreateWalletError { .. }) // handled in the CreateWalletModal
-                | Some(TspWalletAction::DidCreationResult(_)) // handled in the CreateDidModal
                 | None => { }
             }
         }
+
+        // | Some(TspWalletAction::SentDidAssociationRequest { .. }) // handled in the TspVerifyUser widget
+        // | Some(TspWalletAction::ErrorSendingDidAssociationRequest { .. }) // handled in the TspVerifyUser widget
+        // | Some(TspWalletAction::ReceivedDidAssociationResponse { .. }) // handled in the TspVerifyUser widget
+        // | Some(TspWalletAction::ReceivedDidAssociationRequest(_)) // handled in the TspVerifyUser widget
+        // | Some(TspWalletAction::ReceiveLoopError { .. }) // handled in the top-level app
 
         if self.view.button(id!(create_wallet_button)).clicked(actions) {
             cx.action(CreateWalletModalAction::Open);

--- a/src/tsp/tsp_verification_modal.rs
+++ b/src/tsp/tsp_verification_modal.rs
@@ -302,6 +302,7 @@ impl WidgetMatchEvent for TspVerificationModal {
                     }
                     cancel_button.set_visible(cx, false);
                     accept_button.apply_over(cx, live!(
+                        enabled: true,
                         text: "Okay",
                         draw_bg: {
                             color: (COLOR_ACTIVE_PRIMARY),

--- a/src/tsp/tsp_verification_modal.rs
+++ b/src/tsp/tsp_verification_modal.rs
@@ -1,0 +1,371 @@
+
+use makepad_widgets::*;
+use tsp_sdk::AsyncSecureStore;
+
+use crate::{shared::styles::*, sliding_sync::current_user_id, tsp::{submit_tsp_request, TspRequest, TspVerificationDetails}};
+
+live_design! {
+    use link::theme::*;
+    use link::widgets::*;
+
+    use crate::shared::styles::*;
+    use crate::shared::icon_button::RobrixIconButton;
+
+    pub TspVerificationModal = {{TspVerificationModal}} {
+        width: Fit
+        height: Fit
+
+        <RoundedView> {
+            flow: Down
+            width: 400
+            height: Fit
+            padding: {top: 25, right: 30 bottom: 30 left: 45}
+            spacing: 10
+
+            show_bg: true
+            draw_bg: {
+                color: #fff
+                border_radius: 3.0
+            }
+
+            title = <View> {
+                width: Fill,
+                height: Fit,
+                flow: Right
+                padding: {top: 0, bottom: 40}
+                align: {x: 0.5, y: 0.0}
+
+                <Label> {
+                    text: "TSP Verification Request"
+                    draw_text: {
+                        text_style: <TITLE_TEXT>{font_size: 13},
+                        color: #000
+                    }
+                }
+            }
+
+            body = <View> {
+                width: Fill,
+                height: Fit,
+                flow: Down,
+                spacing: 40,
+
+                prompt = <Label> {
+                    width: Fill
+                    draw_text: {
+                        text_style: <REGULAR_TEXT>{
+                            font_size: 11.5,
+                        },
+                        color: #000
+                        wrap: Word
+                    }
+                }
+
+                <View> {
+                    width: Fill, height: Fit
+                    flow: Right,
+                    align: {x: 1.0, y: 0.5}
+                    spacing: 20
+
+                    cancel_button = <RobrixIconButton> {
+                        align: {x: 0.5, y: 0.5}
+                        padding: 15,
+                        draw_icon: {
+                            svg_file: (ICON_FORBIDDEN)
+                            color: (COLOR_FG_DANGER_RED),
+                        }
+                        icon_walk: {width: 16, height: 16, margin: {left: -2, right: -1} }
+        
+                        draw_bg: {
+                            border_color: (COLOR_FG_DANGER_RED),
+                            color: (COLOR_BG_DANGER_RED)
+                        }
+                        text: "Ignore Request"
+                        draw_text:{
+                            color: (COLOR_FG_DANGER_RED),
+                        }
+                    }
+
+                    accept_button = <RobrixIconButton> {
+                        align: {x: 0.5, y: 0.5}
+                        padding: 15,
+                        draw_icon: {
+                            svg_file: (ICON_CHECKMARK)
+                            color: (COLOR_FG_ACCEPT_GREEN),
+                        }
+                        icon_walk: {width: 16, height: 16, margin: {left: -2, right: -1} }
+        
+                        draw_bg: {
+                            border_color: (COLOR_FG_ACCEPT_GREEN),
+                            color: (COLOR_BG_ACCEPT_GREEN)
+                        }
+                        text: "Accept Request"
+                        draw_text:{
+                            color: (COLOR_FG_ACCEPT_GREEN),
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct TspVerificationModal {
+    #[deref] view: View,
+    #[rust] state: TspVerificationModalState,
+}
+
+#[derive(Default)]
+enum TspVerificationModalState {
+    #[default]
+    Initial,
+    ReceivedRequest {
+        details: TspVerificationDetails,
+        wallet_db: AsyncSecureStore,
+    },
+    RequestAccepted {
+        details: TspVerificationDetails,
+        wallet_db: AsyncSecureStore,
+    },
+    RequestVerified,
+    RequestDeclined,
+}
+impl TspVerificationModalState {
+    fn details(&self) -> Option<&TspVerificationDetails> {
+        match self {
+            TspVerificationModalState::ReceivedRequest { details, .. }
+            | TspVerificationModalState::RequestAccepted { details, .. } => Some(details),
+            _ => None,
+        }
+    }
+}
+
+/// Actions emitted by or send to the `TspVerificationModal`.
+#[derive(Debug)]
+pub enum TspVerificationModalAction {
+    /// Emitted by the `TspVerificationModal` when it should be closed by its parent widget.
+    Close,
+    /// The result of sending a DID association response.
+    /// This action is sent from the background TSP worker task.
+    SentDidAssociationResponse {
+        details: TspVerificationDetails,
+        result: Result<(), anyhow::Error>,
+    },
+}
+
+impl Widget for TspVerificationModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for TspVerificationModal {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        let accept_button = self.button(id!(accept_button));
+        let cancel_button = self.button(id!(cancel_button));
+
+        let cancel_button_clicked = cancel_button.clicked(actions);
+        let modal_dismissed = actions
+            .iter()
+            .any(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)));
+
+        if cancel_button_clicked || modal_dismissed {
+            match &self.state {
+                TspVerificationModalState::ReceivedRequest { details, wallet_db }
+                | TspVerificationModalState::RequestAccepted { details, wallet_db } => {
+                    submit_tsp_request(TspRequest::RespondToDidAssociationRequest {
+                        details: details.clone(),
+                        wallet_db: wallet_db.clone(),
+                        accepted: false,
+                    });
+                }
+                _ => {}
+            }
+
+            // If the modal was dismissed by clicking outside of it, we MUST NOT emit
+            // a `TspVerificationModalAction::Close` action, as that would cause
+            // an infinite action feedback loop.
+            if !modal_dismissed {
+                cx.action(TspVerificationModalAction::Close);
+            }
+            return;
+        }
+
+        let prompt_label = self.view.label(id!(prompt));
+        if accept_button.clicked(actions) {
+            let current_state = std::mem::take(&mut self.state);
+            let new_state: TspVerificationModalState;
+            match current_state {
+                TspVerificationModalState::ReceivedRequest { details, wallet_db } => {
+                    // Here, we need to confirm that the receiving VID (our VID) is actually in
+                    // the wallet. If not, we need to show an error instructing the user
+                    // to add that VID to their wallet first and then retry the verification process.
+                    // Then, we need to send a negative response to the initiator of the request.
+                    let error_text = if !wallet_db.has_private_vid(&details.responding_vid).is_ok_and(|v| v) {
+                        Some(format!(
+                            "Error: the VID \"{}\" was not found in your current wallet.\n\n\
+                            Either the requestor has the wrong VID for you, or you have not yet added that VID to your wallet.\n\n\
+                            Once you have addressed this, please retry the verification process again.",
+                            details.responding_vid
+                        ))
+                    } else if current_user_id().as_ref() != Some(&details.responding_user_id) {
+                        Some(format!(
+                            "Error: the verification request was intended for Matrix User ID \"{}\", \
+                            but you are not logged in as that user.\n\n\
+                            Either the requestor has the wrong Matrix ID for you, or you are logged into a different account.\n\n\
+                            Once you have addressed this, please retry the verification process again.",
+                            details.responding_user_id
+                        ))
+                    } else {
+                        None
+                    };
+                    if let Some(error_text) = error_text {
+                        prompt_label.set_text(cx, &error_text);
+                        submit_tsp_request(TspRequest::RespondToDidAssociationRequest {
+                            details: details.clone(),
+                            wallet_db: wallet_db.clone(),
+                            accepted: false,
+                        });
+                        cancel_button.set_visible(cx, false);
+                        accept_button.apply_over(cx, live!(
+                            text: "Okay",
+                            draw_bg: {
+                                color: (COLOR_ACTIVE_PRIMARY),
+                            },
+                            draw_icon: {
+                                color: (COLOR_PRIMARY),
+                            }
+                            draw_text: {
+                                color: (COLOR_PRIMARY),
+                            },
+                        ));
+                        new_state = TspVerificationModalState::RequestDeclined;
+                    }
+                    else {
+                        let prompt = format!("You have accepted the TSP verification request.\n\n\
+                            Please confirm that the following code matches for both users:\n\n\
+                            Code: \"{}\"\n",
+                            details.random_str,
+                        );
+                        prompt_label.set_text(cx, &prompt);
+                        accept_button.set_text(cx, "Yes, they match!");
+                        new_state = TspVerificationModalState::RequestAccepted { details, wallet_db };
+                    }
+                }
+
+                TspVerificationModalState::RequestAccepted { details, wallet_db } => {
+                    submit_tsp_request(TspRequest::RespondToDidAssociationRequest {
+                        details: details.clone(),
+                        wallet_db: wallet_db.clone(),
+                        accepted: true,
+                    });
+                    let prompt_text = "You have confirmed the TSP verification request.\n\nSending a response now...";
+                    prompt_label.set_text(cx, prompt_text);
+                    accept_button.set_enabled(cx, false);
+                    // stay in this same state until we get an acknowledgment back 
+                    // that we sent the response (the `SentDidAssociationResponse` action).
+                    new_state = TspVerificationModalState::RequestAccepted { details, wallet_db };
+                }
+
+                TspVerificationModalState::Initial
+                | TspVerificationModalState::RequestDeclined
+                | TspVerificationModalState::RequestVerified => {
+                    cx.action(TspVerificationModalAction::Close);
+                    return;
+                }
+            }
+            self.state = new_state;
+        }
+
+        for action in actions {
+            match action.downcast_ref() {
+                Some(TspVerificationModalAction::SentDidAssociationResponse { details, result }) 
+                    if self.state.details().is_some_and(|d| d == details) =>
+                {
+                    match result {
+                        Ok(()) => {
+                            self.label(id!(prompt)).set_text(cx, "The TSP verification process has completed successfully.\n\nYou may now close this.");
+                            self.state = TspVerificationModalState::RequestVerified;
+                        }
+                        Err(e) => {
+                            self.label(id!(prompt)).set_text(cx, &format!("Error: failed to complete the TSP verification process:\n\n{e}"));
+                            self.state = TspVerificationModalState::RequestDeclined;
+                        }
+                    }
+                    cancel_button.set_visible(cx, false);
+                    accept_button.apply_over(cx, live!(
+                        text: "Okay",
+                        draw_bg: {
+                            color: (COLOR_ACTIVE_PRIMARY),
+                        },
+                        draw_icon: {
+                            color: (COLOR_PRIMARY),
+                        }
+                        draw_text: {
+                            color: (COLOR_PRIMARY),
+                        }
+                    ));
+                    self.redraw(cx);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl TspVerificationModal {
+    fn initialize_with_details(
+        &mut self,
+        cx: &mut Cx,
+        details: TspVerificationDetails,
+        wallet_db: AsyncSecureStore,
+    ) {
+        log!("Initializing TSP verification modal with: {:?}", details);
+        let prompt_text = format!("Matrix User \"{}\" is requesting to verify your identity via TSP.\n\
+            Their TSP identity is: \"{}\".\n\n\
+            They want to verify your TSP identity \"{}\" associated with Matrix User ID \"{}\".\n\n\
+            If you recognize these details, would you like to accept this request?",
+            details.initiating_user_id,
+            details.initiating_vid,
+            details.responding_vid,
+            details.responding_user_id,
+        );
+        self.label(id!(prompt)).set_text(cx, &prompt_text);
+
+        let accept_button = self.button(id!(accept_button));
+        let cancel_button = self.button(id!(cancel_button));
+        accept_button.set_text(cx, "Accept Request");
+        accept_button.set_enabled(cx, true);
+        accept_button.set_visible(cx, true);
+        accept_button.reset_hover(cx);
+        cancel_button.set_text(cx, "Ignore (Decline)");
+        cancel_button.set_enabled(cx, true);
+        cancel_button.set_visible(cx, true);
+        cancel_button.reset_hover(cx);
+
+        self.state = TspVerificationModalState::ReceivedRequest {
+            details,
+            wallet_db,
+        };
+    }
+}
+
+impl TspVerificationModalRef {
+    /// Initialize this modal with the details of a TSP verification request.
+    pub fn initialize_with_details(
+        &self,
+        cx: &mut Cx, 
+        details: TspVerificationDetails,
+        wallet_db: AsyncSecureStore,
+    ) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.initialize_with_details(cx, details, wallet_db);
+        }
+    }
+}

--- a/src/tsp/tsp_verification_modal.rs
+++ b/src/tsp/tsp_verification_modal.rs
@@ -5,6 +5,8 @@ use tsp_sdk::AsyncSecureStore;
 use crate::{shared::styles::*, sliding_sync::current_user_id, tsp::{submit_tsp_request, TspRequest, TspVerificationDetails}};
 
 live_design! {
+    link tsp_enabled
+
     use link::theme::*;
     use link::widgets::*;
 

--- a/src/tsp/verify_user.rs
+++ b/src/tsp/verify_user.rs
@@ -179,7 +179,7 @@ impl MatchEvent for TspVerifyUser {
                     kind: PopupKind::Error,
                 });
             } else if let Some(user_id) = self.user_id.clone() {
-                let _ = submit_tsp_request(TspRequest::AssociateDidWithUserId { did, user_id });
+                submit_tsp_request(TspRequest::AssociateDidWithUserId { did, user_id });
                 verify_user_button.set_enabled(cx, false);
                 verify_user_button.set_text(cx, "Sending request...");
             }
@@ -244,7 +244,7 @@ impl TspVerifyUser {
             TspVerifiedInfo::Verified { did } => {
                 verified_tsp_view.set_visible(cx, true);
                 unverified_tsp_view.set_visible(cx, false);
-                verified_tsp_view.text_input(id!(tsp_did_read_only_input)).set_text(cx, &did);
+                verified_tsp_view.text_input(id!(tsp_did_read_only_input)).set_text(cx, did);
             }
             TspVerifiedInfo::Unverified => {
                 verified_tsp_view.set_visible(cx, false);

--- a/src/tsp/verify_user.rs
+++ b/src/tsp/verify_user.rs
@@ -1,0 +1,279 @@
+use makepad_widgets::*;
+use matrix_sdk::ruma::OwnedUserId;
+
+use crate::{shared::popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, tsp::{submit_tsp_request, tsp_state_ref, TspIdentityAction, TspRequest}};
+
+live_design! {
+    link tsp_enabled
+
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+
+    use crate::shared::helpers::*;
+    use crate::shared::styles::*;
+    use crate::shared::avatar::*;
+    use crate::shared::icon_button::*;
+
+    // A view that allows the user to verify a new DID and associate it
+    // with a particular Matrix User ID.
+    // This is currently shown as part of the UserProfileSlidingPane.
+    pub TspVerifyUser = {{TspVerifyUser}} {
+        width: Fill, height: Fit
+        flow: Down
+        spacing: 20,
+
+        <LineH> { padding: 15 }
+
+        <View> {
+            width: Fill, height: Fit
+            flow: Down
+            spacing: 10
+            padding: { left: 10, right: 10, bottom: 10}
+
+            <Label> {
+                width: Fill, height: Fit
+                draw_text: {
+                    wrap: Word,
+                    text_style: <USERNAME_TEXT_STYLE>{ font_size: 11.5 },
+                    color: #000
+                }
+                text: "TSP User Verification"
+            }
+
+            // Content shown when this user has been verified via TSP.
+            verified_tsp = <View> {
+                visible: false,
+                width: Fill, height: Fit
+                flow: Down,
+                spacing: 10,
+                // margin: { left: 7 }
+
+                <Label> {
+                    width: Fill, height: Fit
+                    draw_text: {
+                        wrap: Line,
+                        color: (COLOR_FG_ACCEPT_GREEN),
+                        text_style: <MESSAGE_TEXT_STYLE>{ font_size: 11 },
+                    }
+                    text: "✅ Verified via TSP"
+                }
+
+                tsp_did_read_only_input = <SimpleTextInput> {
+                    is_read_only: true
+                }
+
+                remove_tsp_association_button = <RobrixIconButton> {
+                    padding: {top: 10, bottom: 10, left: 12, right: 15}
+                    draw_bg: {
+                        border_color: (COLOR_FG_DANGER_RED),
+                        color: (COLOR_BG_DANGER_RED)
+                    }
+                    draw_icon: {
+                        svg_file: (ICON_CLOSE)
+                        color: (COLOR_FG_DANGER_RED),
+                    }
+                    draw_text: {
+                        color: (COLOR_FG_DANGER_RED),
+                        text_style: <REGULAR_TEXT> {}
+                    }
+                    icon_walk: {width: 22, height: 16, margin: {left: -5, right: -3, top: 1, bottom: -1} }
+                    text: "Remove TSP Association"
+                }
+            }
+
+
+            // Content shown when this user has NOT been verified via TSP.
+            unverified_tsp = <View> {
+                visible: true,
+                width: Fill, height: Fit
+                flow: Down,
+                spacing: 10,
+                // margin: { left: 7 }
+
+                <Label> {
+                    width: Fill, height: Fit
+                    flow: RightWrap,
+                    draw_text: {
+                        wrap: Word,
+                        color: (MESSAGE_TEXT_COLOR),
+                        text_style: <MESSAGE_TEXT_STYLE>{ font_size: 11 },
+                    }
+                    text: "Interactively verify this user by associating their TSP identity (DID) with their Matrix User ID:"
+                }
+
+                tsp_did_input = <SimpleTextInput> {
+                    empty_text: "Enter their TSP DID..."
+                }
+
+                verify_user_button = <RobrixIconButton> {
+                    padding: {top: 10, bottom: 10, left: 12, right: 15}
+                    draw_bg: {
+                        border_color: (COLOR_FG_ACCEPT_GREEN),
+                        color: (COLOR_BG_ACCEPT_GREEN)
+                    }
+                    draw_icon: {
+                        svg_file: (ICON_CHECKMARK)
+                        color: (COLOR_FG_ACCEPT_GREEN),
+                    }
+                    draw_text: {
+                        color: (COLOR_FG_ACCEPT_GREEN)
+                        text_style: <REGULAR_TEXT> {}
+                    }
+                    icon_walk: {width: 22, height: 16, margin: {left: -5, right: -3, top: 1, bottom: -1} }
+                    text: "Verify this user via TSP"
+                }
+            }
+        }
+    }
+}
+
+/// Whether another user has been verified using TSP.
+#[derive(Default)]
+pub enum TspVerifiedInfo {
+    #[default]
+    Unverified,
+    Verified {
+        did: String,
+    },
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct TspVerifyUser {
+    #[deref] view: View,
+    /// The Matrix User ID of the other user that we want to verify.
+    #[rust] user_id: Option<OwnedUserId>,
+    /// Info about whether the other user has or has not been verified via TSP.
+    #[rust] verified_info: TspVerifiedInfo,
+}
+
+impl Widget for TspVerifyUser {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.match_event(cx, event);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+impl MatchEvent for TspVerifyUser {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
+        if self.view.button(id!(remove_tsp_association_button)).clicked(actions) {
+            enqueue_popup_notification(PopupItem {
+                message: "Removing a TSP association is not yet implemented".into(),
+                auto_dismissal_duration: Some(5.0),
+                kind: PopupKind::Warning,
+            });
+        }
+
+        let verify_user_button = self.view.button(id!(verify_user_button));
+        if verify_user_button.clicked(actions) {
+            let did_input = self.view.view(id!(tsp_did_input));
+            let did = did_input.text().trim().to_string();
+            log!("verify_user_button was clicked. DID: {}", did);
+            if did.is_empty() {
+                enqueue_popup_notification(PopupItem {
+                    message: "Please enter a valid TSP DID to verify this user.".into(),
+                    auto_dismissal_duration: Some(5.0),
+                    kind: PopupKind::Error,
+                });
+            } else if let Some(user_id) = self.user_id.clone() {
+                let _ = submit_tsp_request(TspRequest::AssociateDidWithUserId { did, user_id });
+                verify_user_button.set_enabled(cx, false);
+                verify_user_button.set_text(cx, "Sending request...");
+            }
+        }
+
+        for action in actions {
+            match action.downcast_ref() {
+                Some(TspIdentityAction::SentDidAssociationRequest { user_id, .. })
+                    if Some(user_id) == self.user_id.as_ref() =>
+                {
+                    verify_user_button.set_text(cx, "Sent request!");
+                    enqueue_popup_notification(PopupItem {
+                        message: format!("Sent TSP verification request.\n\nWaiting for \"{user_id}\" to respond..."),
+                        auto_dismissal_duration: Some(5.0),
+                        kind: PopupKind::Info,
+                    });
+                }
+                Some(TspIdentityAction::ErrorSendingDidAssociationRequest { user_id, error, .. })
+                    if Some(user_id) == self.user_id.as_ref() =>
+                {
+                    verify_user_button.set_enabled(cx, true);
+                    verify_user_button.set_text(cx, "Verify this user via TSP");
+                    enqueue_popup_notification(PopupItem {
+                        message: format!("Error sending TSP verification request to \"{user_id}\": {error}"),
+                        auto_dismissal_duration: None,
+                        kind: PopupKind::Error,
+                    });
+                }
+                Some(TspIdentityAction::ReceivedDidAssociationResponse { did, user_id, accepted })
+                    if Some(user_id) == self.user_id.as_ref() =>
+                {
+                    if *accepted {
+                        enqueue_popup_notification(PopupItem {
+                            message: format!("User \"{user_id}\" accepted your TSP verification request."),
+                            auto_dismissal_duration: None,
+                            kind: PopupKind::Success,
+                        });
+                        self.verified_info = TspVerifiedInfo::Verified { did: did.clone() };
+                    } else {
+                        enqueue_popup_notification(PopupItem {
+                            message: format!("User \"{user_id}\" rejected your TSP verification request."),
+                            auto_dismissal_duration: None,
+                            kind: PopupKind::Warning,
+                        });
+                    }
+                    // Repopulate the content of this widget.
+                    self.refresh_from_verified_info(cx);
+                    self.redraw(cx);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl TspVerifyUser {
+    /// Repopulates this widget's UI content from its inner verified info.
+    fn refresh_from_verified_info(&mut self, cx: &mut Cx) {
+        let verified_tsp_view = self.view.view(id!(verified_tsp));
+        let unverified_tsp_view = self.view.view(id!(unverified_tsp));
+        match &self.verified_info {
+            TspVerifiedInfo::Verified { did } => {
+                verified_tsp_view.set_visible(cx, true);
+                unverified_tsp_view.set_visible(cx, false);
+                verified_tsp_view.text_input(id!(tsp_did_read_only_input)).set_text(cx, &did);
+            }
+            TspVerifiedInfo::Unverified => {
+                verified_tsp_view.set_visible(cx, false);
+                unverified_tsp_view.set_visible(cx, true);
+                unverified_tsp_view.text_input(id!(tsp_did_input)).set_text(cx, "");
+                let verify_user_button = unverified_tsp_view.button(id!(verify_user_button));
+                verify_user_button.set_enabled(cx, true);
+                verify_user_button.set_text(cx, "Verify this user via TSP");
+            }
+        }
+    }
+
+    fn show(&mut self, cx: &mut Cx, user_id: OwnedUserId) {
+        let verified_info = tsp_state_ref().lock().unwrap()
+            .get_associated_did(&user_id)
+            .map_or(
+                TspVerifiedInfo::Unverified,
+                |did| TspVerifiedInfo::Verified { did: did.to_string() },
+            );
+
+        self.verified_info = verified_info;
+        self.user_id = Some(user_id);
+        self.refresh_from_verified_info(cx);
+    }
+}
+
+impl TspVerifyUserRef {
+    pub fn show(&self, cx: &mut Cx, user_id: OwnedUserId) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.show(cx, user_id);
+    }
+}

--- a/src/tsp/wallet_entry/mod.rs
+++ b/src/tsp/wallet_entry/mod.rs
@@ -158,7 +158,7 @@ impl Widget for WalletEntry {
         let Some(metadata) = self.metadata.as_ref() else { return };
         if let Event::Actions(actions) = event {
             if self.view.button(id!(set_default_wallet_button)).clicked(actions) {
-                submit_tsp_request(TspRequest::SetDefaultWallet(metadata.clone())).unwrap();
+                submit_tsp_request(TspRequest::SetDefaultWallet(metadata.clone()));
             }
             if self.view.button(id!(remove_wallet_button)).clicked(actions) {
                 let metadata_clone = metadata.clone();
@@ -171,7 +171,7 @@ impl Widget for WalletEntry {
                     ).into(),
                     accept_button_text: Some("Remove".into()),
                     on_accept_clicked: Some(Box::new(move |_cx| {
-                        submit_tsp_request(TspRequest::RemoveWallet(metadata_clone)).unwrap();
+                        submit_tsp_request(TspRequest::RemoveWallet(metadata_clone));
                     })),
                     ..Default::default()
                 };

--- a/src/tsp_dummy/mod.rs
+++ b/src/tsp_dummy/mod.rs
@@ -58,4 +58,9 @@ live_design! {
     pub CreateDidModal = <View> {
         visible: false,
     }
+
+    pub TspVerifyUser = <View> {
+        height: 50
+        width: Fill,
+    }
 }

--- a/src/tsp_dummy/mod.rs
+++ b/src/tsp_dummy/mod.rs
@@ -63,4 +63,8 @@ live_design! {
         height: 50
         width: Fill,
     }
+
+    pub TspVerificationModal = <View> {
+        visible: false
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 // Ignore clippy warnings in `DeRon` macro derive bodies.
 #![allow(clippy::question_mark)]
 
-use std::{borrow::Cow, fmt::Display, ops::Deref, str::{Chars, FromStr}, time::SystemTime};
+use std::{borrow::Cow, fmt::Display, ops::{Deref, DerefMut}, str::{Chars, FromStr}, time::SystemTime};
 
 use unicode_segmentation::UnicodeSegmentation;
 use chrono::{DateTime, Duration, Local, TimeZone};
@@ -11,6 +11,30 @@ use matrix_sdk_ui::timeline::{EventTimelineItem, PaginationError, TimelineDetail
 
 use crate::sliding_sync::{submit_async_request, MatrixRequest};
 
+
+/// A wrapper type that implements the `Debug` trait for non-`Debug` types.
+pub struct DebugWrapper<T>(T);
+impl<T> std::fmt::Debug for DebugWrapper<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({})", std::any::type_name::<T>())
+    }
+}
+impl<T> Deref for DebugWrapper<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T> DerefMut for DebugWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+impl<T> From<T> for DebugWrapper<T> {
+    fn from(value: T) -> Self {
+        DebugWrapper(value)
+    }
+}
 
 /// Returns true if the given event is an interactive hit-related event
 /// that should require a view/widget to be visible in order to handle/receive it.


### PR DESCRIPTION
Implements item (1) from issue #551. (and part of (3), i suppose...)

~~Things are largely untested, but the basic UI and logic are there.~~ tested working, currently just on macOS and windows but it should work elsewhere too

~~TODO: still need to add a UI pane for accepting/rejecting an incoming TSP verification request (similar to the VerificationModal, but for TSP instead of Matrix-native verification requests).~~ done

Added a TSP section to the UserProfileSlidingPane that allows the user to enter a DID and associate it with another Matrix user ID, upon which a verification request will be sent to them. ~~(This is untested)~~ working

Fix issue where interactive events are delivered to the overlay views in the RoomScreen (UserProfileSlidingPane, LoadingPane).