### PR TITLE
Add tooltips to navigation tab bar buttons

### DIFF
--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -512,6 +512,44 @@ impl Widget for NavigationTabBar {
                 }
             }
         }
+
+        // Handle tooltips for navigation buttons
+        let tooltip_mappings = [
+            (ids!(home_button), "Home"),
+            (ids!(add_room_button), "Add / Join Room"),
+            (ids!(settings_button), "Settings"),
+            (ids!(toggle_spaces_bar_button), "Spaces"),
+        ];
+
+        for (button_id, text) in tooltip_mappings {
+            let button = self.view.widget(button_id);
+            let area = button.area();
+            match event.hits(cx, area) {
+                Hit::FingerHoverIn(_) => {
+                    let options = CalloutTooltipOptions {
+                        position: if cx.display_context.is_desktop() {
+                            TooltipPosition::Right
+                        } else {
+                            TooltipPosition::Top
+                        },
+                        ..Default::default()
+                    };
+                    cx.widget_action(
+                        self.widget_uid(),
+                        &scope.path,
+                        TooltipAction::HoverIn {
+                            text: text.to_string(),
+                            widget_rect: area.rect(cx),
+                            options,
+                        },
+                    );
+                }
+                Hit::FingerHoverOut(_) => {
+                     cx.widget_action(self.widget_uid(), &scope.path, TooltipAction::HoverOut);
+                }
+                _ => {}
+            }
+        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {


### PR DESCRIPTION
Implemented tooltips for the main navigation buttons in `src/home/navigation_tab_bar.rs`.
- Iterated over the buttons (`home_button`, `add_room_button`, `settings_button`, `toggle_spaces_bar_button`).
- Added `Hit::FingerHoverIn` and `Hit::FingerHoverOut` handling in `handle_event`.
- Dispatched `TooltipAction` events to show/hide tooltips with appropriate text and positioning.

---
*PR created automatically by Jules for task [14787294448442673137](https://jules.google.com/task/14787294448442673137) started by @kevinaboos*