### PR TITLE
Show non-member room state across list and room view

### DIFF
--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -396,7 +396,7 @@ impl Widget for InviteScreen {
         if !self.is_loaded {
             let mut restore_status_view = self.view.restore_status_view(ids!(restore_status_view));
             if let Some(room_name) = &self.room_name_id {
-                restore_status_view.set_content(cx, self.all_rooms_loaded, room_name);
+                restore_status_view.set_content(cx, self.all_rooms_loaded, room_name, None);
             }
             return restore_status_view.draw(cx, scope);
         }
@@ -536,11 +536,7 @@ impl InviteScreen {
 
         let restore_status_view = self.view.restore_status_view(ids!(restore_status_view));
         if !self.is_loaded {
-            restore_status_view.set_content(
-                cx,
-                self.all_rooms_loaded,
-                room_name_id,
-            );
+            restore_status_view.set_content(cx, self.all_rooms_loaded, room_name_id, None);
             restore_status_view.set_visible(cx, true);
         } else {
             restore_status_view.set_visible(cx, false);

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -387,6 +387,10 @@ impl Widget for InviteScreen {
         }
 
         if self.invite_state != orig_state {
+            if let (Some(room_name_id), true) = (self.room_name_id.as_ref(), cx.has_global::<RoomsListRef>()) {
+                let rooms_list_ref = cx.get_global::<RoomsListRef>();
+                rooms_list_ref.set_invite_state(room_name_id.room_id().clone(), self.invite_state);
+            }
             self.redraw(cx);
         }
     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -25,7 +25,7 @@ use matrix_sdk_ui::timeline::{
 use ruma::{OwnedUserId, events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent}};
 
 use crate::{
-    app::AppStateAction, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{get_image_name_and_filesize, populate_matrix_image_modal}, rooms_list::RoomsListRef, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    app::AppStateAction, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{get_image_name_and_filesize, populate_matrix_image_modal}, rooms_list::{enqueue_rooms_list_update, InviteState, InvitedRoomInfo, RoomsListRef, RoomsListUpdate}, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
         user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     },
@@ -590,6 +590,8 @@ pub struct RoomScreen {
     #[rust] all_rooms_loaded: bool,
     /// Tracks whether the current user is no longer a member of this room.
     #[rust] removed_state: Option<RoomState>,
+    /// Tracks whether the membership footer was shown for an invite state.
+    #[rust] was_invited: bool,
     /// Cached join rule for the removed room, used to determine re-join options.
     #[rust] removed_join_rule: Option<JoinRuleSummary>,
     /// Whether a room preview request is in flight for removed-room status.
@@ -772,6 +774,89 @@ impl Widget for RoomScreen {
                             self.removed_preview_requested = false;
                             self.removed_preview_attempted = true;
                             self.update_membership_footer(cx);
+                        }
+                    }
+                }
+
+                if let Some(room_name_id) = self.room_name_id.as_ref() {
+                    let room_id = room_name_id.room_id();
+                    let rooms_list_ref = cx.has_global::<RoomsListRef>().then(|| cx.get_global::<RoomsListRef>());
+                    let is_invited = rooms_list_ref
+                        .as_ref()
+                        .and_then(|rooms_list_ref| rooms_list_ref.get_invite_state(room_id))
+                        .is_some();
+                    let should_notify = self.removed_state.is_some() || is_invited;
+
+                    if let Some(JoinRoomResultAction::Joined { room_id: action_room_id }) = action.downcast_ref() {
+                        if action_room_id == room_id {
+                            if is_invited {
+                                if let Some(rooms_list_ref) = rooms_list_ref.as_ref() {
+                                    rooms_list_ref.set_invite_state(room_id.clone(), InviteState::WaitingForJoinedRoom);
+                                }
+                            }
+                            if should_notify {
+                                enqueue_popup_notification(PopupItem {
+                                    message: "Successfully joined room.".into(),
+                                    kind: PopupKind::Success,
+                                    auto_dismissal_duration: Some(5.0),
+                                });
+                            }
+                            self.update_membership_footer(cx);
+                            continue;
+                        }
+                    }
+
+                    if let Some(JoinRoomResultAction::Failed { room_id: action_room_id, error }) = action.downcast_ref() {
+                        if action_room_id == room_id {
+                            if is_invited {
+                                if let Some(rooms_list_ref) = rooms_list_ref.as_ref() {
+                                    rooms_list_ref.set_invite_state(room_id.clone(), InviteState::WaitingOnUserInput);
+                                }
+                            }
+                            if should_notify {
+                                let msg = utils::stringify_join_leave_error(error, room_name_id, true, is_invited);
+                                enqueue_popup_notification(PopupItem {
+                                    message: msg,
+                                    kind: PopupKind::Error,
+                                    auto_dismissal_duration: None,
+                                });
+                            }
+                            self.update_membership_footer(cx);
+                            continue;
+                        }
+                    }
+
+                    if let Some(LeaveRoomResultAction::Left { room_id: action_room_id }) = action.downcast_ref() {
+                        if action_room_id == room_id && is_invited {
+                            if let Some(rooms_list_ref) = rooms_list_ref.as_ref() {
+                                rooms_list_ref.set_invite_state(room_id.clone(), InviteState::RoomLeft);
+                            }
+                            if should_notify {
+                                enqueue_popup_notification(PopupItem {
+                                    message: "Successfully rejected invite.".into(),
+                                    kind: PopupKind::Success,
+                                    auto_dismissal_duration: Some(5.0),
+                                });
+                            }
+                            self.update_membership_footer(cx);
+                            continue;
+                        }
+                    }
+
+                    if let Some(LeaveRoomResultAction::Failed { room_id: action_room_id, error }) = action.downcast_ref() {
+                        if action_room_id == room_id && is_invited {
+                            if let Some(rooms_list_ref) = rooms_list_ref.as_ref() {
+                                rooms_list_ref.set_invite_state(room_id.clone(), InviteState::WaitingOnUserInput);
+                            }
+                            if should_notify {
+                                enqueue_popup_notification(PopupItem {
+                                    message: format!("Failed to reject invite: {error}"),
+                                    kind: PopupKind::Error,
+                                    auto_dismissal_duration: None,
+                                });
+                            }
+                            self.update_membership_footer(cx);
+                            continue;
                         }
                     }
                 }
@@ -1229,16 +1314,66 @@ impl RoomScreen {
         if !cx.has_global::<RoomsListRef>() {
             return;
         }
+        let rooms_list_ref = cx.get_global::<RoomsListRef>();
         let room_input_bar = self.view.room_input_bar(ids!(room_input_bar));
-        let mut removed_state = {
-            let rooms_list_ref = cx.get_global::<RoomsListRef>();
-            rooms_list_ref.get_removed_room_state(room_name_id.room_id())
-        };
-
+        let mut actual_state = None;
+        let mut actual_room = None;
         if let Some(client) = get_client()
             && let Some(room) = client.get_room(room_name_id.room_id())
         {
-            let actual_state = room.state();
+            actual_state = Some(room.state());
+            actual_room = Some(room);
+        }
+
+        let invite_state = rooms_list_ref.get_invite_state(room_name_id.room_id());
+        let mut is_invited = invite_state.is_some()
+            || rooms_list_ref.get_room_state(room_name_id.room_id()) == Some(RoomState::Invited);
+        if !is_invited && matches!(actual_state, Some(RoomState::Invited)) {
+            is_invited = true;
+            if rooms_list_ref.get_room_state(room_name_id.room_id()) != Some(RoomState::Invited) {
+                if let Some(room) = actual_room.as_ref() {
+                    let room_avatar = utils::avatar_from_room_name(room_name_id.name_for_avatar().as_deref());
+                    enqueue_rooms_list_update(RoomsListUpdate::AddInvitedRoom(InvitedRoomInfo {
+                        room_name_id: room_name_id.clone(),
+                        canonical_alias: room.canonical_alias(),
+                        alt_aliases: room.alt_aliases(),
+                        room_avatar,
+                        inviter_info: None,
+                        latest: None,
+                        invite_state: invite_state.unwrap_or(InviteState::WaitingOnUserInput),
+                        is_selected: false,
+                        is_direct: false,
+                    }));
+                }
+            }
+        }
+        if is_invited {
+            self.was_invited = true;
+            if self.removed_state.is_some()
+                || self.removed_join_rule.is_some()
+                || self.removed_preview_requested
+                || self.removed_preview_attempted
+            {
+                self.removed_state = None;
+                self.removed_join_rule = None;
+                self.removed_preview_requested = false;
+                self.removed_preview_attempted = false;
+            }
+            room_input_bar.update_membership_footer(
+                cx,
+                room_name_id,
+                RoomState::Invited,
+                None,
+                false,
+                invite_state,
+            );
+            return;
+        }
+        let mut removed_state = {
+            rooms_list_ref.get_removed_room_state(room_name_id.room_id())
+        };
+
+        if let Some(actual_state) = actual_state {
             let desired_removed_state = match actual_state {
                 RoomState::Left | RoomState::Banned => Some(actual_state),
                 _ => None,
@@ -1255,6 +1390,7 @@ impl RoomScreen {
 
         match removed_state {
             Some(state) if matches!(state, RoomState::Left | RoomState::Banned) => {
+                self.was_invited = false;
                 if self.removed_state != Some(state) {
                     self.removed_state = Some(state);
                     self.removed_join_rule = None;
@@ -1281,11 +1417,13 @@ impl RoomScreen {
                     state,
                     self.removed_join_rule.clone(),
                     preview_pending,
+                    None,
                 );
             }
             _ => {
-                if self.removed_state.is_some() {
+                if self.removed_state.is_some() || self.was_invited {
                     self.removed_state = None;
+                    self.was_invited = false;
                     self.removed_join_rule = None;
                     self.removed_preview_requested = false;
                     self.removed_preview_attempted = false;
@@ -2449,6 +2587,7 @@ impl RoomScreen {
 
         self.hide_timeline();
         self.removed_state = None;
+        self.was_invited = false;
         self.removed_join_rule = None;
         self.removed_preview_requested = false;
         self.removed_preview_attempted = false;

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -520,7 +520,7 @@ impl RoomsList {
     pub fn get_removed_room_state(&self, room_id: &OwnedRoomId) -> Option<RoomState> {
         self.all_joined_rooms
             .get(room_id)
-            .and_then(|jr| jr.removed_state.clone())
+            .and_then(|jr| jr.removed_state)
     }
 
     /// Handle all pending updates to the list of all rooms.

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -8,7 +8,7 @@ use crate::{
     }, utils::{self, relative_format}
 };
 
-use super::rooms_list::{InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListScopeProps};
+use super::rooms_list::{InviteState, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListScopeProps};
 live_design! {
     use link::theme::*;
     use link::shaders::*;
@@ -340,11 +340,22 @@ impl RoomsListEntryContent {
         self.view.label(ids!(room_name)).set_text(cx, &room_info.room_name_id.to_string());
         // Hide the timestamp field, and use the latest message field to show the inviter.
         self.view.label(ids!(timestamp)).set_text(cx, "");
-        let inviter_string = match &room_info.inviter_info {
+        let mut inviter_string = match &room_info.inviter_info {
             Some(InviterInfo { user_id, display_name: Some(dn), .. }) => format!("Invited by <b>{dn}</b> ({user_id})"),
             Some(InviterInfo { user_id, .. }) => format!("Invited by {user_id}"),
             None => String::from("You were invited"),
         };
+        let status_suffix = match room_info.invite_state {
+            InviteState::WaitingOnUserInput => "",
+            InviteState::WaitingForJoinResult => "Joining...",
+            InviteState::WaitingForLeaveResult => "Rejecting...",
+            InviteState::WaitingForJoinedRoom => "Waiting for room...",
+            InviteState::RoomLeft => "Invite rejected",
+        };
+        if !status_suffix.is_empty() {
+            inviter_string.push_str(" - ");
+            inviter_string.push_str(status_suffix);
+        }
         self.view.html_or_plaintext(ids!(latest_message)).show_html(cx, &inviter_string);
 
         match room_info.room_avatar {

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -297,7 +297,7 @@ impl RoomsListEntryContent {
         room_info: &JoinedRoomInfo,
     ) {
         self.view.label(ids!(room_name)).set_text(cx, &room_info.room_name_id.to_string());
-        if let Some(removed_state) = room_info.removed_state.clone() {
+        if let Some(removed_state) = room_info.removed_state {
             let status_text = match removed_state {
                 RoomState::Banned => "<i>You have been banned from this room.</i>",
                 RoomState::Left => "<i>You are no longer a member of this room.</i>",

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -13,13 +13,14 @@
 //! * The editing pane, which is shown when the user is editing a previous message.
 //! * A tombstone footer, which is shown if the room has been tombstoned (replaced).
 //! * A "cannot-send-message" notice, which is shown if the user cannot send messages to the room.
+//! * A membership footer, which is shown if the user is no longer a room member.
 //!
 
 use makepad_widgets::*;
-use matrix_sdk::room::reply::{EnforceThread, Reply};
+use matrix_sdk::{RoomState, room::reply::{EnforceThread, Reply}};
 use matrix_sdk_ui::timeline::{EmbeddedEvent, EventTimelineItem, TimelineEventItemId};
-use ruma::{events::room::message::{LocationMessageEventContent, MessageType, RoomMessageEventContent}, OwnedRoomId};
-use crate::{home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt}, location_preview::LocationPreviewWidgetExt, room_screen::{populate_preview_of_timeline_item, MessageAction, RoomScreenProps}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}}, location::init_location_subscriber, shared::{avatar::AvatarWidgetRefExt, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::MentionableTextInputWidgetExt, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, styles::*}, sliding_sync::{submit_async_request, MatrixRequest, UserPowerLevels}, utils};
+use ruma::{events::room::message::{LocationMessageEventContent, MessageType, RoomMessageEventContent}, room::JoinRuleSummary, OwnedRoomId};
+use crate::{home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt}, location_preview::LocationPreviewWidgetExt, room_screen::{populate_preview_of_timeline_item, MessageAction, RoomScreenProps}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}}, location::init_location_subscriber, shared::{avatar::AvatarWidgetRefExt, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::MentionableTextInputWidgetExt, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, styles::*}, sliding_sync::{submit_async_request, MatrixRequest, UserPowerLevels}, utils::{self, RoomNameId}};
 
 live_design! {
     use link::theme::*;
@@ -159,11 +160,59 @@ live_design! {
                 }
             }
 
+            membership_footer = <View> {
+                visible: false
+                show_bg: true
+                draw_bg: {
+                    color: (COLOR_SECONDARY)
+                }
+                padding: {left: 50, right: 50, top: 20, bottom: 20}
+                align: {y: 0.5}
+                width: Fill, height: Fit
+                flow: Down,
+                spacing: 8
+
+                status_text = <Label> {
+                    width: Fill,
+                    draw_text: {
+                        color: (TYPING_NOTICE_TEXT_COLOR)
+                        text_style: <REGULAR_TEXT>{font_size: 11}
+                        wrap: Word,
+                    }
+                    text: ""
+                }
+
+                action_button = <RobrixIconButton> {
+                    padding: 15,
+                    draw_icon: {
+                        svg_file: (ICON_JOIN_ROOM),
+                        color: (COLOR_FG_ACCEPT_GREEN),
+                    }
+                    icon_walk: {width: 17, height: 17, margin: {left: -2, right: -1} }
+
+                    draw_bg: {
+                        border_color: (COLOR_FG_ACCEPT_GREEN),
+                        color: (COLOR_BG_ACCEPT_GREEN)
+                    }
+                    draw_text: {
+                        color: (COLOR_FG_ACCEPT_GREEN),
+                    }
+                }
+            }
+
             tombstone_footer = <TombstoneFooter> { }
 
             editing_pane = <EditingPane> { }
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+enum MembershipFooterAction {
+    #[default]
+    None,
+    Join,
+    Knock,
 }
 
 /// Main component for message input with @mention support
@@ -176,6 +225,12 @@ pub struct RoomInputBar {
     #[rust] was_replying_preview_visible: bool,
     /// Info about the message event that the user is currently replying to, if any.
     #[rust] replying_to: Option<(EventTimelineItem, EmbeddedEvent)>,
+    /// Tracks whether the membership footer is visible and which action it should take.
+    #[rust] membership_footer_action: MembershipFooterAction,
+    #[rust] membership_footer_room_id: Option<OwnedRoomId>,
+    #[rust] membership_footer_visible: bool,
+    /// Tracks whether the tombstone footer is currently visible.
+    #[rust] tombstone_footer_visible: bool,
 }
 
 impl Widget for RoomInputBar {
@@ -236,6 +291,28 @@ impl RoomInputBar {
         {
             self.clear_replying_to(cx);
             self.redraw(cx);
+        }
+
+        if self.button(ids!(membership_footer.action_button)).clicked(actions) {
+            if let Some(room_id) = self.membership_footer_room_id.clone() {
+                match self.membership_footer_action {
+                    MembershipFooterAction::Join => {
+                        submit_async_request(MatrixRequest::JoinRoom { room_id });
+                    }
+                    MembershipFooterAction::Knock => {
+                        submit_async_request(MatrixRequest::Knock {
+                            room_or_alias_id: room_id.clone().into(),
+                            reason: None,
+                            server_names: Vec::new(),
+                        });
+                    }
+                    MembershipFooterAction::None => {}
+                }
+            }
+        }
+
+        if self.membership_footer_visible || self.tombstone_footer_visible {
+            return;
         }
 
         // Handle the add location button being clicked.
@@ -446,7 +523,9 @@ impl RoomInputBar {
         // In `show_editing_pane()` above, we hid the input_bar while the editing pane
         // was being shown, so here we need to make it visible again.
         // Same goes for the replying_preview, if it was previously shown.
-        self.view.view(ids!(input_bar)).set_visible(cx, true);
+        if !self.membership_footer_visible && !self.tombstone_footer_visible {
+            self.view.view(ids!(input_bar)).set_visible(cx, true);
+        }
         if self.was_replying_preview_visible && self.replying_to.is_some() {
             self.view.view(ids!(replying_preview)).set_visible(cx, true);
         }
@@ -463,18 +542,115 @@ impl RoomInputBar {
         tombstoned_room_id: &OwnedRoomId,
         successor_room_details: Option<&SuccessorRoomDetails>,
     ) {
+        if self.membership_footer_visible {
+            self.tombstone_footer_visible = successor_room_details.is_some();
+            self.tombstone_footer(ids!(tombstone_footer)).hide(cx);
+            return;
+        }
+
         let tombstone_footer = self.tombstone_footer(ids!(tombstone_footer));
         let input_bar = self.view(ids!(input_bar));
 
         if let Some(srd) = successor_room_details {
             tombstone_footer.show(cx, tombstoned_room_id, srd);
             input_bar.set_visible(cx, false);
+            self.tombstone_footer_visible = true;
         } else {
             tombstone_footer.hide(cx);
             if !self.editing_pane(ids!(editing_pane)).is_currently_shown(cx) {
                 input_bar.set_visible(cx, true);
             }
+            self.tombstone_footer_visible = false;
         }
+    }
+
+    fn update_membership_footer(
+        &mut self,
+        cx: &mut Cx,
+        room_name_id: &RoomNameId,
+        state: RoomState,
+        join_rule: Option<JoinRuleSummary>,
+        preview_pending: bool,
+    ) {
+        let membership_footer = self.view.view(ids!(membership_footer));
+        let status_text = membership_footer.label(ids!(status_text));
+        let action_button = membership_footer.button(ids!(action_button));
+
+        self.membership_footer_visible = true;
+        self.membership_footer_room_id = Some(room_name_id.room_id().clone());
+        membership_footer.set_visible(cx, true);
+        self.view.view(ids!(input_bar)).set_visible(cx, false);
+        self.view.view(ids!(can_not_send_message_notice)).set_visible(cx, false);
+        self.tombstone_footer(ids!(tombstone_footer)).hide(cx);
+        self.tombstone_footer_visible = false;
+        if self.editing_pane(ids!(editing_pane)).is_currently_shown(cx) {
+            self.editing_pane(ids!(editing_pane)).force_reset_hide(cx);
+            self.on_editing_pane_hidden(cx);
+        }
+        self.clear_replying_to(cx);
+        self.location_preview(ids!(location_preview)).clear();
+
+        let room_label = room_name_id.to_string();
+        let status_message = match state {
+            RoomState::Banned => format!("You have been banned from {room_label}."),
+            RoomState::Left => format!("You are no longer a member of {room_label}."),
+            _ => format!("You are no longer a member of {room_label}."),
+        };
+        status_text.set_text(cx, &status_message);
+
+        let (mut button_text, mut action) = match state {
+            RoomState::Banned => ("Cannot rejoin until un-banned".to_owned(), MembershipFooterAction::None),
+            RoomState::Left => match join_rule {
+                Some(JoinRuleSummary::Public) => ("Re-join this room".to_owned(), MembershipFooterAction::Join),
+                Some(JoinRuleSummary::Invite) => ("Re-joining requires an invite".to_owned(), MembershipFooterAction::None),
+                Some(JoinRuleSummary::Knock | JoinRuleSummary::KnockRestricted(_)) => {
+                    ("Knock to re-join".to_owned(), MembershipFooterAction::Knock)
+                }
+                Some(JoinRuleSummary::Restricted(_)) => {
+                    ("Re-joining requires an invite or other room membership".to_owned(), MembershipFooterAction::None)
+                }
+                None => ("Re-join options unavailable".to_owned(), MembershipFooterAction::None),
+                _ => ("Not allowed to re-join this room".to_owned(), MembershipFooterAction::None),
+            },
+            _ => ("Not allowed to re-join this room".to_owned(), MembershipFooterAction::None),
+        };
+
+        if preview_pending {
+            button_text = "Checking re-join options...".to_owned();
+            action = MembershipFooterAction::None;
+        }
+
+        self.membership_footer_action = action;
+        action_button.set_text(cx, &button_text);
+        let enabled = matches!(action, MembershipFooterAction::Join | MembershipFooterAction::Knock);
+        let (fg_color, bg_color, border_color) = if enabled {
+            (COLOR_FG_ACCEPT_GREEN, COLOR_BG_ACCEPT_GREEN, COLOR_FG_ACCEPT_GREEN)
+        } else {
+            (COLOR_FG_DISABLED, COLOR_BG_DISABLED, COLOR_FG_DISABLED)
+        };
+        action_button.apply_over(cx, live! {
+            enabled: (enabled),
+            draw_icon: {
+                color: (fg_color),
+            }
+            draw_text: {
+                color: (fg_color),
+            }
+            draw_bg: {
+                color: (bg_color),
+                border_color: (border_color),
+            }
+        });
+    }
+
+    fn hide_membership_footer(&mut self, cx: &mut Cx) {
+        self.membership_footer_visible = false;
+        self.membership_footer_action = MembershipFooterAction::None;
+        self.membership_footer_room_id = None;
+        let membership_footer = self.view.view(ids!(membership_footer));
+        membership_footer.set_visible(cx, false);
+        membership_footer.label(ids!(status_text)).set_text(cx, "");
+        membership_footer.button(ids!(action_button)).set_text(cx, "");
     }
 
     /// Sets the send_message_button to be enabled and green, or disabled and gray.
@@ -507,6 +683,12 @@ impl RoomInputBar {
         cx: &mut Cx,
         user_power_levels: UserPowerLevels,
     ) {
+        if self.membership_footer_visible || self.tombstone_footer_visible {
+            self.view.view(ids!(input_bar)).set_visible(cx, false);
+            self.view.view(ids!(can_not_send_message_notice)).set_visible(cx, false);
+            return;
+        }
+
         let can_send = user_power_levels.can_send_message();
         self.view.view(ids!(input_bar)).set_visible(cx, can_send);
         self.view.view(ids!(can_not_send_message_notice)).set_visible(cx, !can_send);
@@ -572,6 +754,25 @@ impl RoomInputBarRef {
         inner.update_tombstone_footer(cx, tombstoned_room_id, successor_room_details);
     }
 
+    /// Shows or updates the membership footer based on the given room state.
+    pub fn update_membership_footer(
+        &self,
+        cx: &mut Cx,
+        room_name_id: &RoomNameId,
+        state: RoomState,
+        join_rule: Option<JoinRuleSummary>,
+        preview_pending: bool,
+    ) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.update_membership_footer(cx, room_name_id, state, join_rule, preview_pending);
+    }
+
+    /// Hides the membership footer and clears its state.
+    pub fn hide_membership_footer(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.hide_membership_footer(cx);
+    }
+
     /// Forwards the result of an edit request to the `EditingPane` widget
     /// within this `RoomInputBar`.
     pub fn handle_edit_result(
@@ -615,6 +816,8 @@ impl RoomInputBarRef {
             replying_to,
             editing_pane_state,
         } = saved_state;
+
+        inner.hide_membership_footer(cx);
 
         // Note: we do *not* restore the location preview state here; see `save_state()`.
 

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -20,7 +20,7 @@ use makepad_widgets::*;
 use matrix_sdk::{RoomState, room::reply::{EnforceThread, Reply}};
 use matrix_sdk_ui::timeline::{EmbeddedEvent, EventTimelineItem, TimelineEventItemId};
 use ruma::{events::room::message::{LocationMessageEventContent, MessageType, RoomMessageEventContent}, room::JoinRuleSummary, OwnedRoomId};
-use crate::{home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt}, location_preview::LocationPreviewWidgetExt, room_screen::{populate_preview_of_timeline_item, MessageAction, RoomScreenProps}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}}, location::init_location_subscriber, shared::{avatar::AvatarWidgetRefExt, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::MentionableTextInputWidgetExt, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, styles::*}, sliding_sync::{submit_async_request, MatrixRequest, UserPowerLevels}, utils::{self, RoomNameId}};
+use crate::{home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt}, location_preview::LocationPreviewWidgetExt, room_screen::{populate_preview_of_timeline_item, MessageAction, RoomScreenProps}, rooms_list::{InviteState, RoomsListRef}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}}, location::init_location_subscriber, shared::{avatar::AvatarWidgetRefExt, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::MentionableTextInputWidgetExt, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, styles::*}, sliding_sync::{submit_async_request, MatrixRequest, UserPowerLevels}, utils::{self, RoomNameId}};
 
 live_design! {
     use link::theme::*;
@@ -182,20 +182,44 @@ live_design! {
                     text: ""
                 }
 
-                action_button = <RobrixIconButton> {
-                    padding: 15,
-                    draw_icon: {
-                        svg_file: (ICON_JOIN_ROOM),
-                        color: (COLOR_FG_ACCEPT_GREEN),
-                    }
-                    icon_walk: {width: 17, height: 17, margin: {left: -2, right: -1} }
+                actions_row = <View> {
+                    width: Fit,
+                    height: Fit,
+                    flow: Right,
+                    spacing: 10,
 
-                    draw_bg: {
-                        border_color: (COLOR_FG_ACCEPT_GREEN),
-                        color: (COLOR_BG_ACCEPT_GREEN)
+                    action_button = <RobrixIconButton> {
+                        padding: 15,
+                        draw_icon: {
+                            svg_file: (ICON_JOIN_ROOM),
+                            color: (COLOR_FG_ACCEPT_GREEN),
+                        }
+                        icon_walk: {width: 17, height: 17, margin: {left: -2, right: -1} }
+
+                        draw_bg: {
+                            border_color: (COLOR_FG_ACCEPT_GREEN),
+                            color: (COLOR_BG_ACCEPT_GREEN)
+                        }
+                        draw_text: {
+                            color: (COLOR_FG_ACCEPT_GREEN),
+                        }
                     }
-                    draw_text: {
-                        color: (COLOR_FG_ACCEPT_GREEN),
+
+                    decline_button = <RobrixIconButton> {
+                        padding: 15,
+                        draw_icon: {
+                            svg_file: (ICON_FORBIDDEN),
+                            color: (COLOR_FG_DANGER_RED),
+                        }
+                        icon_walk: {width: 17, height: 17, margin: {left: -2, right: -1} }
+
+                        draw_bg: {
+                            border_color: (COLOR_FG_DANGER_RED),
+                            color: (COLOR_BG_DANGER_RED)
+                        }
+                        draw_text: {
+                            color: (COLOR_FG_DANGER_RED),
+                        }
                     }
                 }
             }
@@ -229,6 +253,7 @@ pub struct RoomInputBar {
     #[rust] membership_footer_action: MembershipFooterAction,
     #[rust] membership_footer_room_id: Option<OwnedRoomId>,
     #[rust] membership_footer_visible: bool,
+    #[rust] membership_footer_is_invited: bool,
     /// Tracks whether the tombstone footer is currently visible.
     #[rust] tombstone_footer_visible: bool,
 }
@@ -293,11 +318,15 @@ impl RoomInputBar {
             self.redraw(cx);
         }
 
-        if self.button(ids!(membership_footer.action_button)).clicked(actions) {
+        if self.button(ids!(membership_footer.actions_row.action_button)).clicked(actions) {
             if let Some(room_id) = self.membership_footer_room_id.clone() {
                 match self.membership_footer_action {
                     MembershipFooterAction::Join => {
-                        submit_async_request(MatrixRequest::JoinRoom { room_id });
+                        submit_async_request(MatrixRequest::JoinRoom { room_id: room_id.clone() });
+                        if self.membership_footer_is_invited && cx.has_global::<RoomsListRef>() {
+                            let rooms_list_ref = cx.get_global::<RoomsListRef>();
+                            rooms_list_ref.set_invite_state(room_id, InviteState::WaitingForJoinResult);
+                        }
                     }
                     MembershipFooterAction::Knock => {
                         submit_async_request(MatrixRequest::Knock {
@@ -307,6 +336,18 @@ impl RoomInputBar {
                         });
                     }
                     MembershipFooterAction::None => {}
+                }
+            }
+        }
+
+        if self.button(ids!(membership_footer.actions_row.decline_button)).clicked(actions) {
+            if self.membership_footer_is_invited {
+                if let Some(room_id) = self.membership_footer_room_id.clone() {
+                    submit_async_request(MatrixRequest::LeaveRoom { room_id: room_id.clone() });
+                    if cx.has_global::<RoomsListRef>() {
+                        let rooms_list_ref = cx.get_global::<RoomsListRef>();
+                        rooms_list_ref.set_invite_state(room_id, InviteState::WaitingForLeaveResult);
+                    }
                 }
             }
         }
@@ -571,13 +612,17 @@ impl RoomInputBar {
         state: RoomState,
         join_rule: Option<JoinRuleSummary>,
         preview_pending: bool,
+        invite_state: Option<InviteState>,
     ) {
         let membership_footer = self.view.view(ids!(membership_footer));
         let status_text = membership_footer.label(ids!(status_text));
-        let action_button = membership_footer.button(ids!(action_button));
+        let actions_row = membership_footer.view(ids!(actions_row));
+        let action_button = membership_footer.button(ids!(actions_row.action_button));
+        let decline_button = membership_footer.button(ids!(actions_row.decline_button));
 
         self.membership_footer_visible = true;
         self.membership_footer_room_id = Some(room_name_id.room_id().clone());
+        self.membership_footer_is_invited = matches!(state, RoomState::Invited);
         membership_footer.set_visible(cx, true);
         self.view.view(ids!(input_bar)).set_visible(cx, false);
         self.view.view(ids!(can_not_send_message_notice)).set_visible(cx, false);
@@ -591,45 +636,100 @@ impl RoomInputBar {
         self.location_preview(ids!(location_preview)).clear();
 
         let room_label = room_name_id.to_string();
-        let status_message = match state {
-            RoomState::Banned => format!("You have been banned from {room_label}."),
-            RoomState::Left => format!("You are no longer a member of {room_label}."),
-            _ => format!("You are no longer a member of {room_label}."),
+        let mut status_message = if self.membership_footer_is_invited {
+            format!("You have been invited to join {room_label}.")
+        } else {
+            match state {
+                RoomState::Banned => format!("You have been banned from {room_label}."),
+                RoomState::Left => format!("You are no longer a member of {room_label}."),
+                _ => format!("You are no longer a member of {room_label}."),
+            }
         };
-        status_text.set_text(cx, &status_message);
+        let mut button_text = String::new();
+        let mut decline_text = String::new();
+        let mut action = MembershipFooterAction::None;
+        let mut show_actions_row = true;
+        let mut show_decline_button = false;
+        let mut action_enabled = false;
+        let mut decline_enabled = false;
 
-        let (mut button_text, mut action) = match state {
-            RoomState::Banned => ("Cannot rejoin until un-banned".to_owned(), MembershipFooterAction::None),
-            RoomState::Left => match join_rule {
-                Some(JoinRuleSummary::Public) => ("Re-join this room".to_owned(), MembershipFooterAction::Join),
-                Some(JoinRuleSummary::Invite) => ("Re-joining requires an invite".to_owned(), MembershipFooterAction::None),
-                Some(JoinRuleSummary::Knock | JoinRuleSummary::KnockRestricted(_)) => {
-                    ("Knock to re-join".to_owned(), MembershipFooterAction::Knock)
+        if self.membership_footer_is_invited {
+            let invite_state = invite_state.unwrap_or(InviteState::WaitingOnUserInput);
+            match invite_state {
+                InviteState::WaitingOnUserInput => {
+                    button_text = "Accept invite".to_owned();
+                    decline_text = "Decline invite".to_owned();
+                    action = MembershipFooterAction::Join;
+                    action_enabled = true;
+                    decline_enabled = true;
+                    show_decline_button = true;
                 }
-                Some(JoinRuleSummary::Restricted(_)) => {
-                    ("Re-joining requires an invite or other room membership".to_owned(), MembershipFooterAction::None)
+                InviteState::WaitingForJoinResult => {
+                    button_text = "Joining...".to_owned();
+                    decline_text = "Decline invite".to_owned();
+                    show_decline_button = true;
                 }
-                None => ("Re-join options unavailable".to_owned(), MembershipFooterAction::None),
+                InviteState::WaitingForLeaveResult => {
+                    button_text = "Accept invite".to_owned();
+                    decline_text = "Rejecting...".to_owned();
+                    show_decline_button = true;
+                }
+                InviteState::WaitingForJoinedRoom => {
+                    button_text = "Waiting for room...".to_owned();
+                    decline_text = "Decline invite".to_owned();
+                    show_decline_button = true;
+                }
+                InviteState::RoomLeft => {
+                    status_message = format!("Invite rejected for {room_label}.");
+                    show_actions_row = false;
+                }
+            }
+        } else {
+            (button_text, action) = match state {
+                RoomState::Banned => ("Cannot rejoin until un-banned".to_owned(), MembershipFooterAction::None),
+                RoomState::Left => match join_rule {
+                    Some(JoinRuleSummary::Public) => ("Re-join this room".to_owned(), MembershipFooterAction::Join),
+                    Some(JoinRuleSummary::Invite) => ("Re-joining requires an invite".to_owned(), MembershipFooterAction::None),
+                    Some(JoinRuleSummary::Knock | JoinRuleSummary::KnockRestricted(_)) => {
+                        ("Knock to re-join".to_owned(), MembershipFooterAction::Knock)
+                    }
+                    Some(JoinRuleSummary::Restricted(_)) => {
+                        ("Re-joining requires an invite or other room membership".to_owned(), MembershipFooterAction::None)
+                    }
+                    None => ("Re-join options unavailable".to_owned(), MembershipFooterAction::None),
+                    _ => ("Not allowed to re-join this room".to_owned(), MembershipFooterAction::None),
+                },
                 _ => ("Not allowed to re-join this room".to_owned(), MembershipFooterAction::None),
-            },
-            _ => ("Not allowed to re-join this room".to_owned(), MembershipFooterAction::None),
-        };
+            };
 
-        if preview_pending {
-            button_text = "Checking re-join options...".to_owned();
-            action = MembershipFooterAction::None;
+            if preview_pending {
+                button_text = "Checking re-join options...".to_owned();
+                action = MembershipFooterAction::None;
+            }
+
+            action_enabled = matches!(action, MembershipFooterAction::Join | MembershipFooterAction::Knock);
         }
+
+        status_text.set_text(cx, &status_message);
+        actions_row.set_visible(cx, show_actions_row);
+        action_button.set_visible(cx, show_actions_row);
+        decline_button.set_visible(cx, show_actions_row && show_decline_button);
 
         self.membership_footer_action = action;
         action_button.set_text(cx, &button_text);
-        let enabled = matches!(action, MembershipFooterAction::Join | MembershipFooterAction::Knock);
-        let (fg_color, bg_color, border_color) = if enabled {
+        if show_decline_button {
+            decline_button.set_text(cx, &decline_text);
+        } else {
+            decline_button.set_text(cx, "");
+        }
+
+        let (fg_color, bg_color, border_color) = if action_enabled {
             (COLOR_FG_ACCEPT_GREEN, COLOR_BG_ACCEPT_GREEN, COLOR_FG_ACCEPT_GREEN)
         } else {
             (COLOR_FG_DISABLED, COLOR_BG_DISABLED, COLOR_FG_DISABLED)
         };
         action_button.apply_over(cx, live! {
-            enabled: (enabled),
+            enabled: (action_enabled),
             draw_icon: {
                 color: (fg_color),
             }
@@ -641,16 +741,38 @@ impl RoomInputBar {
                 border_color: (border_color),
             }
         });
+
+        let (decline_fg, decline_bg, decline_border) = if decline_enabled {
+            (COLOR_FG_DANGER_RED, COLOR_BG_DANGER_RED, COLOR_FG_DANGER_RED)
+        } else {
+            (COLOR_FG_DISABLED, COLOR_BG_DISABLED, COLOR_FG_DISABLED)
+        };
+        decline_button.apply_over(cx, live! {
+            enabled: (decline_enabled),
+            draw_icon: {
+                color: (decline_fg),
+            }
+            draw_text: {
+                color: (decline_fg),
+            }
+            draw_bg: {
+                color: (decline_bg),
+                border_color: (decline_border),
+            }
+        });
     }
 
     fn hide_membership_footer(&mut self, cx: &mut Cx) {
         self.membership_footer_visible = false;
         self.membership_footer_action = MembershipFooterAction::None;
         self.membership_footer_room_id = None;
+        self.membership_footer_is_invited = false;
         let membership_footer = self.view.view(ids!(membership_footer));
         membership_footer.set_visible(cx, false);
         membership_footer.label(ids!(status_text)).set_text(cx, "");
-        membership_footer.button(ids!(action_button)).set_text(cx, "");
+        membership_footer.button(ids!(actions_row.action_button)).set_text(cx, "");
+        membership_footer.button(ids!(actions_row.decline_button)).set_text(cx, "");
+        membership_footer.button(ids!(actions_row.decline_button)).set_visible(cx, false);
     }
 
     /// Sets the send_message_button to be enabled and green, or disabled and gray.
@@ -762,9 +884,10 @@ impl RoomInputBarRef {
         state: RoomState,
         join_rule: Option<JoinRuleSummary>,
         preview_pending: bool,
+        invite_state: Option<InviteState>,
     ) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.update_membership_footer(cx, room_name_id, state, join_rule, preview_pending);
+        inner.update_membership_footer(cx, room_name_id, state, join_rule, preview_pending, invite_state);
     }
 
     /// Hides the membership footer and clears its state.


### PR DESCRIPTION
## PR Content

- keep left/banned rooms visible with status hint
- switch input bar to membership footer and stop typing actions
- update restore status view for persisted rooms

### 

1. if any administer ban somebody, the room screen will show:
<img width="1093" height="119" alt="image" src="https://github.com/user-attachments/assets/8f8a0fd5-11ad-4132-8152-eda1e19bfdc1" />
and you can't re-join again, but if administer unban, it will show:
<img width="1098" height="121" alt="image" src="https://github.com/user-attachments/assets/c9bc1902-2758-44b7-a524-fae2378fece6" />
 and you can re-join again.

2. if you has been removed, if this room join rule is can re-join again, seem about `administer unban you` solution above.

3. if adminster changes room's join rule, seem room_input_bar will display differece view. 

- public (user can easy to re-join)
- invite olny (adminster must re-send a invitation)

<img width="1086" height="116" alt="image" src="https://github.com/user-attachments/assets/e4e7dedb-4b09-4a25-ae87-d449de965401" />

like this flow: user joined -> adminster remove user -> adminster send invitation again -> user can accpet or reject.
-> if user accept, the normal join room process.
-> if not(below): 

If the user has previously visited this room, the room will remain accessible, but the user will be unable to send messages and can only view historical messages. If the user has never visited this room, they will enter the standard rejection process.


## PR Related PR/Issue

- https://github.com/project-robius/robrix/issues/656