### PR TITLE
Fix login screen layout on mobile devices

### DIFF
--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -57,7 +57,7 @@ live_design! {
         }
 
         <ScrollXYView> {
-            width: Fit, height: Fill,
+            width: Fill, height: Fill,
             // Note: *do NOT* vertically center this, it will break scrolling.
             align: {x: 0.5}
             show_bg: true,


### PR DESCRIPTION
This PR fixes the layout issue where the login screen was not correctly horizontally centered on mobile devices.

The issue was caused by the `ScrollXYView` having `width: Fit`, which made it shrink to the width of its content. As a result, the internal alignment (`align: {x: 0.5}`) only centered the content within that shrunk width, not relative to the screen.

By changing `width` to `Fill`, the `ScrollXYView` now occupies the full screen width, allowing the content to be properly centered horizontally.

This change is consistent with other screens (e.g., `SettingsScreen`, `UserProfileView`) which also use `width: Fill` for their top-level `ScrollXYView`.

---
*PR created automatically by Jules for task [5841726047480892108](https://jules.google.com/task/5841726047480892108) started by @kevinaboos*