### PR TITLE
Allow tooltip to handle its own actions directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "bytes"
@@ -1941,9 +1941,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2945,12 +2945,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2989,15 +2989,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3005,22 +3005,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3034,7 +3034,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "ttf-parser",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3075,12 +3075,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3111,15 +3111,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3140,7 +3140,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3152,12 +3152,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3165,13 +3165,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3188,14 +3188,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3249,18 +3249,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "simd-adler32",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3663,7 +3663,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "mime"
@@ -4392,10 +4392,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
- "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
  "unicase 2.9.0",
 ]
 
@@ -5203,12 +5203,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5303,7 +5303,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "sealed"
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "siphasher"
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "socket2"
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "tungstenite"
@@ -6461,7 +6461,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-bidi"
@@ -6472,17 +6472,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-ident"
@@ -6493,7 +6493,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-normalization"
@@ -6513,12 +6513,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6529,7 +6529,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "unicode-width"
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6873,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6883,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "log",
  "pkg-config",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7147,7 +7147,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 
 [[package]]
 name = "windows-numerics"
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#ebe1cab1b79d52194552f59f0478d56e799493a1"
+source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "tooltip_consistent_hover_in_out", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "tooltip_consistent_hover_in_out" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/app.rs
+++ b/src/app.rs
@@ -142,6 +142,8 @@ script_mod! {
 
                         // Tooltips must be shown in front of all other UI elements,
                         // since they can be shown as a hover atop any other widget.
+                        // This tooltip widget handles TooltipActions directly by itself,
+                        // so we don't need to call show/hide ourselves.
                         app_tooltip := CalloutTooltip {}
                     }
                 } // end of body
@@ -381,30 +383,6 @@ impl MatchEvent for App {
                     if let Some((dest_room, room_to_close)) = self.waiting_to_navigate_to_room.take() {
                         self.navigate_to_room(cx, room_to_close.as_ref(), &dest_room);
                     }
-                    continue;
-                }
-                _ => {}
-            }
-
-            // Handle actions for showing or hiding the tooltip.
-            match action.as_widget_action().cast() {
-                TooltipAction::HoverIn { text, widget_rect, options } => {
-                    // Don't show any tooltips if the message context menu is currently shown.
-                    if self.ui.new_message_context_menu(cx, ids!(new_message_context_menu)).is_currently_shown(cx) {
-                        self.ui.callout_tooltip(cx, ids!(app_tooltip)).hide(cx);
-                    }
-                    else {
-                        self.ui.callout_tooltip(cx, ids!(app_tooltip)).show_with_options(
-                            cx,
-                            &text,
-                            widget_rect,
-                            options,
-                        );
-                    }
-                    continue;
-                }
-                TooltipAction::HoverOut => {
-                    self.ui.callout_tooltip(cx, ids!(app_tooltip)).hide(cx);
                     continue;
                 }
                 _ => {}


### PR DESCRIPTION
This simplifies the app code but also is more correct because the tooltip can now batch/buffer actions to properly handle a flood of hover-in/hover-out events that all happen "simultaneously".