### PR TITLE
Fix joining replacement room and ensure navigation works

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,10 +10,7 @@ use makepad_widgets::{makepad_micro_serde::*, *};
 use matrix_sdk::ruma::{OwnedRoomId, RoomId};
 use crate::{
     avatar_cache::clear_avatar_cache, home::{
-        main_desktop_ui::MainDesktopUiAction,
-        new_message_context_menu::NewMessageContextMenuWidgetRefExt,
-        room_screen::{clear_timeline_states, MessageAction},
-        rooms_list::{clear_all_invited_rooms, enqueue_rooms_list_update, RoomsListAction, RoomsListRef, RoomsListUpdate},
+        main_desktop_ui::MainDesktopUiAction, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_screen::{clear_timeline_states, MessageAction}, rooms_list::{clear_all_invited_rooms, enqueue_rooms_list_update, RoomsListAction, RoomsListRef, RoomsListUpdate}
     }, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
     }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, shared::callout_tooltip::{
@@ -138,11 +135,12 @@ app_main!(App);
 
 #[derive(Live)]
 pub struct App {
-    #[live]
-    ui: WidgetRef,
-
-    #[rust]
-    app_state: AppState,
+    #[live] ui: WidgetRef,
+    /// The top-level app state, shared across various parts of the app.
+    #[rust] app_state: AppState,
+    /// The details of a room we're waiting on to be joined so that we can navigate to it.
+    /// Also includes an optional room ID to be closed once the awaited room is joined.
+    #[rust] waiting_to_navigate_to_joined_room: Option<(BasicRoomDetails, Option<OwnedRoomId>)>,
 }
 
 impl LiveRegister for App {
@@ -220,12 +218,14 @@ impl MatchEvent for App {
                 match logout_modal_action {
                     LogoutConfirmModalAction::Open => {
                         self.ui.logout_confirm_modal(id!(logout_confirm_modal_inner)).reset_state(cx);
-                        self.ui.modal(id!(logout_confirm_modal)).open(cx)
+                        self.ui.modal(id!(logout_confirm_modal)).open(cx);
+                        continue;
                     },
                     LogoutConfirmModalAction::Close { was_internal, .. } => {
                         if *was_internal {
                             self.ui.modal(id!(logout_confirm_modal)).close(cx);
                         }
+                        continue;
                     },
                     _ => {}
                 }
@@ -272,14 +272,6 @@ impl MatchEvent for App {
                 continue;
             }
 
-            if let Some(AppStateAction::RestoreAppStateFromPersistentState(app_state)) = action.downcast_ref() {
-                // Ignore the `logged_in` state that was stored persistently.
-                let logged_in_actual = self.app_state.logged_in;
-                self.app_state = app_state.clone();
-                self.app_state.logged_in = logged_in_actual;
-                cx.action(MainDesktopUiAction::LoadDockFromAppState);
-            }
-
             if let RoomsListAction::Selected(selected_room) = action.as_widget_action().cast() {
                 // A room has been selected, update the app state and navigate to the main content view.
                 let display_name = room_name_or_id(selected_room.room_name(), selected_room.room_id());
@@ -300,16 +292,16 @@ impl MatchEvent for App {
             }
 
             // Handle actions that instruct us to update the top-level app state.
-            match action.as_widget_action().cast() {
-                AppStateAction::RoomFocused(selected_room) => {
+            match action.downcast_ref() {
+                Some(AppStateAction::RoomFocused(selected_room)) => {
                     self.app_state.selected_room = Some(selected_room.clone());
                     continue;
                 }
-                AppStateAction::FocusNone => {
+                Some(AppStateAction::FocusNone) => {
                     self.app_state.selected_room = None;
                     continue;
                 }
-                AppStateAction::UpgradedInviteToJoinedRoom(room_id) => {
+                Some(AppStateAction::UpgradedInviteToJoinedRoom(room_id)) => {
                     if let Some(selected_room) = self.app_state.selected_room.as_mut() {
                         let did_upgrade = selected_room.upgrade_invite_to_joined(&room_id);
                         // Updating the AppState's selected room and issuing a redraw
@@ -320,56 +312,27 @@ impl MatchEvent for App {
                     }
                     continue;
                 }
-                AppStateAction::NavigateToRoom { current_room_id, destination_room_detail } => {
-                    // Check if successor room is loaded, if not show join modal
-                    let rooms_list_ref = cx.get_global::<RoomsListRef>();
-                    if !rooms_list_ref.is_room_loaded(&destination_room_detail.room_id) {
-                        log!("Destination room {} not loaded, showing join modal",
-                            destination_room_detail.room_id
-                        );
-                        // Show join room modal for the successor room
-                        cx.action(JoinLeaveRoomModalAction::Open {
-                            kind: JoinLeaveModalKind::JoinRoom(destination_room_detail.clone()), 
-                            show_tip: false,
-                        });
-                        continue;
+                Some(AppStateAction::RestoreAppStateFromPersistentState(app_state)) => {
+                    // Ignore the `logged_in` state that was stored persistently.
+                    let logged_in_actual = self.app_state.logged_in;
+                    self.app_state = app_state.clone();
+                    self.app_state.logged_in = logged_in_actual;
+                    cx.action(MainDesktopUiAction::LoadDockFromAppState);
+                    continue;
+                }
+                Some(AppStateAction::NavigateToRoom { room_to_close, destination_room }) => {
+                    self.navigate_to_room(cx, room_to_close.as_ref(), destination_room);
+                    continue;
+                }
+                // If we successfully loaded a room that we were waiting to join,
+                // we can now navigate to it and optionally close a previous room.
+                Some(AppStateAction::RoomLoadedSuccessfully(room_id)) if
+                    self.waiting_to_navigate_to_joined_room.as_ref().is_some_and(|(dr, _)| &dr.room_id == room_id) =>
+                {
+                    log!("Joined awaited room {}, navigating to it now...", room_id);
+                    if let Some((dest_room, room_to_close)) = self.waiting_to_navigate_to_joined_room.take() {
+                        self.navigate_to_room(cx, room_to_close.as_ref(), &dest_room);
                     }
-
-                    log!("Navigating from room: {} to destination room: {}",
-                        current_room_id,
-                        destination_room_detail.room_id
-                    );
-
-                    // Select and scroll to the destination room in the rooms list.
-                    let new_selected_room = SelectedRoom::JoinedRoom {
-                        room_id: destination_room_detail.room_id.clone().into(),
-                        room_name: destination_room_detail.room_name.clone(),
-                    };
-                    enqueue_rooms_list_update(RoomsListUpdate::ScrollToRoom(destination_room_detail.room_id));
-                    cx.widget_action(
-                        self.ui.widget_uid(),
-                        &Scope::default().path,
-                        RoomsListAction::Selected(new_selected_room),
-                    );
-
-                    // Close the current room.
-                    // For the mobile UI, navigate back to the root view.
-                    // For the desktop UI, close the current room's tab if it's open.
-                    cx.widget_action(
-                        self.ui.widget_uid(),
-                        &Scope::default().path,
-                        StackNavigationAction::PopToRoot,
-                    );
-                    if let Some(tab_id) = self.app_state.saved_dock_state.open_rooms.iter()
-                        .find_map(|(tab_id, room)| (room.room_id() == &current_room_id).then_some(*tab_id))
-                    {
-                        cx.widget_action(
-                            self.ui.widget_uid(),
-                            &Scope::default().path,
-                            DockAction::TabCloseWasPressed(tab_id),
-                        );
-                    }
-
                     continue;
                 }
                 _ => {}
@@ -468,7 +431,7 @@ impl MatchEvent for App {
             //     }
             //     _ => {}
             // }
-        }
+        }   
     }
 }
 
@@ -569,6 +532,64 @@ impl App {
         self.ui.view(id!(login_screen_view)).set_visible(cx, show_login);
         self.ui.view(id!(home_screen_view)).set_visible(cx, !show_login);
     }
+
+    /// Navigates to the given `destination_room`, optionally closing the `room_to_close`.
+    fn navigate_to_room(
+        &mut self,
+        cx: &mut Cx,
+        room_to_close: Option<&OwnedRoomId>,
+        destination_room: &BasicRoomDetails,
+    ) {
+        // A closure that closes the given `room_to_close`, if it exists in an open tab.
+        let close_room_closure_opt = room_to_close.and_then(|to_close|
+            self.app_state.saved_dock_state.open_rooms
+                .iter()
+                .find_map(|(tab_id, r)| (r.room_id() == to_close).then_some(*tab_id))
+        ).map(|tab_id| {
+            let widget_uid = self.ui.widget_uid();
+            move |cx: &mut Cx| {
+                cx.widget_action(
+                    widget_uid,
+                    &Scope::default().path,
+                    DockAction::TabCloseWasPressed(tab_id),
+                );
+            }
+        });
+
+        // If the successor room is not loaded, show a join modal.
+        let rooms_list_ref = cx.get_global::<RoomsListRef>();
+        if !rooms_list_ref.is_room_loaded(&destination_room.room_id) {
+            log!("Destination room {} not loaded, showing join modal...", destination_room.room_id);
+            self.waiting_to_navigate_to_joined_room = Some((
+                destination_room.clone(),
+                room_to_close.cloned(),
+            ));
+            cx.action(JoinLeaveRoomModalAction::Open {
+                kind: JoinLeaveModalKind::JoinRoom(destination_room.clone()), 
+                show_tip: false,
+            });
+            return;
+        }
+
+        log!("Navigating to destination room: {}, closing room {room_to_close:?}", destination_room.room_id);
+
+        // Select and scroll to the destination room in the rooms list.
+        let new_selected_room = SelectedRoom::JoinedRoom {
+            room_id: destination_room.room_id.clone().into(),
+            room_name: destination_room.room_name.clone(),
+        };
+        enqueue_rooms_list_update(RoomsListUpdate::ScrollToRoom(destination_room.room_id.clone()));
+        cx.widget_action(
+            self.ui.widget_uid(),
+            &Scope::default().path,
+            RoomsListAction::Selected(new_selected_room),
+        );
+
+        // Close a previously/currently-open room if specified.
+        if let Some(closure) = close_room_closure_opt {
+            closure(cx);
+        }
+    }
 }
 
 /// App-wide state that is stored persistently across multiple app runs
@@ -654,7 +675,9 @@ impl PartialEq for SelectedRoom {
 impl Eq for SelectedRoom {}
 
 /// Actions sent to the top-level App in order to update / restore its [`AppState`].
-#[derive(Clone, Debug, DefaultNone)]
+///
+/// These are *NOT* widget actions.
+#[derive(Debug)]
 pub enum AppStateAction {
     /// The given room was focused (selected).
     RoomFocused(SelectedRoom),
@@ -670,11 +693,10 @@ pub enum AppStateAction {
     ///
     /// The RoomScreen for this room can now fully display the room's timeline.
     RoomLoadedSuccessfully(OwnedRoomId),
-    /// Navigate to the room.
-    /// Contains the current room ID and destination room's room details.
+    /// A request to navigate to a different room, optionally closing a prior/current room.
     NavigateToRoom {
-        current_room_id: OwnedRoomId,
-        destination_room_detail: BasicRoomDetails,
+        room_to_close: Option<OwnedRoomId>,
+        destination_room: BasicRoomDetails,
     },
     None,
 }

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -220,8 +220,11 @@ impl Deref for InviteDetails {
 }
 
 /// Actions sent from the backend task as a result of a [`MatrixRequest::JoinRoom`].
+///
+/// Note that this *DOES NOT MEAN* that the room has actually been fully joined yet.
+/// For that, you must wait for a [`AppStateAction::RoomLoadedSuccessfully`] action to occur.
 #[derive(Debug)]
-pub enum JoinRoomAction {
+pub enum JoinRoomResultAction {
     /// The user has successfully joined the room.
     Joined {
         room_id: OwnedRoomId,
@@ -234,8 +237,10 @@ pub enum JoinRoomAction {
 }
 
 /// Actions sent from the backend task as a result of a [`MatrixRequest::LeaveRoom`].
+///
+/// Note that this *DOES NOT MEAN* that the room has actually been fully left yet.
 #[derive(Debug)]
-pub enum LeaveRoomAction {
+pub enum LeaveRoomResultAction {
     /// The user has successfully left the room.
     Left {
         room_id: OwnedRoomId,
@@ -336,14 +341,14 @@ impl Widget for InviteScreen {
 
             for action in actions {
                 match action.downcast_ref() {
-                    Some(JoinRoomAction::Joined { room_id }) if room_id == &info.room_id => {
+                    Some(JoinRoomResultAction::Joined { room_id }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::WaitingForJoinedRoom;
                         if !self.has_shown_confirmation {
                             enqueue_popup_notification(PopupItem{ message: "Successfully joined room.".into(), kind: PopupKind::Success, auto_dismissal_duration: None });
                         }
                         continue;
                     }
-                    Some(JoinRoomAction::Failed { room_id, error }) if room_id == &info.room_id => {
+                    Some(JoinRoomResultAction::Failed { room_id, error }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::WaitingOnUserInput;
                         if !self.has_shown_confirmation {
                             let msg = utils::stringify_join_leave_error(error, info.room_name.as_deref(), true, true);
@@ -355,14 +360,14 @@ impl Widget for InviteScreen {
                 }
 
                 match action.downcast_ref() {
-                    Some(LeaveRoomAction::Left { room_id }) if room_id == &info.room_id => {
+                    Some(LeaveRoomResultAction::Left { room_id }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::RoomLeft;
                         if !self.has_shown_confirmation {
                             enqueue_popup_notification(PopupItem { message: "Successfully rejected invite.".into(), kind: PopupKind::Success, auto_dismissal_duration: Some(5.0) });
                         }
                         continue;
                     }
-                    Some(LeaveRoomAction::Failed { room_id, error }) if room_id == &info.room_id => {
+                    Some(LeaveRoomResultAction::Failed { room_id, error }) if room_id == &info.room_id => {
                         self.invite_state = InviteState::WaitingOnUserInput;
                         if !self.has_shown_confirmation {
                             enqueue_popup_notification(PopupItem { message: format!("Failed to reject invite: {error}"), kind: PopupKind::Error, auto_dismissal_duration: None });

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -188,11 +188,7 @@ impl MainDesktopUI {
                     if active_room == room_being_closed {
                         if let Some(new_focused_room) = self.room_order.last() {
                             // notify the app state about the new focused room
-                            cx.widget_action(
-                                self.widget_uid(),
-                                &HeapLiveIdPath::default(),
-                                AppStateAction::RoomFocused(new_focused_room.clone()),
-                            );
+                            cx.action(AppStateAction::RoomFocused(new_focused_room.clone()));
 
                             // Set the new selected room to be used in the current draw
                             self.most_recently_selected_room = Some(new_focused_room.clone());
@@ -201,12 +197,7 @@ impl MainDesktopUI {
                 }
             } else {
                 // If there is no room to focus, notify app to reset the selected room in the app state
-                cx.widget_action(
-                    self.widget_uid(),
-                    &HeapLiveIdPath::default(),
-                    AppStateAction::FocusNone,
-                );
-
+                cx.action(AppStateAction::FocusNone);
                 dock.select_tab(cx, live_id!(home_tab));
                 self.most_recently_selected_room = None;
             }
@@ -225,11 +216,7 @@ impl MainDesktopUI {
         }
 
         dock.select_tab(cx, live_id!(home_tab));
-        cx.widget_action(
-            self.widget_uid(),
-            &HeapLiveIdPath::default(),
-            AppStateAction::FocusNone,
-        );
+        cx.action(AppStateAction::FocusNone);
 
         // Clear tab-related dock UI state.
         self.open_rooms.clear();
@@ -242,7 +229,7 @@ impl MainDesktopUI {
     fn replace_invite_with_joined_room(
         &mut self,
         cx: &mut Cx,
-        scope: &mut Scope,
+        _scope: &mut Scope,
         room_id: OwnedRoomId,
         room_name: Option<String>,
     ) {
@@ -276,11 +263,7 @@ impl MainDesktopUI {
         }
 
         // Finally, emit an action to update the AppState with the new room.
-        cx.widget_action(
-            self.widget_uid(),
-            &scope.path,
-            AppStateAction::UpgradedInviteToJoinedRoom(room_id),
-        );
+        cx.action(AppStateAction::UpgradedInviteToJoinedRoom(room_id));
     }
 }
 
@@ -301,19 +284,11 @@ impl WidgetMatchEvent for MainDesktopUI {
                 // Whenever a tab (except for the home_tab) is pressed, notify the app state.
                 DockAction::TabWasPressed(tab_id) => {
                     if tab_id == live_id!(home_tab) {
-                        cx.widget_action(
-                            self.widget_uid(),
-                            &HeapLiveIdPath::default(),
-                            AppStateAction::FocusNone,
-                        );
+                        cx.action(AppStateAction::FocusNone);
                         self.most_recently_selected_room = None;
                     }
                     else if let Some(selected_room) = self.open_rooms.get(&tab_id) {
-                        cx.widget_action(
-                            self.widget_uid(),
-                            &HeapLiveIdPath::default(),
-                            AppStateAction::RoomFocused(selected_room.clone()),
-                        );
+                        cx.action(AppStateAction::RoomFocused(selected_room.clone()));
                         self.most_recently_selected_room = Some(selected_room.clone());
                     }
                     should_save_dock_action = true;

--- a/src/home/main_mobile_ui.rs
+++ b/src/home/main_mobile_ui.rs
@@ -58,12 +58,7 @@ impl Widget for MainMobileUI {
                     // Because the MainMobileUI is drawn based on the AppState only,
                     // all we need to do is update the AppState here.
                     RoomsListAction::InviteAccepted { room_id, .. } => {
-                        // Emit an action to update the AppState with the new room.
-                        cx.widget_action(
-                            self.widget_uid(),
-                            &scope.path,
-                            AppStateAction::UpgradedInviteToJoinedRoom(room_id),
-                        );
+                        cx.action(AppStateAction::UpgradedInviteToJoinedRoom(room_id));
                     }
                     RoomsListAction::None => {}
                 }

--- a/src/home/tombstone_footer.rs
+++ b/src/home/tombstone_footer.rs
@@ -178,26 +178,16 @@ impl TombstoneFooter {
     /// If the successor room is not loaded, show a join room modal. Otherwise,
     /// close the tombstone room and show the successor room in the room list.
     ///
-    fn navigate_to_successor_room(&mut self, cx: &mut Cx, scope: &mut Scope) {
+    fn navigate_to_successor_room(&mut self, cx: &mut Cx, _scope: &mut Scope) {
         let Some(successor_room_detail) = self.successor_info.as_ref() else {
-            error!("Cannot navigate: no successor room information");
+            error!("BUG: cannot navigate to replacement room: no successor room information.");
             return;
         };
 
-        let Some(room_id) = self.room_id.as_ref() else {
-            error!("Cannot navigate to successor room: current room ID is not set");
-            return;
-        };
-
-        // Trigger the NavigateToRoom action which handles all the widget actions
-        cx.widget_action(
-            self.widget_uid(),
-            &scope.path,
-            AppStateAction::NavigateToRoom {
-                current_room_id: room_id.clone(),
-                destination_room_detail: successor_room_detail.clone(),
-            }
-        );
+        cx.action(AppStateAction::NavigateToRoom {
+            room_to_close: self.room_id.clone(),
+            destination_room: successor_room_detail.clone(),
+        });
     }
 
     /// Hides the tombstone footer, making it invisible and clearing any successor room information.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,6 +35,17 @@ impl<T> From<T> for DebugWrapper<T> {
         DebugWrapper(value)
     }
 }
+impl<T: Default> Default for DebugWrapper<T> {
+    fn default() -> Self {
+        DebugWrapper(T::default())
+    }
+}
+impl<T> DebugWrapper<T> {
+    /// Consumes the wrapper and returns the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
 
 /// Returns true if the given event is an interactive hit-related event
 /// that should require a view/widget to be visible in order to handle/receive it.


### PR DESCRIPTION
Previously, PR #536 added support for showing a tombstoned room and information about its successor/replacement room, but did not fully handle the case where a new room is unknown. We now handle that properly, and also support deferred navigation to the newly-joined room that waits for it to actually joined and fully loaded/received by our client from the homeserver, at which point it can actually jump to that new room.