### PR TITLE
Implement setting the user's display name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ description = "A Matrix chat client written using Makepad + Robius app dev frame
 documentation = "https://docs.rs/robrix"
 edition = "2024"  ## mostly just to allow let-chains
 homepage = "https://robius.rs/"
-keywords = ["matrix", "chat", "client", "robrix", "robius"]
+keywords = ["matrix", "chat", "client", "robius", "makepad"]
 license = "MIT"
 readme = "README.md"
+categories = [ "gui" ]
 repository = "https://github.com/project-robius/robrix"
 version = "0.0.1-pre-alpha-4"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
@@ -50,6 +51,7 @@ matrix-sdk-ui = { git = "https://github.com/matrix-org/matrix-rust-sdk", branch 
 ## Enable a few extra features:
 ## * "compat-optional" feature to allow missing body field in m.room.tombstone event.
 ## * "compat-unset-avatar" feature to allow deleting the user's avatar to work properly.
+## * Note: we need a feature like "compat-unset-display-name" to unset display names, but that doesn't exist yet.
 ruma = { version = "0.14.1", features = ["compat-optional", "compat-unset-avatar"] } 
 rand = "0.8.5"
 rangemap = "1.5.0"

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -368,6 +368,20 @@ impl Widget for ProfileIcon {
                         // this is only handled in the account settings screen
                         continue;
                     }
+                    Some(AccountDataAction::DisplayNameChanged(new_display_name)) => {
+                        if let Some(p) = self.own_profile.as_mut() {
+                            p.username = new_display_name.clone();
+                            user_profile_cache::enqueue_user_profile_update(
+                                UserProfileUpdate::UserProfileOnly(p.clone())
+                            );
+                            self.view.redraw(cx);
+                        }
+                        continue;
+                    }
+                    Some(AccountDataAction::DisplayNameChangeFailed(_)) => {
+                        // this is only handled in the account settings screen
+                        continue;
+                    }
                     _ => {}
                 }
             }

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -415,6 +415,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                     color: (COLOR_PRIMARY)
                 }
             });
+            accept_button.reset_hover(cx);
             cancel_button.set_visible(cx, false);
         }
         if needs_redraw {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -285,6 +285,10 @@ pub enum AccountDataAction {
     AvatarChanged(Option<OwnedMxcUri>),
     /// Failed to update or remove the user's avatar.
     AvatarChangeFailed(String),
+    /// The user's display name was successfully updated or removed.
+    DisplayNameChanged(Option<String>),
+    /// Failed to update the user's display name.
+    DisplayNameChangeFailed(String),
 }
 
 /// The set of requests for async work that can be made to the worker thread.
@@ -417,11 +421,16 @@ pub enum MatrixRequest {
         room_id: OwnedRoomId,
     },
     /// Request to set or remove the avatar of the current user's account.
-    ///
-    /// * If `avatar_url` is `Some`, the avatar will be set to the given MXC URI.
-    /// * If `avatar_url` is `None`, the avatar will be removed.
     SetAvatar {
+        /// * If `Some`, the avatar will be set to the given MXC URI.
+        /// * If `None`, the avatar will be removed.
         avatar_url: Option<OwnedMxcUri>,
+    },
+    /// Request to set or remove the display name of the current user's account.
+    SetDisplayName {
+        /// * If `Some`, the display name will be set to the given value.
+        /// * If `None`, the display name will be removed.
+        new_display_name: Option<String>,
     },
     /// Request to resolve a room alias into a room ID and the servers that know about that room.
     ResolveRoomAlias(OwnedRoomAliasId),
@@ -1056,6 +1065,27 @@ async fn matrix_worker_task(
                         Err(e) => {
                             let err_msg = format!("Failed to {} avatar: {e}", if is_removing { "remove" } else { "set" });
                             Cx::post_action(AccountDataAction::AvatarChangeFailed(err_msg));
+                        }
+                    }
+                });
+            }
+            MatrixRequest::SetDisplayName { new_display_name } => {
+                let Some(client) = get_client() else { continue };
+                let _set_display_name_task = Handle::current().spawn(async move {
+                    let is_removing = new_display_name.is_none();
+                    log!("Sending request to {} display name{}...",
+                        if is_removing { "remove" } else { "set" },
+                        new_display_name.as_ref().map(|n| format!(" to '{n}'")).unwrap_or_default()
+                    );
+                    let result = client.account().set_display_name(new_display_name.as_deref()).await;
+                    match result {
+                        Ok(_) => {
+                            log!("Successfully {} display name.", if is_removing { "removed" } else { "set" });
+                            Cx::post_action(AccountDataAction::DisplayNameChanged(new_display_name));
+                        }
+                        Err(e) => {
+                            let err_msg = format!("Failed to {} display name: {e}", if is_removing { "remove" } else { "set" });
+                            Cx::post_action(AccountDataAction::DisplayNameChangeFailed(err_msg));
                         }
                     }
                 });


### PR DESCRIPTION
Currently there is an SDK/ruma bug that prevents the user from clearing their display name by saving an empty name. However, all other non-empty string names are tested working.