### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file persistence

### DIFF
--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     app_data_dir,
     login::login_screen::LoginAction,
+    persistence::write_file_securely,
 };
 
 /// The data needed to re-build a client.
@@ -116,7 +117,7 @@ pub async fn most_recent_user_id() -> Option<OwnedUserId> {
 
 /// Save which user was the most recently logged in.
 async fn save_latest_user_id(user_id: &UserId) -> anyhow::Result<()> {
-    tokio::fs::write(
+    write_file_securely(
         app_data_dir().join(LATEST_USER_ID_FILE_NAME),
         user_id.as_str(),
     ).await?;
@@ -218,7 +219,7 @@ pub async fn save_session(
     if let Some(parent) = session_file.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
-    tokio::fs::write(&session_file, serialized_session).await?;
+    write_file_securely(&session_file, serialized_session).await?;
 
     log!("Session persisted to: {}", session_file.display());
     Ok(())

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -8,6 +8,10 @@ pub use matrix_state::*;
 pub mod app_state;
 pub use app_state::*;
 
+/// Common utilities for persistence.
+pub mod utils;
+pub use utils::*;
+
 /// For persisting state related to TSP wallets and identities.
 #[cfg(feature = "tsp")]
 pub mod tsp_state;

--- a/src/persistence/utils.rs
+++ b/src/persistence/utils.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+use anyhow::{Context, Result};
+use rand::Rng;
+use tokio::io::AsyncWriteExt;
+
+/// Writes the given `content` to the file at `path` in a secure and atomic manner.
+///
+/// This function:
+/// 1. Creates a temporary file in the same directory as the target `path`.
+/// 2. Sets the file permissions to `0o600` (read/write only for the owner) on Unix systems.
+/// 3. Writes the content to the temporary file.
+/// 4. Atomically renames the temporary file to the target `path`.
+///
+/// This prevents partial writes (corruption) and ensures that sensitive data is not readable by other users.
+pub async fn write_file_securely(path: impl AsRef<Path>, content: impl AsRef<[u8]>) -> Result<()> {
+    let path = path.as_ref();
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+
+    // Create a temporary file name with a random suffix.
+    let random_suffix: u32 = {
+        let mut rng = rand::thread_rng();
+        rng.r#gen()
+    };
+    let temp_filename = format!(
+        "{}.tmp.{}",
+        path.file_name().unwrap_or_default().to_string_lossy(),
+        random_suffix
+    );
+    let temp_path = parent.join(temp_filename);
+
+    // Open the file with restrictive permissions on creation if possible.
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(&temp_path).await
+        .with_context(|| format!("Failed to create temp file {}", temp_path.display()))?;
+
+    file.write_all(content.as_ref()).await
+        .with_context(|| format!("Failed to write to temp file {}", temp_path.display()))?;
+
+    file.flush().await
+        .with_context(|| format!("Failed to flush temp file {}", temp_path.display()))?;
+
+    // Ensure the file is closed before renaming (on Windows especially).
+    // Dropping `file` closes it, but async close is better if supported.
+    // Tokio `File` creates an async wrapper around std `File` (blocking).
+    // Dropping it closes the underlying fd.
+    drop(file);
+
+    // Rename (atomic replace).
+    tokio::fs::rename(&temp_path, path).await
+        .with_context(|| format!("Failed to rename {} to {}", temp_path.display(), path.display()))?;
+
+    Ok(())
+}


### PR DESCRIPTION
Implemented `write_file_securely` to atomically write sensitive session data.
This function writes to a temporary file with restricted permissions (0o600 on Unix) and then atomically renames it to the target path.
This prevents partial writes and ensures sensitive data is not world-readable.
Updated `src/persistence/matrix_state.rs` to use this new function for saving session and user ID.
Verified with `cargo check` and `cargo test` (existing failures are unrelated).

---
*PR created automatically by Jules for task [10178974387879733704](https://jules.google.com/task/10178974387879733704) started by @kevinaboos*