### PR TITLE
Update callout tooltip positioning to be visually nicer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -342,7 +342,7 @@ impl MatchEvent for App {
 
             // Handle actions for showing or hiding the tooltip.
             match action.as_widget_action().cast() {
-                TooltipAction::HoverIn(text, callout_tooltip_options) => {
+                TooltipAction::HoverIn { text, widget_rect, options } => {
                     // Don't show any tooltips if the message context menu is currently shown.
                     if self.ui.new_message_context_menu(ids!(new_message_context_menu)).is_currently_shown(cx) {
                         self.ui.callout_tooltip(ids!(app_tooltip)).hide(cx);
@@ -351,7 +351,8 @@ impl MatchEvent for App {
                         self.ui.callout_tooltip(ids!(app_tooltip)).show_with_options(
                             cx,
                             &text,
-                            callout_tooltip_options,
+                            widget_rect,
+                            options,
                         );
                     }
                     continue;

--- a/src/home/edited_indicator.rs
+++ b/src/home/edited_indicator.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Local};
 use makepad_widgets::*;
 use matrix_sdk_ui::timeline::EventTimelineItem;
 
-use crate::{shared::callout_tooltip::{CalloutTooltipOptions, TooltipAction}, utils::unix_time_millis_to_datetime};
+use crate::{shared::callout_tooltip::{CalloutTooltipOptions, TooltipAction, TooltipPosition}, utils::unix_time_millis_to_datetime};
 
 live_design! {
     use link::theme::*;
@@ -84,10 +84,14 @@ impl Widget for EditedIndicator {
             cx.widget_action(
                 self.widget_uid(),
                 &scope.path,
-                TooltipAction::HoverIn(text, CalloutTooltipOptions {
+                TooltipAction::HoverIn {
+                    text,
                     widget_rect: area.rect(cx),
-                    ..Default::default()
-                }),
+                    options: CalloutTooltipOptions {
+                        position: TooltipPosition::Right,
+                        ..Default::default()
+                    }
+                },
             );
         }
     }

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -217,7 +217,6 @@ impl ReactionList {
             &scope.path,
             RoomScreenTooltipActions::HoverInReactionButton {
                 widget_rect: button_ref.area().rect(cx),
-                bg_color: None,
                 reaction_data,
             },
         );
@@ -319,27 +318,21 @@ impl ReactionListRef {
         inner.timeline_event_id = Some(timeline_event_item_id);
     }
 
-    /// Handles hover in action and returns the appropriate `RoomScreenTooltipActions`.
+    /// Returns any `RoomScreenTooltipActions` that occurred in the given list of `actions`.
     ///
     /// This function checks if there is a widget action associated with the current
-    /// widget's unique identifier in the provided `actions`. If an action exists,
-    /// it is cast to `RoomScreenTooltipActions` and returned. Otherwise, it returns
-    /// `RoomScreenTooltipActions::None`.
-    ///
-    /// # Arguments
-    ///
-    /// * `actions` - A reference to the `Actions` that may contain widget actions
-    ///   relevant to this widget.
-    pub fn hover_in(&self, actions: &Actions) -> RoomScreenTooltipActions {
+    /// widget's unique identifier in the provided `actions`.
+    /// If an action exists, it is cast to `RoomScreenTooltipActions` and returned.
+    /// Otherwise, it returns `RoomScreenTooltipActions::None`.
+    pub fn hovered_in(&self, actions: &Actions) -> RoomScreenTooltipActions {
         if let Some(item) = actions.find_widget_action(self.widget_uid()) {
             item.cast()
         } else {
             RoomScreenTooltipActions::None
         }
     }
-    /// Handles widget actions and returns `true` if the hover out action was found in the provided `actions`.
-    /// Otherwise, returns `false`.
-    pub fn hover_out(&self, actions: &Actions) -> bool {
+    /// Returns whether the given `actions` contained a `RoomScreenTooltipActions::HoverOut` action.
+    pub fn hovered_out(&self, actions: &Actions) -> bool {
         if let Some(item) = actions.find_widget_action(self.widget_uid()) {
             matches!(item.cast(), RoomScreenTooltipActions::HoverOut)
         } else {

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -39,7 +39,7 @@ use crate::{
         user_profile_cache::{self, UserProfileUpdate},
     }, shared::{
         avatar::AvatarWidgetExt,
-        callout_tooltip::{CalloutTooltipOptions, TooltipAction},
+        callout_tooltip::{CalloutTooltipOptions, TooltipAction, TooltipPosition},
         styles::*,
         verification_badge::VerificationBadgeWidgetExt,
     }, sliding_sync::current_user_id, utils
@@ -367,15 +367,21 @@ impl Widget for ProfileIcon {
                     || format!("Not logged in.\n\n{}", verification_str),
                     |p| format!("Logged in as \"{}\".\n\n{}", p.displayable_name(), verification_str)
                 );
-                let rect = area.rect(cx);
+                let mut options = CalloutTooltipOptions {
+                    position: if cx.display_context.is_desktop() { TooltipPosition::Right} else { TooltipPosition::Top},
+                    ..Default::default()
+                };
+                if let Some(c) = bg_color {
+                    options.bg_color = c;
+                }
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
-                    TooltipAction::HoverIn(text, CalloutTooltipOptions {
-                        widget_rect: rect,
-                        bg_color,
-                        ..Default::default()
-                    }),
+                    TooltipAction::HoverIn {
+                        text,
+                        widget_rect: area.rect(cx),
+                        options,
+                    },
                 );
             }
             Hit::FingerHoverOut(_) => {

--- a/src/home/room_read_receipt.rs
+++ b/src/home/room_read_receipt.rs
@@ -116,7 +116,6 @@ impl Widget for AvatarRow {
                     &scope.path,
                     RoomScreenTooltipActions::HoverInReadReceipt {
                         widget_rect,
-                        bg_color: None,
                         read_receipts: read_receipts.clone(),
                     },
                 );

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -606,9 +606,8 @@ impl Widget for RoomScreen {
                 let reaction_list = wr.reaction_list(ids!(reaction_list));
                 if let RoomScreenTooltipActions::HoverInReactionButton {
                     widget_rect,
-                    bg_color,
                     reaction_data,
-                } = reaction_list.hover_in(actions) {
+                } = reaction_list.hovered_in(actions) {
                     let Some(_tl_state) = self.tl_state.as_ref() else { continue };
                     let tooltip_text_arr: Vec<String> = reaction_data.reaction_senders.iter().map(|(sender, _react_info)| {
                         user_profile_cache::get_user_profile_and_room_member(cx, sender.clone(), &reaction_data.room_id, true).0
@@ -620,25 +619,28 @@ impl Widget for RoomScreen {
                     cx.widget_action(
                         room_screen_widget_uid,
                         &scope.path,
-                        TooltipAction::HoverIn(tooltip_text, CalloutTooltipOptions{
+                        TooltipAction::HoverIn {
+                            text: tooltip_text,
                             widget_rect,
-                            bg_color,
-                            position: TooltipPosition::Bottom,
-                            ..Default::default()
-                        })
+                            options: CalloutTooltipOptions {
+                                position: TooltipPosition::Bottom,
+                                ..Default::default()
+                            },
+                        },
                     );
                 }
-                if reaction_list.hover_out(actions) {
+
+                if reaction_list.hovered_out(actions) {
                     cx.widget_action(
                         room_screen_widget_uid,
                         &scope.path,
-                        TooltipAction::HoverOut
+                        TooltipAction::HoverOut,
                     );
                 }
+
                 let avatar_row_ref = wr.avatar_row(ids!(avatar_row));
                 if let RoomScreenTooltipActions::HoverInReadReceipt {
                     widget_rect,
-                    bg_color,
                     read_receipts
                 } = avatar_row_ref.hover_in(actions) {
                     let Some(room_id) = &self.room_id else { return; };
@@ -646,14 +648,17 @@ impl Widget for RoomScreen {
                     cx.widget_action(
                         room_screen_widget_uid,
                         &scope.path,
-                        TooltipAction::HoverIn(tooltip_text, CalloutTooltipOptions {
+                        TooltipAction::HoverIn {
+                            text: tooltip_text,
                             widget_rect,
-                            bg_color,
-                            position: TooltipPosition::Bottom,
-                            ..Default::default()
-                        })
+                            options: CalloutTooltipOptions {
+                                position: TooltipPosition::Left,
+                                ..Default::default()
+                            },
+                        },
                     );
                 }
+
                 if avatar_row_ref.hover_out(actions) {
                     cx.widget_action(
                         room_screen_widget_uid,
@@ -2320,18 +2325,14 @@ pub enum RoomScreenTooltipActions {
     HoverInReadReceipt {
         /// The rect of the moused over widget
         widget_rect: Rect,
-        /// Color of the background, default is black
-        bg_color: Option<Vec4>,
         /// Includes the list of users who have seen this event
         read_receipts: indexmap::IndexMap<matrix_sdk::ruma::OwnedUserId, Receipt>,
     },
     /// Mouse over event when the mouse is over the reaction button.
     HoverInReactionButton {
-        /// The rect of the moused over widget
+        /// The rectangle (bounds) of the hovered-over widget.
         widget_rect: Rect,
-        /// Color of the background, default is black
-        bg_color: Option<Vec4>,
-        /// Includes the list of users who have reacted to the emoji
+        /// Includes the list of users who have reacted to the emoji.
         reaction_data: ReactionData,
     },
     /// Mouse out event and clear tooltip.

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -274,15 +274,18 @@ impl Widget for SpacesBarEntry {
             cx.widget_action(
                 this.widget_uid(),
                 &scope.path,
-                TooltipAction::HoverIn(this.space_name.clone(), CalloutTooltipOptions {
+                TooltipAction::HoverIn {
+                    text: this.space_name.clone(),
                     widget_rect: area.rect(cx),
-                    position: if !is_desktop {
-                        TooltipPosition::Top
-                    } else {
-                        TooltipPosition::Bottom
+                    options: CalloutTooltipOptions {
+                        position: if is_desktop {
+                            TooltipPosition::Right
+                        } else {
+                            TooltipPosition::Top
+                        },
+                        ..Default::default()
                     },
-                    ..Default::default()
-                }),
+                },
             );
         };
 

--- a/src/shared/timestamp.rs
+++ b/src/shared/timestamp.rs
@@ -63,11 +63,14 @@ impl Widget for Timestamp {
             cx.widget_action(
                 self.widget_uid(),
                 &scope.path,
-                TooltipAction::HoverIn(self.dt.format(locale_extended_fmt_en_us).to_string(), CalloutTooltipOptions {
+                TooltipAction::HoverIn {
+                    text: self.dt.format(locale_extended_fmt_en_us).to_string(),
                     widget_rect: area.rect(cx),
-                    position: TooltipPosition::Left,
-                    ..Default::default()
-                })
+                    options: CalloutTooltipOptions {
+                        position: TooltipPosition::Right,
+                        ..Default::default()
+                    },
+                },
             );
         }
     }

--- a/src/tsp/tsp_sign_indicator.rs
+++ b/src/tsp/tsp_sign_indicator.rs
@@ -91,25 +91,28 @@ impl Widget for TspSignIndicator {
             let (text, bg_color) = match self.state {
                 TspSignState::Unknown => (
                     "The sender's TSP signature is unknown.\n\nClick on their avatar to verify their TSP identity.",
-                    Some(COLOR_FG_DISABLED),
+                    COLOR_FG_DISABLED,
                 ),
                 TspSignState::Verified => (
                     "This message was signed with the user's verified TSP identity.",
-                    Some(COLOR_FG_ACCEPT_GREEN),
+                    COLOR_FG_ACCEPT_GREEN, 
                 ),
                 TspSignState::WrongSignature => (
                     "Warning: this message's TSP signature does NOT match the expected sender signature.",
-                    Some(COLOR_FG_DANGER_RED),
+                    COLOR_FG_DANGER_RED,
                 ),
             };
             cx.widget_action(
                 self.widget_uid(),
                 &scope.path,
-                TooltipAction::HoverIn(text.to_string(), CalloutTooltipOptions {
+                TooltipAction::HoverIn {
+                    text: text.to_string(),
                     widget_rect: area.rect(cx),
-                    bg_color,
-                    ..Default::default()
-                })
+                    options: CalloutTooltipOptions {
+                        bg_color,
+                        ..Default::default()
+                    },
+                },
             );
         }
     }


### PR DESCRIPTION
Also, the widget's rectangle is no longer optional and has no default value, so it must be specified by every caller, which is more correct.