### PR TITLE
Use pure_rust_locales for timestamp formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "pure-rust-locales",
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.0",
@@ -1429,7 +1430,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1584,7 +1585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2803,7 +2804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -4430,6 +4431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "pure-rust-locales"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869675ad2d7541aea90c6d88c81f46a7f4ea9af8cd0395d38f11a95126998a0d"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4872,6 +4879,7 @@ dependencies = [
  "matrix-sdk-base",
  "matrix-sdk-ui",
  "percent-encoding",
+ "pure-rust-locales",
  "quinn",
  "rand 0.8.5",
  "rangemap",
@@ -5125,7 +5133,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5972,7 +5980,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6953,7 +6961,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ robius-location = { git = "https://github.com/project-robius/robius" }
 
 
 anyhow = "1.0"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["unstable-locales"] }
 clap = { version = "4.0.16", features = ["derive"] }
 crossbeam-channel = "0.5.10"
 crossbeam-queue = "0.3.8"
@@ -79,6 +79,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "macos-system-configuration",
 ] }
 thiserror = "2.0.16"
+pure-rust-locales = "0.8.2"
 
 
 [features]

--- a/src/home/edited_indicator.rs
+++ b/src/home/edited_indicator.rs
@@ -10,6 +10,7 @@
 use chrono::{DateTime, Local};
 use makepad_widgets::*;
 use matrix_sdk_ui::timeline::EventTimelineItem;
+use pure_rust_locales::Locale;
 
 use crate::{shared::callout_tooltip::{CalloutTooltipOptions, TooltipAction, TooltipPosition}, utils::unix_time_millis_to_datetime};
 
@@ -73,10 +74,12 @@ impl Widget for EditedIndicator {
             _ => false,
         };
         if should_hover_in {
-            // TODO: use pure_rust_locales crate to format the time based on the chosen Locale.
-            let locale_extended_fmt_en_us= "%a %b %-d, %Y, %r";
+            // TODO: use the user's actual chosen Locale once we have a way to select it.
+            // For now we hardcode en_US, but we use `format_localized` so it's ready.
+            let locale = Locale::en_US;
             let text = if let Some(ts) = self.latest_edit_ts {
-                format!("Last edited {}", ts.format(locale_extended_fmt_en_us))
+                // %c is the locale's preferred date and time representation
+                format!("Last edited {}", ts.format_localized("%c", locale))
             } else {
                 "Last edit time unknown".to_string()
             };

--- a/src/shared/timestamp.rs
+++ b/src/shared/timestamp.rs
@@ -3,6 +3,7 @@
 
 use chrono::{DateTime, Local};
 use makepad_widgets::*;
+use pure_rust_locales::Locale;
 
 use crate::shared::callout_tooltip::{CalloutTooltipOptions, TooltipPosition};
 
@@ -57,13 +58,15 @@ impl Widget for Timestamp {
             _ => false,
         };
         if should_hover_in {
-            // TODO: use pure_rust_locales crate to format the time based on the chosen Locale.
-            let locale_extended_fmt_en_us= "%a %b %-d, %Y, %r";
+            // TODO: use the user's actual chosen Locale once we have a way to select it.
+            // For now we hardcode en_US, but we use `format_localized` so it's ready.
+            let locale = Locale::en_US;
             cx.widget_action(
                 self.widget_uid(),
                 &scope.path,
                 TooltipAction::HoverIn {
-                    text: self.dt.format(locale_extended_fmt_en_us).to_string(),
+                    // %c is the locale's preferred date and time representation
+                    text: self.dt.format_localized("%c", locale).to_string(),
                     widget_rect: area.rect(cx),
                     options: CalloutTooltipOptions {
                         position: TooltipPosition::Right,
@@ -81,11 +84,13 @@ impl Widget for Timestamp {
 
 impl Timestamp {
     pub fn set_date_time(&mut self, cx: &mut Cx, dt: DateTime<Local>) {
-        // TODO: use pure_rust_locales crate to format the time based on the chosen Locale.
-        let locale_fmt_en_us = "%-I:%M %P";
+        // TODO: use the user's actual chosen Locale once we have a way to select it.
+        // For now we hardcode en_US, but we use `format_localized` so it's ready.
+        let locale = Locale::en_US;
+        // %X is the locale's preferred time representation
         self.label(ids!(ts_label)).set_text(
             cx,
-            &dt.format(locale_fmt_en_us).to_string()
+            &dt.format_localized("%X", locale).to_string()
         );
         self.dt = dt;
     }


### PR DESCRIPTION
Implemented locale-aware timestamp formatting using the `pure_rust_locales` crate as requested.

Changes:
- Added `pure-rust-locales` dependency.
- Enabled `unstable-locales` feature for `chrono`.
- Updated `src/shared/timestamp.rs` to use `dt.format_localized()` with `%c` (tooltip) and `%X` (label).
- Updated `src/home/edited_indicator.rs` to use `dt.format_localized()` with `%c`.
- Currently defaults to `Locale::en_US` as there is no global locale setting yet, but the mechanism is now in place to support switching locales easily.

---
*PR created automatically by Jules for task [3164989320181925500](https://jules.google.com/task/3164989320181925500) started by @kevinaboos*