### PR TITLE
Reduce blurhash decode cost and cache link preview widgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "bytes"
@@ -1941,9 +1941,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -2790,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2945,12 +2945,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2989,15 +2989,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3005,22 +3005,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3034,7 +3034,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "ttf-parser",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3075,12 +3075,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3111,15 +3111,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3140,7 +3140,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3152,12 +3152,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3165,13 +3165,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3188,14 +3188,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3249,18 +3249,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "simd-adler32",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3663,7 +3663,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "mime"
@@ -4392,10 +4392,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicase 2.9.0",
 ]
 
@@ -5203,12 +5203,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5303,7 +5303,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "sealed"
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "siphasher"
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "socket2"
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "tungstenite"
@@ -6461,7 +6461,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-bidi"
@@ -6472,17 +6472,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-ident"
@@ -6493,7 +6493,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-normalization"
@@ -6513,12 +6513,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6529,7 +6529,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "unicode-width"
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6873,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6883,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "log",
  "pkg-config",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7147,7 +7147,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 
 [[package]]
 name = "windows-numerics"
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=tooltip_consistent_hover_in_out#7bcda1ad1c7658dff7b0ecf3dbbe4665e16e3d74"
+source = "git+https://github.com/makepad/makepad?branch=dev#3cf602a4322f8eb4b5cf8709aeac13e6913f7713"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,8 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
-
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "tooltip_consistent_hover_in_out", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "tooltip_consistent_hover_in_out" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/app.rs
+++ b/src/app.rs
@@ -186,19 +186,6 @@ impl MatchEvent for App {
         // only init logging/tracing once
         let _ = tracing_subscriber::fmt::try_init();
 
-        // Override Makepad's new default-JSON logger. We just want regular formatting.
-        fn regular_log(file_name: &str, line_start: u32, column_start: u32, _line_end: u32, _column_end: u32, message: String, level: LogLevel) {
-            let l = match level {
-                LogLevel::Panic   => "[!]",
-                LogLevel::Error   => "[E]",
-                LogLevel::Warning => "[W]",
-                LogLevel::Log     => "[I]",
-                LogLevel::Wait    => "[.]",
-            };
-            println!("{l} {file_name}:{}:{}: {message}", line_start + 1, column_start + 1);
-        }
-        *LOG_WITH_LEVEL.write().unwrap() = regular_log;
-
         // Initialize the project directory here from the main UI thread
         // such that background threads/tasks will be able to can access it.
         let _app_data_dir = crate::app_data_dir();

--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -231,6 +231,10 @@ pub struct LinkPreview {
     is_expanded: bool,
     #[rust]
     hidden_links_count: usize,
+    /// Tracks the URLs that were last used to populate this widget's children,
+    /// so we can skip expensive widget recreation when the same links are shown.
+    #[rust]
+    last_populated_links: Vec<String>,
 }
 
 impl Widget for LinkPreview {
@@ -467,17 +471,16 @@ impl LinkPreviewRef {
     {
         const SKIPPED_DOMAINS: &[&str] = &["matrix.to", "matrix.io"];
         const MAX_LINK_PREVIEWS_BY_EXPAND: usize = 2;
-        let mut fully_drawn_count = 0;
-        let mut accepted_link_count = 0;
-        let mut views = Vec::new();
+
+        // Build the list of accepted URLs (after dedup + domain filtering)
+        // to check if we can skip the expensive widget recreation.
+        let mut accepted_urls: Vec<String> = Vec::new();
         let mut seen_urls = std::collections::HashSet::new();
-        
         for link in links {
             let url_string = link.to_string();
             if seen_urls.contains(&url_string) {
                 continue;
             }
-            
             if let Some(domain) = link.host_str() {
                 if SKIPPED_DOMAINS
                     .iter()
@@ -486,12 +489,28 @@ impl LinkPreviewRef {
                     continue;
                 }
             }
-            
             seen_urls.insert(url_string.clone());
-            accepted_link_count += 1;
+            accepted_urls.push(url_string);
+        }
+
+        // If the links haven't changed and children are already populated,
+        // skip the expensive widget recreation entirely.
+        if let Some(inner) = self.borrow() {
+            if accepted_urls == inner.last_populated_links && !inner.children.is_empty() {
+                return true;
+            }
+        }
+
+        let mut fully_drawn_count = 0;
+        let accepted_link_count = accepted_urls.len();
+        let mut views = Vec::with_capacity(accepted_link_count);
+
+        for (url_string, link) in accepted_urls.iter().zip(
+            links.iter().filter(|l| accepted_urls.contains(&l.to_string()))
+        ) {
             let (view_ref, was_image_drawn) = self.populate_view(
                 cx,
-                link_preview_cache.get_or_fetch_link_preview(url_string),
+                link_preview_cache.get_or_fetch_link_preview(url_string.clone()),
                 link,
                 media_cache,
                 |cx, text_or_image_ref, image_info_source, original_source, body, media_cache| {
@@ -504,6 +523,9 @@ impl LinkPreviewRef {
         if views.len() > MAX_LINK_PREVIEWS_BY_EXPAND {
             let hidden_count = views.len() - MAX_LINK_PREVIEWS_BY_EXPAND;
             self.show_collapsible_buttons(cx, hidden_count);
+        }
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.last_populated_links = accepted_urls;
         }
         self.set_children(views);
         fully_drawn_count == accepted_link_count

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -54,7 +54,12 @@ use super::{event_reaction_list::ReactionData, loading_pane::LoadingPaneRef, new
 const MAX_ITEMS_TO_SEARCH_THROUGH: usize = 100;
 
 /// The max size (width or height) of a blurhash image to decode.
-const BLURHASH_IMAGE_MAX_SIZE: u32 = 500;
+/// Blurhash is a blurred placeholder — it is designed to be decoded at a small
+/// size and then stretched by the GPU. Decoding at large sizes is extremely
+/// expensive (CPU-bound, O(width*height)) and completely unnecessary since the
+/// result is inherently blurry. A 32×32 decode is ~240x faster than 500×500
+/// while being visually indistinguishable when scaled up.
+const BLURHASH_IMAGE_MAX_SIZE: u32 = 32;
 
 static UNNAMED_ROOM: &str = "Unnamed Room";
 
@@ -522,6 +527,11 @@ script_mod! {
 
             auto_tail: true, // set to `true` to lock the view to the last item.
             max_pull_down: 0.0, // set to `0.0` to disable the pulldown bounce animation.
+            // TODO: enable `reuse_items: true` once Makepad's Html/TextFlow widget
+            //   properly resets all internal state during `script_apply(Reload)`.
+            //   Currently, stale TextFlow layout state (particularly related to
+            //   list items) leaks through when a widget is recycled, causing
+            //   excessive whitespace in HTML messages with `<ul>`/`<ol>` lists.
 
             // Below, we must place all of the possible templates (views) that can be used in the portal list.
             Message := mod.widgets.Message {}

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -93,7 +93,7 @@ script_mod! {
         width: Fill,
         spacing: 0.0
 
-        auto_tail: false, 
+        auto_tail: false,
         max_pull_down: 0.0,
         scroll_bar: ScrollBar {  // hide the scroll bar
             bar_size: 0.0,

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1177,7 +1177,7 @@ async fn matrix_worker_task(
                                     room_member,
                                 });
                             } else {
-                                log!("User profile request: user {user_id} was not a member of room {room_id}");
+                                // log!("User profile request: user {user_id} was not a member of room {room_id}");
                             }
                         } else {
                             log!("User profile request: client could not get room with ID {room_id}");


### PR DESCRIPTION
* Reduce blurhash placeholder decode size since it gets scaled on GPU anyway
* Cache link preview widgets to avoid wasted work when links haven't changed
* Document that `reuse_items` isn't working right
  * we need Makepad's Html/TextFlow to properly reset internal state during script_apply(Reload)
* Remove custom log formatting, we now fixed it in Makepad