### PR TITLE
Fix SSO button image shader on login screen

### DIFF
--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -34,10 +34,10 @@ script_mod! {
         draw_bg +: {
             mask: instance(0.0)
             pixel: fn() {
-                let color = self.get_color();
-                let gray = dot(color.rgb, vec3(0.299, 0.587, 0.114));
-                let grayed = mix(color, vec4(gray, gray, gray, color.a), self.mask);
-                return grayed;
+                let color = mix(self.get_color(), #3, self.async_load)
+                let gray = dot(color.rgb, vec3(0.299, 0.587, 0.114))
+                let grayed = mix(color, vec4(gray, gray, gray, color.a), self.mask)
+                return Pal.premul(vec4(grayed.xyz, grayed.w * self.opacity))
             }
         }
     }


### PR DESCRIPTION
Just noticed it wasn't working on android previously, which was a residual artifact from the makepad 2.0 migraiton