### PR TITLE
Minor optimization in post-verification device logging

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Replace `String::push_str(&format!(...))` with `writeln!(...)`
+**Learning:** In Rust loops, repeatedly concatenating formatted strings via `string.push_str(&format!(...))` creates unnecessary intermediate string allocations on every iteration.
+**Action:** Use `std::fmt::Write` and `writeln!(&mut string, ...)` instead to format directly into the destination string buffer, avoiding allocations and improving performance.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-05-15 - Replace `String::push_str(&format!(...))` with `writeln!(...)`
-**Learning:** In Rust loops, repeatedly concatenating formatted strings via `string.push_str(&format!(...))` creates unnecessary intermediate string allocations on every iteration.
-**Action:** Use `std::fmt::Write` and `writeln!(&mut string, ...)` instead to format directly into the destination string buffer, avoiding allocations and improving performance.

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -77,7 +77,6 @@ async fn dump_devices(user_id: &UserId, client: &Client) -> String {
     let mut devices = String::new();
     for device in client.encryption().get_user_devices(user_id).await.unwrap().devices() {
         let current = client.device_id().is_some_and(|id| id == device.device_id());
-        // ⚡ Bolt: avoid creating an intermediate string allocation for every device
         let _ = writeln!(&mut devices,
             "    {:<10} {:<30} {:<}{}",
             device.device_id(),

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::sync::Arc;
 use futures_util::StreamExt;
 use makepad_widgets::{log, Cx};
@@ -76,13 +77,14 @@ async fn dump_devices(user_id: &UserId, client: &Client) -> String {
     let mut devices = String::new();
     for device in client.encryption().get_user_devices(user_id).await.unwrap().devices() {
         let current = client.device_id().is_some_and(|id| id == device.device_id());
-        devices.push_str(&format!(
-            "    {:<10} {:<30} {:<}{}\n",
+        // ⚡ Bolt: avoid creating an intermediate string allocation for every device
+        let _ = writeln!(&mut devices,
+            "    {:<10} {:<30} {:<}{}",
             device.device_id(),
             device.display_name().unwrap_or("(unknown name)"),
             if device.is_verified() { "✅" } else { "❌" },
             if current { " <-- this device" } else { "" },
-        ));
+        );
     }
     format!("Currently-known devices of user {user_id}:\n{}",
         if devices.is_empty() { "    (none)" } else { &devices },


### PR DESCRIPTION
💡 What: Replaced `push_str(&format!(...))` with `writeln!(...)` inside a loop in `dump_devices`.
🎯 Why: To avoid unnecessary intermediate `String` allocations inside the loop.
📊 Impact: Reduces allocations in `dump_devices` by N (where N is the number of devices).
🔬 Measurement: Verify tests still pass and verify the output matches expectations.

---
*PR created automatically by Jules for task [6933929457038986152](https://jules.google.com/task/6933929457038986152) started by @kevinaboos*