### PR TITLE
Upgrade to latest Makepad. Override their strange log behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 
 [[package]]
 name = "accessory"
@@ -1429,7 +1429,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1584,7 +1584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2393,7 +2393,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2803,7 +2803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3001,9 +3001,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "makepad-error-log"
+version = "1.0.0"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+dependencies = [
+ "makepad-micro-serde",
+]
+
+[[package]]
 name = "makepad-fonts-chinese-bold"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-platform",
 ]
@@ -3011,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold-2"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-platform",
 ]
@@ -3019,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-platform",
 ]
@@ -3027,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular-2"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-platform",
 ]
@@ -3035,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-emoji"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-platform",
 ]
@@ -3043,17 +3051,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3061,7 +3069,10 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+dependencies = [
+ "makepad-script",
+]
 
 [[package]]
 name = "makepad-jni-sys"
@@ -3072,7 +3083,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -3082,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3091,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3099,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -3109,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3117,12 +3128,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3131,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3139,29 +3150,28 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 
 [[package]]
 name = "makepad-platform"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "bitflags 2.10.0",
  "hilog-sys",
  "makepad-android-state",
+ "makepad-error-log",
  "makepad-futures",
  "makepad-futures-legacy",
  "makepad-http",
  "makepad-jni-sys",
  "makepad-objc-sys",
- "makepad-script",
  "makepad-shader-compiler",
  "makepad-wasm-bridge",
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
  "smallvec",
- "tempfile",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3173,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -3188,9 +3198,11 @@ dependencies = [
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
+ "makepad-error-log",
  "makepad-live-id",
+ "makepad-math",
  "makepad-script-derive",
  "smallvec",
 ]
@@ -3198,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3206,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -3214,12 +3226,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 
 [[package]]
 name = "makepad-vector"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -3228,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3237,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3257,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3265,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3273,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -5113,7 +5125,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5268,7 +5280,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=serde_optional#e070743668bdd2abb102d1f6f6ea9cfca3e3132e"
+source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
 
 [[package]]
 name = "sealed"
@@ -5960,7 +5972,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ version = "0.0.1-pre-alpha-4"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "serde_optional", features = ["serde"] }
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -220,6 +220,19 @@ impl MatchEvent for App {
         // only init logging/tracing once
         let _ = tracing_subscriber::fmt::try_init();
 
+        // Override Makepad's new default-JSON logger. We just want regular formatting.
+        fn regular_log(file_name: &str, line_start: u32, column_start: u32, _line_end: u32, _column_end: u32, message: String, level: LogLevel) {
+            let l = match level {
+                LogLevel::Panic   => "[!]",
+                LogLevel::Error   => "[E]",
+                LogLevel::Warning => "[W]",
+                LogLevel::Log     => "[I]",
+                LogLevel::Wait    => "[.]",
+            };
+            println!("{l} {file_name}:{}:{}: {message}", line_start + 1, column_start + 1);
+        }
+        *LOG_WITH_LEVEL.write().unwrap() = regular_log;
+
         // Initialize the project directory here from the main UI thread
         // such that background threads/tasks will be able to can access it.
         let _app_data_dir = crate::app_data_dir();


### PR DESCRIPTION
Fixes the issue of whitespace being wrapped (see #594)