### PR TITLE
Update makepad to use our Modal widget with fixed event handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "accessory"
@@ -722,9 +722,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "byteorder"
@@ -3034,7 +3034,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3079,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-platform",
 ]
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-platform",
 ]
@@ -3095,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-platform",
 ]
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-platform",
 ]
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-emoji"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-platform",
 ]
@@ -3119,17 +3119,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -3148,7 +3148,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -3166,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -3184,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3192,12 +3192,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3206,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3214,12 +3214,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "makepad-platform"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "bitflags 2.9.4",
  "hilog-sys",
@@ -3248,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-id",
  "makepad-script-derive",
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -3289,12 +3289,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "makepad-vector"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "bitflags 2.9.4",
 ]
@@ -3339,7 +3339,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3347,7 +3347,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -5316,7 +5316,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#5f58721cc5108eea23ed6572dd1f230e1a3253e5"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_modal_event_handling#f2ce539ba17020ad1a9abf8a7db11ed0a8a8c8be"
 
 [[package]]
 name = "sealed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ version = "0.0.1-pre-alpha-4"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "fix_modal_event_handling" }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"

--- a/src/home/editing_pane.rs
+++ b/src/home/editing_pane.rs
@@ -29,7 +29,7 @@ live_design! {
 
     EditingContent = <View> {
         width: Fill,
-        height: Fit { max: Rel(0.625) }
+        height: Fit { max: Rel { base: Full, factor: 0.625 } }
         align: {x: 0.5, y: 1.0}, // centered horizontally, bottom-aligned
         padding: { left: 20, right: 20, top: 10, bottom: 10 }
         margin: {top: 2}
@@ -98,7 +98,7 @@ live_design! {
 
         edit_text_input = <MentionableTextInput> {
             width: Fill
-            height: Fit { max: Rel(0.625) }
+            height: Fit { max: Rel { base: Full, factor: 0.625 } }
             margin: { bottom: 5, top: 5 }
         }
     }
@@ -107,7 +107,7 @@ live_design! {
     pub EditingPane = {{EditingPane}} {
         visible: false,
         width: Fill,
-        height: Fit { max: Rel(0.625) }
+        height: Fit { max: Rel { base: Full, factor: 0.625 } }
         align: {x: 0.5, y: 1.0}
         // TODO: FIXME: this is a hack to make the editing pane
         //              able to slide out of the bottom of the screen.

--- a/src/home/tombstone_footer.rs
+++ b/src/home/tombstone_footer.rs
@@ -28,7 +28,7 @@ live_design! {
     pub TombstoneFooter = {{TombstoneFooter}}<ScrollYView> {
         visible: false,
         width: Fill,
-        height: Fit { max: Rel(0.625) }
+        height: Fit { max: Rel { base: Full, factor: 0.625 } }
         flow: Down,
         align: {x: 0.5}
         padding: 20,

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -42,7 +42,7 @@ live_design! {
 
     pub RoomInputBar = {{RoomInputBar}}<RoundedView> {
         width: Fill,
-        height: Fit { max: Rel(0.625) }
+        height: Fit { max: Rel { base: Full, factor: 0.625 } }
         flow: Down,
 
         // These margins are a hack to make the borders of the RoomInputBar
@@ -75,13 +75,13 @@ live_design! {
         // * the EditingPane, which slides up as an overlay in front of the other views below.
         overlay_wrapper = <View> {
             width: Fill,
-            height: Fit { max: Rel(0.625) }
+            height: Fit { max: Rel { base: Full, factor: 0.625 } }
             flow: Overlay,
 
             // Below that, display a view that holds the message input bar and send button.
             input_bar = <View> {
                 width: Fill,
-                height: Fit { max: Rel(0.625) }
+                height: Fit { max: Rel { base: Full, factor: 0.625 } }
                 flow: Right
                 // Bottom-align everything to ensure that buttons always stick to the bottom
                 // even when the mentionable_text_input box is very tall.
@@ -110,7 +110,7 @@ live_design! {
 
                 mentionable_text_input = <MentionableTextInput> {
                     width: Fill,
-                    height: Fit { max: Rel(0.625) }
+                    height: Fit { max: Rel { base: Full, factor: 0.625 } }
                     margin: { top: 5, bottom: 12, left: 1, right: 1 },
 
                     persistent = {


### PR DESCRIPTION
Everything now works as expected, _except_ for scrolling, which still permeates through to the views behind the Modal. 

That is a Makepad-level problem due to how the `PortalList` and `ScrollBar` widgets handle scrolling actions. There's nothing we can do to fix that at the moment.