### PR TITLE
🎨 Palette: Add tooltips to RoomInputBar buttons

### DIFF
--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -19,7 +19,7 @@ use makepad_widgets::*;
 use matrix_sdk::room::reply::{EnforceThread, Reply};
 use matrix_sdk_ui::timeline::{EmbeddedEvent, EventTimelineItem, TimelineEventItemId};
 use ruma::{events::room::message::{LocationMessageEventContent, MessageType, RoomMessageEventContent}, OwnedRoomId};
-use crate::{home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt}, location_preview::LocationPreviewWidgetExt, room_screen::{populate_preview_of_timeline_item, MessageAction, RoomScreenProps}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}}, location::init_location_subscriber, shared::{avatar::AvatarWidgetRefExt, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::MentionableTextInputWidgetExt, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, styles::*}, sliding_sync::{submit_async_request, MatrixRequest, UserPowerLevels}, utils};
+use crate::{home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt}, location_preview::LocationPreviewWidgetExt, room_screen::{populate_preview_of_timeline_item, MessageAction, RoomScreenProps}, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}}, location::init_location_subscriber, shared::{avatar::AvatarWidgetRefExt, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::MentionableTextInputWidgetExt, popup_list::{enqueue_popup_notification, PopupItem, PopupKind}, styles::*, callout_tooltip::{CalloutTooltipOptions, TooltipAction, TooltipPosition}}, sliding_sync::{submit_async_request, MatrixRequest, UserPowerLevels}, utils};
 
 live_design! {
     use link::theme::*;
@@ -203,6 +203,61 @@ impl Widget for RoomInputBar {
                         auto_dismissal_duration: None
                     });
                 }
+            }
+            _ => {}
+        }
+
+        match event.hits(cx, self.button(ids!(location_button)).area()) {
+            Hit::FingerHoverIn(fe) => {
+                cx.widget_action(
+                    room_screen_props.room_screen_widget_uid,
+                    &scope.path,
+                    TooltipAction::HoverIn {
+                        text: "Share location".to_string(),
+                        widget_rect: fe.rect,
+                        options: CalloutTooltipOptions {
+                            position: TooltipPosition::Top,
+                            ..Default::default()
+                        },
+                    },
+                );
+            }
+            Hit::FingerHoverOut(_) => {
+                cx.widget_action(
+                    room_screen_props.room_screen_widget_uid,
+                    &scope.path,
+                    TooltipAction::HoverOut,
+                );
+            }
+            _ => {}
+        }
+
+        match event.hits(cx, self.button(ids!(send_message_button)).area()) {
+            Hit::FingerHoverIn(fe) => {
+                let text = if self.mentionable_text_input(ids!(mentionable_text_input)).text().trim().is_empty() {
+                    "Type a message to send".to_string()
+                } else {
+                    "Send message".to_string()
+                };
+                cx.widget_action(
+                    room_screen_props.room_screen_widget_uid,
+                    &scope.path,
+                    TooltipAction::HoverIn {
+                        text,
+                        widget_rect: fe.rect,
+                        options: CalloutTooltipOptions {
+                            position: TooltipPosition::Top,
+                            ..Default::default()
+                        },
+                    },
+                );
+            }
+            Hit::FingerHoverOut(_) => {
+                cx.widget_action(
+                    room_screen_props.room_screen_widget_uid,
+                    &scope.path,
+                    TooltipAction::HoverOut,
+                );
             }
             _ => {}
         }


### PR DESCRIPTION
💡 What: Added tooltips to the "Share location" and "Send message" icon-only buttons in the `RoomInputBar`.
🎯 Why: Improves accessibility and usability by providing text labels for icon-only controls.
♿ Accessibility: Users can now identify button functions via hover. The disabled state of the send button also explains why it is disabled.


---
*PR created automatically by Jules for task [4475918511641602731](https://jules.google.com/task/4475918511641602731) started by @kevinaboos*