### PR TITLE
Ensure that RoomInputBar components don't exceed 5/8 of the RoomScreen's height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "accessory"
@@ -2894,7 +2894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -3046,7 +3046,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-platform",
 ]
@@ -3099,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-platform",
 ]
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-platform",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-platform",
 ]
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-emoji"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-platform",
 ]
@@ -3131,17 +3131,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -3160,7 +3160,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3186,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3204,12 +3204,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3226,12 +3226,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "makepad-platform"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "bitflags 2.9.4",
  "hilog-sys",
@@ -3255,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -3270,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -3278,12 +3278,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "makepad-vector"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3320,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -5308,7 +5308,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#99f27908fc9c0093ff941e3366697f128768bdfd"
+source = "git+https://github.com/makepad/makepad?branch=dev#ae2ed8542c53d3a997d586abc7e382b08a14d424"
 
 [[package]]
 name = "sec1"

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -42,7 +42,7 @@ live_design! {
 
     pub RoomInputBar = {{RoomInputBar}} {
         width: Fill,
-        height: Fit,
+        height: Fit { max: Rel(0.625) }
         flow: Down,
 
         // The top-most element is a preview of the message that the user is replying to, if any.
@@ -58,13 +58,13 @@ live_design! {
         // * the EditingPane, which slides up as an overlay in front of the other views below.
         overlay_wrapper = <View> {
             width: Fill,
-            height: Fit,
+            height: Fit { max: Rel(0.625) }
             flow: Overlay,
 
             // Below that, display a view that holds the message input bar and send button.
             input_bar = <View> {
                 width: Fill,
-                height: Fit
+                height: Fit { max: Rel(0.625) }
                 flow: Right
                 // Bottom-align everything to ensure that buttons always stick to the bottom
                 // even when the mentionable_text_input box is very tall.
@@ -88,7 +88,7 @@ live_design! {
 
                 mentionable_text_input = <MentionableTextInput> {
                     width: Fill,
-                    height: Fit
+                    height: Fit { max: Rel(0.625) }
                     margin: { bottom: 12 },
 
                     persistent = {


### PR DESCRIPTION
This primarily applies to the TextInput within the RoomInputBar, but it also limits the height of everything else within the RoomInputBar, such as the ReplyPreview + TextInput together.

Makepad's TextInput widget still doesn't support internal scrolling, so you cannot see all the text when it exceeds the max size bound. But it's still a major improvement because it doesn't push the buttons off-screen.

Update makepad version to include Eddy's latest commit that supports Fit size bounds with maximum sizes that are relative to an ancestor widget.