### PR TITLE
Allow hiding a room from the rooms list

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -549,6 +549,7 @@ impl App {
                     &HeapLiveIdPath::default(),
                     DockAction::TabCloseWasPressed(tab_id),
                 );
+                enqueue_rooms_list_update(RoomsListUpdate::HideRoom { room_id: to_close.clone() });
             }
         });
 


### PR DESCRIPTION
This is useful when extreme homeserver latency causes a big delay between joining a successor room and the RoomListService receiving the update that the tombstoned room should no longer be considered "active" and can be removed. Or, if the room never gets removed, the user can still observe the expected result.

In the future, this could also be used to allow the user themselves to permanently hide certain rooms, e.g., spam invites that they do not want to see without requiring them to fully clear the client cache. However, to support that, we'd need to distinguish between hiding a room temporarily vs permanently, and then save the list of permanently-hidden rooms to the persistent app state.