### PR TITLE
Remove the now-unnecessary "show tooltip" action upon hover over

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 
 [[package]]
 name = "accessory"
@@ -1584,7 +1584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2803,7 +2803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3011,7 +3011,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-platform",
 ]
@@ -3019,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold-2"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-platform",
 ]
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-platform",
 ]
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular-2"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-platform",
 ]
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-emoji"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-platform",
 ]
@@ -3051,17 +3051,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-script",
 ]
@@ -3083,7 +3083,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3128,12 +3128,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3142,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3150,12 +3150,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 
 [[package]]
 name = "makepad-platform"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "bitflags 2.10.0",
  "hilog-sys",
@@ -3183,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-error-log",
  "makepad-live-id",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -3226,12 +3226,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 
 [[package]]
 name = "makepad-vector"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3269,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -5125,7 +5125,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5280,7 +5280,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_hide_fix#46f1d6a372c3cab4076454eb5841809f27d4b32b"
+source = "git+https://github.com/makepad/makepad?branch=dev#2898fb1367a95385df79141cd765bf8cf0719b8d"
 
 [[package]]
 name = "sealed"
@@ -5972,7 +5972,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ version = "0.0.1-pre-alpha-4"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "tooltip_hide_fix", features = ["serde"] }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/home/edited_indicator.rs
+++ b/src/home/edited_indicator.rs
@@ -60,7 +60,6 @@ impl Widget for EditedIndicator {
         let area = self.view.area();
         let should_hover_in = match event.hits(cx, area) {
             Hit::FingerLongPress(_)
-            | Hit::FingerHoverOver(..) // TODO: remove once CalloutTooltip bug is fixed
             | Hit::FingerHoverIn(..) => true,
             // TODO: show edit history modal on click
             // Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() => {

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -150,8 +150,7 @@ impl Widget for ReactionList {
                     cx.set_key_focus(button_area);
                     break;
                 }
-                Hit::FingerHoverOver(..) // TODO: remove once CalloutTooltip bug is fixed
-                | Hit::FingerHoverIn(..) => {
+                Hit::FingerHoverIn(..) => {
                     self.do_hover_in(cx, scope, button_ref, reaction_data.clone());
                     break;
                 }

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -335,7 +335,6 @@ impl Widget for ProfileIcon {
         let area = self.view.area();
         match event.hits(cx, area) {
             Hit::FingerLongPress(_)
-            | Hit::FingerHoverOver(_) // TODO: remove once CalloutTooltip bug is fixed
             | Hit::FingerHoverIn(_) => {
                 let (verification_str, bg_color) = self.view
                     .verification_badge(ids!(verification_badge))

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -294,9 +294,6 @@ impl Widget for SpacesBarEntry {
                 self.animator_play(cx, ids!(hover.on));
                 emit_hover_in_action(self, cx);
             }
-            Hit::FingerHoverOver(_) => {
-                emit_hover_in_action(self, cx);
-            }
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, ids!(hover.off));
                 cx.widget_action(
@@ -341,7 +338,6 @@ impl Widget for SpacesBarEntry {
             Hit::FingerUp(fe) if !fe.is_over => {
                 self.animator_play(cx, ids!(hover.off));
             }
-            Hit::FingerMove(_fe) => { }
             _ => {}
         }
     }

--- a/src/shared/timestamp.rs
+++ b/src/shared/timestamp.rs
@@ -48,7 +48,6 @@ impl Widget for Timestamp {
         let area = self.view.area();
         let should_hover_in = match event.hits(cx, area) {
             Hit::FingerLongPress(_)
-            | Hit::FingerHoverOver(..) // TODO: remove once CalloutTooltip bug is fixed
             | Hit::FingerHoverIn(..) => true,
             Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() => true,
             Hit::FingerHoverOut(_) => {


### PR DESCRIPTION
This should have never been needed, but there was an issue with how the tooltip worked previousy. Now it no longer needs this, so it's inefficient to re-display the tooltip upon every hover over event; it should only happen on the initial hover-in (or long press) event/hit.