### PR TITLE
Re-design how tombstoned rooms are handled in the sliding_sync backend

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
Fixes #604 

Save successor room into roomslistRef
Get successor room in room_input_bar