### PR TITLE
Fix CalloutTooltip behavior to be automatically redrawn if needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 
 [[package]]
 name = "accessory"
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3011,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-platform",
 ]
@@ -3019,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-platform",
 ]
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-platform",
 ]
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular-2"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-platform",
 ]
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-emoji"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-platform",
 ]
@@ -3051,17 +3051,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-script",
 ]
@@ -3083,7 +3083,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3128,12 +3128,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3142,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3150,12 +3150,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 
 [[package]]
 name = "makepad-platform"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "bitflags 2.10.0",
  "hilog-sys",
@@ -3183,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-error-log",
  "makepad-live-id",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -3226,12 +3226,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 
 [[package]]
 name = "makepad-vector"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3269,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -5280,7 +5280,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#7a5069495ae9f795da74795d9b4a04ee82fc6212"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
 
 [[package]]
 name = "sealed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ version = "0.0.1-pre-alpha-4"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "tooltip_hide_fix", features = ["serde"] }
+
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
 robius-use-makepad = "0.1.1"

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -34,10 +34,7 @@ use crate::{
         user_profile::UserProfile,
         user_profile_cache::{self, UserProfileUpdate},
     }, shared::{
-        avatar::{AvatarState, AvatarWidgetExt},
-        callout_tooltip::{CalloutTooltipOptions, TooltipAction, TooltipPosition},
-        styles::*,
-        verification_badge::VerificationBadgeWidgetExt,
+        avatar::{AvatarState, AvatarWidgetExt}, callout_tooltip::{CalloutTooltipOptions, TooltipAction, TooltipPosition}, styles::*, verification_badge::VerificationBadgeWidgetExt
     }, sliding_sync::current_user_id, utils::{self, RoomNameId}
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use std::{path::Path, sync::OnceLock};
 
 use robius_directories::ProjectDirs;


### PR DESCRIPTION
Tested thoroughly to work both on mobile (via long press) and desktop (via mouse hover).

This isn't really the most *ideal* way to reposition the tooltip if it needs to be moved (e.g., to avoid clipping outside the window), but it does work.

Once makepad supports post-draw repositioning easily, then we can stop using this timer hack.