### PR TITLE
Mobile fixes: better safe-area layout, iOS session restore, etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "bytes"
@@ -1941,9 +1941,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2945,12 +2945,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2989,15 +2989,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3005,22 +3005,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3034,7 +3034,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "ttf-parser",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3075,12 +3075,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3111,15 +3111,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3140,7 +3140,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3152,12 +3152,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3165,13 +3165,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3188,14 +3188,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3249,18 +3249,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "simd-adler32",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3663,7 +3663,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "mime"
@@ -4392,10 +4392,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
  "unicase 2.9.0",
 ]
 
@@ -5203,12 +5203,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5303,7 +5303,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "sealed"
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "siphasher"
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "socket2"
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "tungstenite"
@@ -6461,7 +6461,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-bidi"
@@ -6472,17 +6472,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-ident"
@@ -6493,7 +6493,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-normalization"
@@ -6513,12 +6513,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6529,7 +6529,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "unicode-width"
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6873,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6883,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "log",
  "pkg-config",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7147,7 +7147,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 
 [[package]]
 name = "windows-numerics"
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
+source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "bytes"
@@ -1941,9 +1941,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2945,12 +2945,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2989,15 +2989,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3005,22 +3005,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3034,7 +3034,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "ttf-parser",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3075,12 +3075,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3111,15 +3111,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3140,7 +3140,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3152,12 +3152,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3165,13 +3165,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3188,14 +3188,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3249,18 +3249,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "simd-adler32",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3663,7 +3663,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "mime"
@@ -4392,10 +4392,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
- "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
  "unicase 2.9.0",
 ]
 
@@ -5203,12 +5203,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5303,7 +5303,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "sealed"
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "siphasher"
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "socket2"
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "tungstenite"
@@ -6461,7 +6461,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-bidi"
@@ -6472,17 +6472,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-ident"
@@ -6493,7 +6493,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-normalization"
@@ -6513,12 +6513,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6529,7 +6529,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "unicode-width"
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6873,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6883,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "log",
  "pkg-config",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7147,7 +7147,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 
 [[package]]
 name = "windows-numerics"
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#18669f5a585f0e17f98718b3f0e69941db504605"
+source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_pass_touch_finger_up_to_children#36112191f9b2828576f03f745f7f139421ad8736"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "portal_list_pass_touch_finger_up_to_children", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "portal_list_pass_touch_finger_up_to_children" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "portal_list_pass_touch_finger_up_to_children", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "portal_list_pass_touch_finger_up_to_children" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "script_reapply_variant", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "script_reapply_variant" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,16 +39,11 @@ script_mod! {
             
 
                 body +: {
-                    // Only the TOP safe-area inset is applied at the body level, because top
-                    // is shared by every screen (status bar / notch avoidance) and no bar
-                    // owns the top edge. Bottom, left, and right are delegated to the
-                    // content containers that touch those edges — NavigationTabBar owns its
-                    // respective edge per variant, and page content applies its own l/r/b
-                    // insets where appropriate. This is the canonical edge-to-edge mobile
-                    // pattern (UIKit safeAreaLayoutGuide / Compose systemBars / Flutter
-                    // SafeArea): each container manages its own edge so bar backgrounds fill
-                    // the inset region rather than leaving a bare clear-color strip.
-                    // On desktop platforms all four insets are 0 so this has no effect there.
+                    // Only TOP is applied here — top is shared by every screen
+                    // and no bar owns it. Bottom/left/right are delegated to
+                    // whatever content touches those edges (NavigationTabBar,
+                    // page content), so bar backgrounds fill the inset strip
+                    // instead of leaving a bare clear-color band.
                     padding: Inset{
                         top: (mod.widgets.SAFE_INSET_PAD_TOP),
                         bottom: 0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,11 +39,11 @@ script_mod! {
             
 
                 body +: {
-                    // Only TOP is applied here — top is shared by every screen
-                    // and no bar owns it. Bottom/left/right are delegated to
-                    // whatever content touches those edges (NavigationTabBar,
-                    // page content), so bar backgrounds fill the inset strip
-                    // instead of leaving a bare clear-color band.
+                    // Only TOP is applied here, since top is shared by every screen
+                    // and no bar owns it. Bottom/left/right are delegated to whatever
+                    // content touches those edges (NavigationTabBar, page content),
+                    // so bar backgrounds fill the inset strip instead of leaving
+                    // a bare clear-color band.
                     padding: Inset{
                         top: (mod.widgets.SAFE_INSET_PAD_TOP),
                         bottom: 0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,11 +39,21 @@ script_mod! {
             
 
                 body +: {
+                    // Only the TOP safe-area inset is applied at the body level, because top
+                    // is shared by every screen (status bar / notch avoidance) and no bar
+                    // owns the top edge. Bottom, left, and right are delegated to the
+                    // content containers that touch those edges — NavigationTabBar owns its
+                    // respective edge per variant, and page content applies its own l/r/b
+                    // insets where appropriate. This is the canonical edge-to-edge mobile
+                    // pattern (UIKit safeAreaLayoutGuide / Compose systemBars / Flutter
+                    // SafeArea): each container manages its own edge so bar backgrounds fill
+                    // the inset region rather than leaving a bare clear-color strip.
+                    // On desktop platforms all four insets are 0 so this has no effect there.
                     padding: Inset{
                         top: (mod.widgets.SAFE_INSET_PAD_TOP),
-                        bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
-                        left: (mod.widgets.SAFE_INSET_PAD_LEFT),
-                        right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
                     }
 
                     overlay_container := View {

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -44,8 +44,8 @@ script_mod! {
             body: "<p>You can enter a room/space address using either:</p>
                 <ul>
                   <li> An <i>alias</i>, starting with <code>#</code>, like <code>#robrix:matrix.org</code>.</li>
-                  <li> An <i>ID</i>, starting with <code>!</code>, like <code>!moVNEIUPxJZpxRHDUv:matrix.org</code>.</li>
-                  <li> A Matrix link, like <code>https:matrix.to/...</code> or <code>matrix:...</code>.</li>
+                  <li> An <i>ID</i>, starting with <code>!</code>, like <code>!room_id:matrix.org</code>.</li>
+                  <li> A Matrix link, like <code>matrix:...</code> or <code>https:matrix.to/...</code>.</li>
                 </ul>
             "
         }

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -123,8 +123,6 @@ script_mod! {
             content +: {
                 height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)
                 align: Align{y: 0.5}
-                // Inset the controls so they clear side cutouts. The header
-                // background still goes edge-to-edge (like iOS UINavigationBar).
                 padding: Inset{
                     left: (mod.widgets.SAFE_INSET_PAD_LEFT),
                     right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -153,11 +151,8 @@ script_mod! {
             }
         }
         body +: {
-            // Top margin leaves room for the header. L/R/B padding clears
-            // device cutouts. The bottom one matters here cuz pushed views
-            // are drawn fullscreen and bypass the root NavigationTabBar
-            // (which would otherwise own that edge). The top safe inset is
-            // handled by StackNavigation itself.
+            // The top margin leaves room for the stack nav header.
+            // The other padding is for safe inset areas.
             margin: Inset{top: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)}
             padding: Inset{
                 left: (mod.widgets.SAFE_INSET_PAD_LEFT),
@@ -173,10 +168,6 @@ script_mod! {
 
         width: Fill,
         height: (NAVIGATION_TAB_BAR_SIZE)
-        // 4px gap + safe-area inset so the bar clears a side cutout in
-        // iPhone landscape. Addition (not `max()`) cuz DSL `max()` with
-        // `mod.widgets.X` heap paths doesn't evaluate reliably. On desktop
-        // the inset is 0, so this collapses to 4px.
         margin: Inset{
             left: (4.0 + mod.widgets.SAFE_INSET_PAD_LEFT),
             right: (4.0 + mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -242,11 +233,9 @@ script_mod! {
                 // the main desktop UI or the settings screen.
                 home_screen_page_flip := PageFlip {
                     width: Fill, height: Fill
-                    // Bottom padding stops the page backgrounds (settings,
-                    // add_room) from extending under the home indicator —
-                    // the parent's COLOR_SECONDARY fills that strip instead,
-                    // matching the NavigationTabBar. Right handles a side
-                    // cutout; left is owned by the NavigationTabBar.
+                    // We only need bottom and right-side padding,
+                    // as the others are handled by the parent widget
+                    // or by the navigation bar.
                     padding: Inset{
                         bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
                         right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -283,17 +272,9 @@ script_mod! {
                         mod.widgets.MainDesktopUI {}
                     }
 
-                    // RoundedView (not SolidView) with a small margin that lets
-                    // the outer COLOR_SECONDARY peek through — "floating card"
-                    // look matching the RobrixDock on the home page.
                     settings_page := RoundedView {
                         width: Fill, height: Fill
-                        // Asymmetric margin matches the home page's frame:
-                        // top:3 = gap under body padding; left:1 = thin strip
-                        // separating card from NavigationTabBar; right/bottom:0
-                        // = flush with the page-flip's safe-area padding, so
-                        // the outer COLOR_SECONDARY frames fills those strips.
-                        // 4px radius matches the dock's round_corner shader.
+                        // This weird margin is just to make it line up with the home_page content.
                         margin: Inset{top: 3, left: 1, right: 0, bottom: 0}
                         show_bg: true,
                         draw_bg +: {
@@ -308,12 +289,7 @@ script_mod! {
 
                     add_room_page := RoundedView {
                         width: Fill, height: Fill
-                        // Asymmetric margin matches the home page's frame:
-                        // top:3 = gap under body padding; left:1 = thin strip
-                        // separating card from NavigationTabBar; right/bottom:0
-                        // = flush with the page-flip's safe-area padding, so
-                        // the outer COLOR_SECONDARY frames fills those strips.
-                        // 4px radius matches the dock's round_corner shader.
+                        // This weird margin is just to make it line up with the home_page content.
                         margin: Inset{top: 3, left: 1, right: 0, bottom: 0}
                         show_bg: true,
                         draw_bg +: {
@@ -344,9 +320,6 @@ script_mod! {
                         // the main list of rooms or the settings screen.
                         home_screen_page_flip := PageFlip {
                             width: Fill, height: Fill
-                            // L/R safe-area insets at the page-flip level so all
-                            // three pages clear device cutouts. NavigationTabBar
-                            // handles its own l/r insets — it sits outside this.
                             padding: Inset{
                                 left: (mod.widgets.SAFE_INSET_PAD_LEFT),
                                 right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -755,8 +728,6 @@ impl HomeScreen {
             }
         };
 
-        // Set once — `set_title` stores it on the StackNavigationView itself,
-        // which re-asserts it on every apply walk.
         let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
         stack_navigation.set_title(cx, view_id, &selected_room.display_name());
 

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -466,11 +466,38 @@ script_mod! {
 
 
 /// A simple wrapper around the SpacesBar that allows us to animate showing or hiding it.
-#[derive(Script, ScriptHook, Widget, Animator)]
+#[derive(Script, Widget, Animator)]
 pub struct SpacesBarWrapper {
     #[source] source: ScriptObjectRef,
     #[deref] view: View,
     #[apply_default] animator: Animator,
+}
+
+impl ScriptHook for SpacesBarWrapper {
+    fn on_after_apply(
+        &mut self,
+        vm: &mut ScriptVm,
+        apply: &Apply,
+        scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        // When the widget tree is re-applied (e.g. after a preference change),
+        // the deref `view` resets its height to the DSL default,
+        // which clashes with whatever animator state we were in (shown, hidden).
+        // Thus, we re-apply the current animator state to prevent a hidden SpacesBar
+        // from briefly becoming shown before being hidden again.
+        // Note that we can't just call `animator_cut` cuz that uses the script VM
+        // which is unavailable from this `on_after_apply`
+        if !apply.is_script_reapply() {
+            return;
+        }
+        if let Some(state_apply) = self
+            .animator
+            .current_state_apply(live_id!(spaces_bar_animator))
+        {
+            self.script_apply(vm, &Apply::Animate, scope, state_apply.into());
+        }
+    }
 }
 
 impl Widget for SpacesBarWrapper {
@@ -757,9 +784,11 @@ impl HomeScreen {
             }
         };
 
-        // Set the header title for the view being pushed.
-        let title_path = &[view_id, live_id!(header), live_id!(content), live_id!(title_container), live_id!(title)];
-        self.view.label(cx, title_path).set_text(cx, &selected_room.display_name());
+        // Set the header title once. `set_title` stores it on the
+        // `StackNavigationView` itself, which re-asserts it on every apply walk
+        // (rotation, preference change, AdaptiveView swap, etc.).
+        let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
+        stack_navigation.set_title(cx, view_id, &selected_room.display_name());
 
         // Save the current selected_room onto the navigation stack before replacing it.
         if let Some(prev) = app_state.selected_room.take() {
@@ -768,7 +797,7 @@ impl HomeScreen {
         app_state.selected_room = Some(selected_room);
 
         // Push the view onto the mobile navigation stack.
-        self.view.stack_navigation(cx, ids!(view_stack)).push(cx, view_id);
+        stack_navigation.push(cx, view_id);
         self.view.redraw(cx);
     }
 }

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -123,6 +123,15 @@ script_mod! {
             content +: {
                 height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)
                 align: Align{y: 0.5}
+                // Inset the header controls (back button, title) by the safe area so they
+                // don't render under a side cutout, while the header background (with its
+                // shadow in draw_bg above) still extends edge-to-edge — matching the iOS
+                // UINavigationBar pattern where the bar background spans the full width
+                // and items anchor to the safe-area layout guide.
+                padding: Inset{
+                    left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+                    right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                }
                 button_container +: {
                     padding: 0,
                     margin: 0
@@ -147,7 +156,22 @@ script_mod! {
             }
         }
         body +: {
+            // Top margin leaves room for the StackNavigationView's header.
+            // Left/right/bottom padding respects the device safe area so room / invite /
+            // space-lobby screens don't render under the Dynamic Island, notch, or home
+            // indicator. The bottom inset matters here because pushed StackNavigationViews
+            // are drawn fullscreen by StackNavigation and bypass the root_view's
+            // NavigationTabBar (which would otherwise own the bottom edge), so each
+            // pushed view must apply its own bottom inset to keep the message-input bar
+            // and similar bottom-anchored controls clear of the home indicator.
+            // Top safe-inset above the header is handled by StackNavigation itself
+            // (stack_navigation.rs uses `safe_top.max(parent_rect.pos.y)` in fullscreen mode).
             margin: Inset{top: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)}
+            padding: Inset{
+                left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+                right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
+            }
         }
     }
 
@@ -157,7 +181,16 @@ script_mod! {
 
         width: Fill,
         height: (NAVIGATION_TAB_BAR_SIZE)
-        margin: Inset{left: 4, right: 4}
+        // 4px decorative gap + safe-area inset so the SpacesBar doesn't render under a
+        // side cutout in iPhone landscape. Using addition (rather than `max()`) because
+        // DSL `max()` with `mod.widgets.X` heap paths does not evaluate reliably (see
+        // image_viewer.rs::draw_walk for context). On desktop the safe inset is 0, so
+        // this collapses to the original 4px; on mobile devices with a side cutout the
+        // SpacesBar gets the cutout's inset plus 4px of decorative breathing room.
+        margin: Inset{
+            left: (4.0 + mod.widgets.SAFE_INSET_PAD_LEFT),
+            right: (4.0 + mod.widgets.SAFE_INSET_PAD_RIGHT),
+        }
         show_bg: true
         draw_bg +: {
             color: (COLOR_PRIMARY_DARKER)
@@ -219,6 +252,18 @@ script_mod! {
                 // the main desktop UI or the settings screen.
                 home_screen_page_flip := PageFlip {
                     width: Fill, height: Fill
+                    // Bottom padding absorbs the BOTTOM safe-area inset (home indicator).
+                    // Pages with their own background color (settings_page, add_room_page)
+                    // would otherwise extend under the home indicator and show COLOR_PRIMARY
+                    // (white) there. With this padding, the pages stop above the inset and
+                    // the parent Desktop SolidView's COLOR_SECONDARY fills the inset strip,
+                    // matching the NavigationTabBar's color for a seamless bottom edge.
+                    // Right padding respects a right-side cutout (e.g., iPhone landscape
+                    // running in Desktop mode); left is owned by the NavigationTabBar.
+                    padding: Inset{
+                        bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
+                        right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                    }
 
                     lazy_init: true,
                     active_page: @home_page
@@ -240,30 +285,68 @@ script_mod! {
                                 room_filter_input_bar := RoomFilterInputBar {}
                             }
 
-                            search_messages_button := SearchMessagesButton {
-                                // make this button match/align with the RoomFilterInputBar
-                                height: 32.5,
-                                margin: Inset{right: 2}
-                            }
+                            // Hide this until it's implemented.
+                            // search_messages_button := SearchMessagesButton {
+                            //     // make this button match/align with the RoomFilterInputBar
+                            //     height: 32.5,
+                            //     margin: Inset{right: 2}
+                            // }
                         }
 
                         mod.widgets.MainDesktopUI {}
                     }
 
-                    settings_page := SolidView {
+                    // The settings and add-room pages use RoundedView rather than a flat
+                    // SolidView, with a small margin that reveals the outer Desktop
+                    // SolidView's COLOR_SECONDARY background on all sides. This creates a
+                    // "floating card" look that visually matches the RobrixDock on the
+                    // home page (whose tab panels are similarly framed in COLOR_SECONDARY),
+                    // softens the otherwise-sharp seam with the NavigationTabBar at the
+                    // top-right, and rounds the visible inside-screen corners.
+                    settings_page := RoundedView {
                         width: Fill, height: Fill
+                        // Small asymmetric margin matches the home page's visual frame:
+                        // top: 2 (gap under the window body's top padding / status-bar area),
+                        // left: 1 (thin COLOR_SECONDARY strip separating card from NavigationTabBar),
+                        // right: 0 / bottom: 0 (flush with body right-inset and the home-indicator
+                        // strip owned by home_screen_page_flip's padding). 4px corner radius
+                        // matches the dock's round_corner shader (dock.rs sdf.box r=4).
+                        // Top/left tuned to visually match the home page's RobrixDock;
+                        // right/bottom stay flush with home_screen_page_flip's padded inner
+                        // area (which already applies SAFE_INSET_PAD_RIGHT and
+                        // SAFE_INSET_PAD_BOTTOM at its level), so the outer Desktop
+                        // COLOR_SECONDARY frame fills the safe-area strips uniformly.
+                        margin: Inset{top: 3, left: 1, right: 0, bottom: 0}
                         show_bg: true,
-                        draw_bg.color: (COLOR_PRIMARY)
+                        draw_bg +: {
+                            color: (COLOR_PRIMARY)
+                            border_radius: 4.0
+                        }
 
                         CachedWidget {
                             settings_screen := mod.widgets.SettingsScreen {}
                         }
                     }
 
-                    add_room_page := SolidView {
+                    add_room_page := RoundedView {
                         width: Fill, height: Fill
+                        // Small asymmetric margin matches the home page's visual frame:
+                        // top: 2 (gap under the window body's top padding / status-bar area),
+                        // left: 1 (thin COLOR_SECONDARY strip separating card from NavigationTabBar),
+                        // right: 0 / bottom: 0 (flush with body right-inset and the home-indicator
+                        // strip owned by home_screen_page_flip's padding). 4px corner radius
+                        // matches the dock's round_corner shader (dock.rs sdf.box r=4).
+                        // Top/left tuned to visually match the home page's RobrixDock;
+                        // right/bottom stay flush with home_screen_page_flip's padded inner
+                        // area (which already applies SAFE_INSET_PAD_RIGHT and
+                        // SAFE_INSET_PAD_BOTTOM at its level), so the outer Desktop
+                        // COLOR_SECONDARY frame fills the safe-area strips uniformly.
+                        margin: Inset{top: 3, left: 1, right: 0, bottom: 0}
                         show_bg: true,
-                        draw_bg.color: (COLOR_PRIMARY)
+                        draw_bg +: {
+                            color: (COLOR_PRIMARY)
+                            border_radius: 4.0
+                        }
 
                         CachedWidget {
                             add_room_screen := mod.widgets.AddRoomScreen {}
@@ -288,6 +371,15 @@ script_mod! {
                         // the main list of rooms or the settings screen.
                         home_screen_page_flip := PageFlip {
                             width: Fill, height: Fill
+                            // Left/right safe-area insets applied at the page-flip level so all
+                            // three pages (home, settings, add_room) respect device cutouts
+                            // (Dynamic Island in landscape, camera notch, etc.). The
+                            // NavigationTabBar handles its own left/right insets separately and
+                            // sits below this, outside the page flip.
+                            padding: Inset{
+                                left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+                                right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+                            }
 
                             lazy_init: true,
                             active_page: @home_page

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -123,11 +123,8 @@ script_mod! {
             content +: {
                 height: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)
                 align: Align{y: 0.5}
-                // Inset the header controls (back button, title) by the safe area so they
-                // don't render under a side cutout, while the header background (with its
-                // shadow in draw_bg above) still extends edge-to-edge — matching the iOS
-                // UINavigationBar pattern where the bar background spans the full width
-                // and items anchor to the safe-area layout guide.
+                // Inset the controls so they clear side cutouts. The header
+                // background still goes edge-to-edge (like iOS UINavigationBar).
                 padding: Inset{
                     left: (mod.widgets.SAFE_INSET_PAD_LEFT),
                     right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -156,16 +153,11 @@ script_mod! {
             }
         }
         body +: {
-            // Top margin leaves room for the StackNavigationView's header.
-            // Left/right/bottom padding respects the device safe area so room / invite /
-            // space-lobby screens don't render under the Dynamic Island, notch, or home
-            // indicator. The bottom inset matters here because pushed StackNavigationViews
-            // are drawn fullscreen by StackNavigation and bypass the root_view's
-            // NavigationTabBar (which would otherwise own the bottom edge), so each
-            // pushed view must apply its own bottom inset to keep the message-input bar
-            // and similar bottom-anchored controls clear of the home indicator.
-            // Top safe-inset above the header is handled by StackNavigation itself
-            // (stack_navigation.rs uses `safe_top.max(parent_rect.pos.y)` in fullscreen mode).
+            // Top margin leaves room for the header. L/R/B padding clears
+            // device cutouts. The bottom one matters here cuz pushed views
+            // are drawn fullscreen and bypass the root NavigationTabBar
+            // (which would otherwise own that edge). The top safe inset is
+            // handled by StackNavigation itself.
             margin: Inset{top: (mod.widgets.STACK_VIEW_HEADER_HEIGHT)}
             padding: Inset{
                 left: (mod.widgets.SAFE_INSET_PAD_LEFT),
@@ -181,12 +173,10 @@ script_mod! {
 
         width: Fill,
         height: (NAVIGATION_TAB_BAR_SIZE)
-        // 4px decorative gap + safe-area inset so the SpacesBar doesn't render under a
-        // side cutout in iPhone landscape. Using addition (rather than `max()`) because
-        // DSL `max()` with `mod.widgets.X` heap paths does not evaluate reliably (see
-        // image_viewer.rs::draw_walk for context). On desktop the safe inset is 0, so
-        // this collapses to the original 4px; on mobile devices with a side cutout the
-        // SpacesBar gets the cutout's inset plus 4px of decorative breathing room.
+        // 4px gap + safe-area inset so the bar clears a side cutout in
+        // iPhone landscape. Addition (not `max()`) cuz DSL `max()` with
+        // `mod.widgets.X` heap paths doesn't evaluate reliably. On desktop
+        // the inset is 0, so this collapses to 4px.
         margin: Inset{
             left: (4.0 + mod.widgets.SAFE_INSET_PAD_LEFT),
             right: (4.0 + mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -252,14 +242,11 @@ script_mod! {
                 // the main desktop UI or the settings screen.
                 home_screen_page_flip := PageFlip {
                     width: Fill, height: Fill
-                    // Bottom padding absorbs the BOTTOM safe-area inset (home indicator).
-                    // Pages with their own background color (settings_page, add_room_page)
-                    // would otherwise extend under the home indicator and show COLOR_PRIMARY
-                    // (white) there. With this padding, the pages stop above the inset and
-                    // the parent Desktop SolidView's COLOR_SECONDARY fills the inset strip,
-                    // matching the NavigationTabBar's color for a seamless bottom edge.
-                    // Right padding respects a right-side cutout (e.g., iPhone landscape
-                    // running in Desktop mode); left is owned by the NavigationTabBar.
+                    // Bottom padding stops the page backgrounds (settings,
+                    // add_room) from extending under the home indicator —
+                    // the parent's COLOR_SECONDARY fills that strip instead,
+                    // matching the NavigationTabBar. Right handles a side
+                    // cutout; left is owned by the NavigationTabBar.
                     padding: Inset{
                         bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
                         right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -296,26 +283,17 @@ script_mod! {
                         mod.widgets.MainDesktopUI {}
                     }
 
-                    // The settings and add-room pages use RoundedView rather than a flat
-                    // SolidView, with a small margin that reveals the outer Desktop
-                    // SolidView's COLOR_SECONDARY background on all sides. This creates a
-                    // "floating card" look that visually matches the RobrixDock on the
-                    // home page (whose tab panels are similarly framed in COLOR_SECONDARY),
-                    // softens the otherwise-sharp seam with the NavigationTabBar at the
-                    // top-right, and rounds the visible inside-screen corners.
+                    // RoundedView (not SolidView) with a small margin that lets
+                    // the outer COLOR_SECONDARY peek through — "floating card"
+                    // look matching the RobrixDock on the home page.
                     settings_page := RoundedView {
                         width: Fill, height: Fill
-                        // Small asymmetric margin matches the home page's visual frame:
-                        // top: 2 (gap under the window body's top padding / status-bar area),
-                        // left: 1 (thin COLOR_SECONDARY strip separating card from NavigationTabBar),
-                        // right: 0 / bottom: 0 (flush with body right-inset and the home-indicator
-                        // strip owned by home_screen_page_flip's padding). 4px corner radius
-                        // matches the dock's round_corner shader (dock.rs sdf.box r=4).
-                        // Top/left tuned to visually match the home page's RobrixDock;
-                        // right/bottom stay flush with home_screen_page_flip's padded inner
-                        // area (which already applies SAFE_INSET_PAD_RIGHT and
-                        // SAFE_INSET_PAD_BOTTOM at its level), so the outer Desktop
-                        // COLOR_SECONDARY frame fills the safe-area strips uniformly.
+                        // Asymmetric margin matches the home page's frame:
+                        // top:3 = gap under body padding; left:1 = thin strip
+                        // separating card from NavigationTabBar; right/bottom:0
+                        // = flush with the page-flip's safe-area padding, so
+                        // the outer COLOR_SECONDARY frames fills those strips.
+                        // 4px radius matches the dock's round_corner shader.
                         margin: Inset{top: 3, left: 1, right: 0, bottom: 0}
                         show_bg: true,
                         draw_bg +: {
@@ -330,17 +308,12 @@ script_mod! {
 
                     add_room_page := RoundedView {
                         width: Fill, height: Fill
-                        // Small asymmetric margin matches the home page's visual frame:
-                        // top: 2 (gap under the window body's top padding / status-bar area),
-                        // left: 1 (thin COLOR_SECONDARY strip separating card from NavigationTabBar),
-                        // right: 0 / bottom: 0 (flush with body right-inset and the home-indicator
-                        // strip owned by home_screen_page_flip's padding). 4px corner radius
-                        // matches the dock's round_corner shader (dock.rs sdf.box r=4).
-                        // Top/left tuned to visually match the home page's RobrixDock;
-                        // right/bottom stay flush with home_screen_page_flip's padded inner
-                        // area (which already applies SAFE_INSET_PAD_RIGHT and
-                        // SAFE_INSET_PAD_BOTTOM at its level), so the outer Desktop
-                        // COLOR_SECONDARY frame fills the safe-area strips uniformly.
+                        // Asymmetric margin matches the home page's frame:
+                        // top:3 = gap under body padding; left:1 = thin strip
+                        // separating card from NavigationTabBar; right/bottom:0
+                        // = flush with the page-flip's safe-area padding, so
+                        // the outer COLOR_SECONDARY frames fills those strips.
+                        // 4px radius matches the dock's round_corner shader.
                         margin: Inset{top: 3, left: 1, right: 0, bottom: 0}
                         show_bg: true,
                         draw_bg +: {
@@ -371,11 +344,9 @@ script_mod! {
                         // the main list of rooms or the settings screen.
                         home_screen_page_flip := PageFlip {
                             width: Fill, height: Fill
-                            // Left/right safe-area insets applied at the page-flip level so all
-                            // three pages (home, settings, add_room) respect device cutouts
-                            // (Dynamic Island in landscape, camera notch, etc.). The
-                            // NavigationTabBar handles its own left/right insets separately and
-                            // sits below this, outside the page flip.
+                            // L/R safe-area insets at the page-flip level so all
+                            // three pages clear device cutouts. NavigationTabBar
+                            // handles its own l/r insets — it sits outside this.
                             padding: Inset{
                                 left: (mod.widgets.SAFE_INSET_PAD_LEFT),
                                 right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
@@ -784,9 +755,8 @@ impl HomeScreen {
             }
         };
 
-        // Set the header title once. `set_title` stores it on the
-        // `StackNavigationView` itself, which re-asserts it on every apply walk
-        // (rotation, preference change, AdaptiveView swap, etc.).
+        // Set once — `set_title` stores it on the StackNavigationView itself,
+        // which re-asserts it on every apply walk.
         let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
         stack_navigation.set_title(cx, view_id, &selected_room.display_name());
 

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -163,11 +163,9 @@ script_mod! {
         }
     }
 
-    // The toggle is built on `NavigationTabButton` so it shares the same
-    // size/padding/margin and hover background animation as the other tab
-    // buttons. Its toggling is independent of the navigation selection
-    // (no "selected" state, doesn't affect the other buttons), so the parent
-    // simply never calls `set_selected` on it.
+    // Built on `NavigationTabButton` so it shares the size/padding and
+    // hover animation. Its toggling is independent of navigation selection,
+    // so the parent never calls `set_selected` on it.
     mod.widgets.ToggleSpacesBarButton = mod.widgets.NavigationTabButton {
         tooltip_text: "Toggle Spaces"
         Icon {
@@ -190,12 +188,10 @@ script_mod! {
         Desktop := RoundedView {
             flow: Down,
             align: Align{x: 0.5}
-            // The bar extends its width and internal padding to absorb the LEFT safe-area
-            // inset (e.g., iPhone landscape with a side cutout), so its own background
-            // fills the inset region edge-to-edge rather than showing the window clear color.
-            // Bottom padding absorbs the bottom safe-area inset (home indicator) for the
-            // same reason. Top inset is handled by the Window body's padding.
-            // On desktop platforms all safe insets are 0, so this reduces to the prior layout.
+            // Grow the bar's width/padding to absorb the LEFT safe-area inset
+            // so its background fills that strip instead of the window's clear
+            // color. Bottom padding does the same for the home-indicator inset.
+            // Top is handled by the Window body. On desktop all insets are 0.
             padding: Inset{
                 top: 8.,
                 bottom: (8.0 + mod.widgets.SAFE_INSET_PAD_BOTTOM),
@@ -230,12 +226,9 @@ script_mod! {
             flow: Right
             align: Align{x: 0.5, y: 0.5}
             width: Fill,
-            // The bar extends its height and internal bottom padding to absorb the BOTTOM
-            // safe-area inset (home indicator) so its background fills the inset region
-            // edge-to-edge. Left padding absorbs the LEFT safe-area inset for devices with
-            // a side cutout in landscape. The bar is already `width: Fill`, so its
-            // background naturally extends to the screen edges on the left/right.
-            // On desktop platforms all safe insets are 0, so this reduces to the prior layout.
+            // Grow the bar's height/bottom padding to absorb the home-indicator
+            // inset; left padding handles a side cutout in landscape. Already
+            // `width: Fill`, so the background extends edge-to-edge on l/r.
             height: (mod.widgets.NAVIGATION_TAB_BAR_SIZE + mod.widgets.SAFE_INSET_PAD_BOTTOM),
             padding: Inset{
                 bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -188,10 +188,8 @@ script_mod! {
         Desktop := RoundedView {
             flow: Down,
             align: Align{x: 0.5}
-            // Grow the bar's width/padding to absorb the LEFT safe-area inset
-            // so its background fills that strip instead of the window's clear
-            // color. Bottom padding does the same for the home-indicator inset.
-            // Top is handled by the Window body. On desktop all insets are 0.
+            // Similar to how we do it for the mobile mode view, but now
+            // the bar is on the left, so we add left padding and extra width.
             padding: Inset{
                 top: 8.,
                 bottom: (8.0 + mod.widgets.SAFE_INSET_PAD_BOTTOM),
@@ -226,9 +224,9 @@ script_mod! {
             flow: Right
             align: Align{x: 0.5, y: 0.5}
             width: Fill,
-            // Grow the bar's height/bottom padding to absorb the home-indicator
-            // inset; left padding handles a side cutout in landscape. Already
-            // `width: Fill`, so the background extends edge-to-edge on l/r.
+            // On mobile, the nav bar is at the bottom, so we let it fill the entire space
+            // *including* drawing within the safe inset areas,
+            // and the bottom-pad its content so the buttons aren't drawn in the safe areas.
             height: (mod.widgets.NAVIGATION_TAB_BAR_SIZE + mod.widgets.SAFE_INSET_PAD_BOTTOM),
             padding: Inset{
                 bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -163,23 +163,24 @@ script_mod! {
         }
     }
 
-    // Note: `ToggleSpacesBarButton` is intentionally NOT a `NavigationBarButton`.
-    // Its toggling is independent of the navigation selection (it doesn't
-    // show a "selected" state and doesn't affect the other buttons), so it
-    // continues to use `RobrixNeutralIconButton` as its base.
-    mod.widgets.ToggleSpacesBarButton = RobrixNeutralIconButton {
-        width: Fill,
-        padding: 16
-        spacing: 0,
-        align: Align{x: 0.5, y: 0.5}
-        draw_icon +: {
-            svg: (ICON_SQUARES)
-            color: (COLOR_NAVIGATION_TAB_FG)
-        }
-        icon_walk: Walk{
-            width: (NAVIGATION_TAB_BAR_SIZE / 2.2),
-            height: (NAVIGATION_TAB_BAR_SIZE / 2.2),
-            margin: 0
+    // The toggle is built on `NavigationTabButton` so it shares the same
+    // size/padding/margin and hover background animation as the other tab
+    // buttons. Its toggling is independent of the navigation selection
+    // (no "selected" state, doesn't affect the other buttons), so the parent
+    // simply never calls `set_selected` on it.
+    mod.widgets.ToggleSpacesBarButton = mod.widgets.NavigationTabButton {
+        tooltip_text: "Toggle Spaces"
+        Icon {
+            margin: 0,
+            icon_walk: Walk {
+                margin: 0,
+                width: (NAVIGATION_TAB_BAR_SIZE / 2.2),
+                height: (NAVIGATION_TAB_BAR_SIZE / 2.2)
+            }
+            draw_icon +: {
+                color: (COLOR_NAVIGATION_TAB_FG)
+                svg: (ICON_SQUARES)
+            }
         }
     }
 
@@ -189,8 +190,18 @@ script_mod! {
         Desktop := RoundedView {
             flow: Down,
             align: Align{x: 0.5}
-            padding: Inset{top: 8., bottom: 8}
-            width: (NAVIGATION_TAB_BAR_SIZE),
+            // The bar extends its width and internal padding to absorb the LEFT safe-area
+            // inset (e.g., iPhone landscape with a side cutout), so its own background
+            // fills the inset region edge-to-edge rather than showing the window clear color.
+            // Bottom padding absorbs the bottom safe-area inset (home indicator) for the
+            // same reason. Top inset is handled by the Window body's padding.
+            // On desktop platforms all safe insets are 0, so this reduces to the prior layout.
+            padding: Inset{
+                top: 8.,
+                bottom: (8.0 + mod.widgets.SAFE_INSET_PAD_BOTTOM),
+                left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+            }
+            width: (mod.widgets.NAVIGATION_TAB_BAR_SIZE + mod.widgets.SAFE_INSET_PAD_LEFT),
             height: Fill
 
             draw_bg +: {
@@ -219,7 +230,18 @@ script_mod! {
             flow: Right
             align: Align{x: 0.5, y: 0.5}
             width: Fill,
-            height: (NAVIGATION_TAB_BAR_SIZE)
+            // The bar extends its height and internal bottom padding to absorb the BOTTOM
+            // safe-area inset (home indicator) so its background fills the inset region
+            // edge-to-edge. Left padding absorbs the LEFT safe-area inset for devices with
+            // a side cutout in landscape. The bar is already `width: Fill`, so its
+            // background naturally extends to the screen edges on the left/right.
+            // On desktop platforms all safe insets are 0, so this reduces to the prior layout.
+            height: (mod.widgets.NAVIGATION_TAB_BAR_SIZE + mod.widgets.SAFE_INSET_PAD_BOTTOM),
+            padding: Inset{
+                bottom: (mod.widgets.SAFE_INSET_PAD_BOTTOM),
+                left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+                right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+            }
 
             draw_bg +: {
                 color: (COLOR_SECONDARY)
@@ -545,7 +567,7 @@ impl Widget for NavigationTabBar {
                 }
             }
 
-            if self.view.button(cx, ids!(toggle_spaces_bar_button)).clicked(actions) {
+            if self.view.navigation_bar_button(cx, ids!(toggle_spaces_bar_button)).clicked(actions) {
                 self.is_spaces_bar_shown = !self.is_spaces_bar_shown;
                 cx.action(NavigationBarAction::ToggleSpacesBar);
             }

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -650,14 +650,6 @@ impl RoomsList {
                         if was_direct == is_direct {
                             continue;
                         }
-                        enqueue_popup_notification(
-                            format!("Note: \"{}\" is now a {} room.",
-                                room.room_name_id,
-                                if is_direct { "direct" } else { "non-direct" },
-                            ),
-                            PopupKind::Info,
-                            Some(5.0),
-                        );
 
                         // Remove the room from the previous list (direct or regular).
                         let list_to_remove_from = if was_direct {

--- a/src/home/rooms_sidebar.rs
+++ b/src/home/rooms_sidebar.rs
@@ -112,7 +112,8 @@ script_mod! {
                         room_filter_input_bar := RoomFilterInputBar {}
                     }
 
-                    search_messages_button := SearchMessagesButton { }
+                    // Hide this until it's implemented.
+                    // search_messages_button := SearchMessagesButton { }
                 }
             }
 

--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -22,7 +22,9 @@ pub struct ClientSessionPersisted {
     /// The URL of the homeserver of the user.
     pub homeserver: String,
 
-    /// The path of the database.
+    /// The database path. New session files store this as a subfolder name
+    /// relative to `app_data_dir()`; legacy session files may contain an
+    /// absolute path. `restore_session` handles both forms.
     pub db_path: PathBuf,
 
     /// The passphrase of the database.
@@ -177,10 +179,37 @@ pub async fn restore_session(
         title: "Connecting to homeserver".into(),
         status: status_str,
     });
+    // Resolve the db path against the current `app_data_dir()`. New session files
+    // store only the db's subfolder name (relative). Legacy session files stored an
+    // absolute path that may now be stale (notably on iOS, where the sandbox
+    // container UUID changes across reinstalls/redeploys), so fall back to the
+    // basename joined with the current data dir if the absolute path is gone.
+    let db_path = if client_session.db_path.is_absolute() {
+        if client_session.db_path.exists() {
+            client_session.db_path.clone()
+        } else if let Some(name) = client_session.db_path.file_name() {
+            let relocated = app_data_dir().join(name);
+            log!(
+                "Stored db_path '{}' no longer exists; using '{}'",
+                client_session.db_path.display(),
+                relocated.display(),
+            );
+            relocated
+        } else {
+            client_session.db_path.clone()
+        }
+    } else {
+        app_data_dir().join(&client_session.db_path)
+    };
+    log!(
+        "Restoring session for {user_id} with db at: {} (stored as: {})",
+        db_path.display(),
+        client_session.db_path.display(),
+    );
     // Build the client with the previous settings from the session.
     let client = Client::builder()
         .homeserver_url(client_session.homeserver)
-        .sqlite_store(client_session.db_path, Some(&client_session.passphrase))
+        .sqlite_store(db_path, Some(&client_session.passphrase))
         .with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
             with_subscriptions: true,
         })

--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -22,9 +22,9 @@ pub struct ClientSessionPersisted {
     /// The URL of the homeserver of the user.
     pub homeserver: String,
 
-    /// The database path. New session files store this as a subfolder name
-    /// relative to `app_data_dir()`; legacy session files may contain an
-    /// absolute path. `restore_session` handles both forms.
+    /// The database path. New sessions store this as a relative subfolder
+    /// (joined with `app_data_dir()` at restore time); legacy sessions
+    /// may have an absolute path. `restore_session` handles both.
     pub db_path: PathBuf,
 
     /// The passphrase of the database.
@@ -179,11 +179,10 @@ pub async fn restore_session(
         title: "Connecting to homeserver".into(),
         status: status_str,
     });
-    // Resolve the db path against the current `app_data_dir()`. New session files
-    // store only the db's subfolder name (relative). Legacy session files stored an
-    // absolute path that may now be stale (notably on iOS, where the sandbox
-    // container UUID changes across reinstalls/redeploys), so fall back to the
-    // basename joined with the current data dir if the absolute path is gone.
+    // Resolve the db path against the current `app_data_dir()`. Legacy
+    // sessions stored an absolute path that may now be stale on iOS
+    // (sandbox UUID changes across reinstalls), so if it's gone, fall
+    // back to its basename joined with the current data dir.
     let db_path = if client_session.db_path.is_absolute() {
         if client_session.db_path.exists() {
             client_session.db_path.clone()

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -227,12 +227,9 @@ impl ScriptHook for AccountSettings {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) {
-        // Restore the user_id label inline (during the apply walk, before any
-        // draw fires) so the user never sees the DSL placeholder flash.
-        // Anything that goes through `cx.with_vm` (button enable colors,
-        // avatar repaint) can't live here cuz the script VM isn't available
-        // from this `on_after_apply` — those get restored a tick later via
-        // `restore_after_reapply`.
+        // Restore user_id inline so the DSL placeholder never flashes.
+        // Anything that goes through `cx.with_vm` (button colors, avatar)
+        // can't run here — handled later in `restore_after_reapply`.
         if !apply.is_script_reapply() {
             return;
         }
@@ -538,14 +535,12 @@ impl AccountSettings {
     }
 
     /// Populates the account settings within the SettingsScreen.
+    /// Pass `Some(new_profile)` to replace the cached profile, or `None`
+    /// to use the existing `self.own_profile`.
     ///
-    /// If `new_profile` is `Some`, it replaces the cached profile.
-    /// Otherwise the existing `self.own_profile` is used.
-    ///
-    /// Don't call this from the `Event::ScriptReapply` path —
-    /// it unconditionally `set_text`s the `display_name_input`,
-    /// which would wipe out any in-progress edit the user has typed.
-    /// Use [`Self::restore_after_reapply`] there instead.
+    /// Don't call this from `Event::ScriptReapply` — it unconditionally
+    /// `set_text`s `display_name_input`, wiping any in-progress edit.
+    /// Use [`Self::restore_after_reapply`] there.
     pub fn populate(&mut self, cx: &mut Cx, new_profile: Option<UserProfile>) {
         if let Some(new_profile) = new_profile {
             self.own_profile = Some(new_profile);
@@ -553,18 +548,16 @@ impl AccountSettings {
         self.populate_inner(cx, PopulateMode::Initial);
     }
 
-    /// Restores widget state after an `Event::ScriptReapply` walk has
-    /// reset DSL-bound fields back to the `script_mod!` defaults.
-    /// See [`PopulateMode::AfterReapply`] for what this re-applies and
-    /// what it deliberately leaves alone.
+    /// Restores widget state after `Event::ScriptReapply` reset DSL-bound
+    /// fields to their `script_mod!` defaults. See
+    /// [`PopulateMode::AfterReapply`] for what's re-applied vs left alone.
     pub fn restore_after_reapply(&mut self, cx: &mut Cx) {
         self.populate_inner(cx, PopulateMode::AfterReapply);
     }
 
-    /// Shared core for `populate` and `restore_after_reapply`. The two
-    /// modes only differ at the text-input writes and the display-name
-    /// button enable logic — everything else (avatar repaint,
-    /// `reset_hover` sweep, redraw) is the same.
+    /// Shared core. The two modes only differ at the text-input writes
+    /// and display-name button enable logic — avatar repaint, hover
+    /// sweep, and redraw are the same.
     fn populate_inner(&mut self, cx: &mut Cx, mode: PopulateMode) {
         let Some(own_profile) = self.own_profile.as_ref() else {
             if matches!(mode, PopulateMode::Initial) {
@@ -575,17 +568,14 @@ impl AccountSettings {
 
         let cached_user_id = own_profile.user_id.as_str().to_owned();
         let cached_name = own_profile.username.clone().unwrap_or_default();
-        // We clone here so the `own_profile` borrow on `self` ends —
-        // the `&mut self` calls further down would otherwise conflict.
+        // Clones release the `own_profile` borrow before the `&mut self`
+        // calls below.
 
-        // `display_name_input` is user-editable, so the two modes have to
-        // diverge here:
-        //   * Initial: authoritatively write the cached username, set the
-        //     user_id label, and start the accept/cancel buttons disabled.
-        //   * AfterReapply: leave the input alone so any in-progress edit
-        //     survives, skip user_id (already restored above in
-        //     `on_after_apply`), and re-derive the button enable state from
-        //     whether the input still matches the cached username.
+        // `display_name_input` is user-editable, so the modes diverge:
+        //   * Initial: write cached username + user_id, buttons disabled.
+        //   * AfterReapply: leave the input alone (preserve in-progress
+        //     edits), skip user_id (already restored in `on_after_apply`),
+        //     re-derive button enable from whether input still matches.
         let modified = match mode {
             PopulateMode::Initial => {
                 self.view.label(cx, ids!(user_id))

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -509,12 +509,30 @@ impl AccountSettings {
         );
     }
 
-    /// Show and initializes the account settings within the SettingsScreen.
-    pub fn populate(&mut self, cx: &mut Cx, own_profile: UserProfile) {
+    /// Populates the account settings within the SettingsScreen.
+    ///
+    /// If `new_profile` is `Some`, it replaces the cached profile and is
+    /// used to drive the UI. If `None`, the currently-cached profile in
+    /// `self.own_profile` is used — this is the path taken by
+    /// `Event::ScriptReapply`, which wipes DSL-bound widget state back to
+    /// `script_mod!` defaults; the `#[rust] own_profile` field survives
+    /// that reload, so no cache lookup or avatar fetch is needed.
+    pub fn populate(&mut self, cx: &mut Cx, new_profile: Option<UserProfile>) {
+        if let Some(new_profile) = new_profile {
+            self.own_profile = Some(new_profile);
+        }
+        let Some(own_profile) = self.own_profile.as_ref() else {
+            error!("BUG: AccountSettings::populate() called with no cached profile.");
+            return;
+        };
+
         self.view.label(cx, ids!(user_id))
             .set_text(cx, own_profile.user_id.as_str());
         self.view.text_input(cx, ids!(display_name_input))
             .set_text(cx, own_profile.username.as_deref().unwrap_or_default());
+        // `own_profile`'s borrow ends here (NLL) — the &mut self calls below
+        // need the struct's field borrow on `own_profile` to have dropped.
+
         Self::enable_display_name_buttons(
             cx,
             false,
@@ -522,7 +540,6 @@ impl AccountSettings {
             &self.view.button(cx, ids!(cancel_display_name_button)),
         );
 
-        self.own_profile = Some(own_profile);
         self.populate_avatar_views(cx);
 
         self.view.button(cx, ids!(upload_avatar_button)).reset_hover(cx);
@@ -639,10 +656,10 @@ impl AccountSettings {
 }
 
 impl AccountSettingsRef {
-    /// See [`AccountSettings::show()`].
-    pub fn populate(&self, cx: &mut Cx, own_profile: UserProfile) {
+    /// See [`AccountSettings::populate()`].
+    pub fn populate(&self, cx: &mut Cx, new_profile: Option<UserProfile>) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.populate(cx, own_profile);
+        inner.populate(cx, new_profile);
     }
 }
 

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -229,7 +229,7 @@ impl ScriptHook for AccountSettings {
     ) {
         // Restore user_id inline so the DSL placeholder never flashes.
         // Anything that goes through `cx.with_vm` (button colors, avatar)
-        // can't run here — handled later in `restore_after_reapply`.
+        // can't run here, so it's handled later in `restore_after_reapply`.
         if !apply.is_script_reapply() {
             return;
         }
@@ -538,9 +538,9 @@ impl AccountSettings {
     /// Pass `Some(new_profile)` to replace the cached profile, or `None`
     /// to use the existing `self.own_profile`.
     ///
-    /// Don't call this from `Event::ScriptReapply` — it unconditionally
-    /// `set_text`s `display_name_input`, wiping any in-progress edit.
-    /// Use [`Self::restore_after_reapply`] there.
+    /// Don't call this from `Event::ScriptReapply`, since it unconditionally
+    /// `set_text`s `display_name_input`, which would wipe any in-progress edit.
+    /// Use [`Self::restore_after_reapply`] for that path.
     pub fn populate(&mut self, cx: &mut Cx, new_profile: Option<UserProfile>) {
         if let Some(new_profile) = new_profile {
             self.own_profile = Some(new_profile);
@@ -556,8 +556,8 @@ impl AccountSettings {
     }
 
     /// Shared core. The two modes only differ at the text-input writes
-    /// and display-name button enable logic — avatar repaint, hover
-    /// sweep, and redraw are the same.
+    /// and display-name button enable logic. Avatar repaint, hover sweep,
+    /// and redraw are the same.
     fn populate_inner(&mut self, cx: &mut Cx, mode: PopulateMode) {
         let Some(own_profile) = self.own_profile.as_ref() else {
             if matches!(mode, PopulateMode::Initial) {
@@ -568,14 +568,14 @@ impl AccountSettings {
 
         let cached_user_id = own_profile.user_id.as_str().to_owned();
         let cached_name = own_profile.username.clone().unwrap_or_default();
-        // Clones release the `own_profile` borrow before the `&mut self`
-        // calls below.
+        // Cloning here releases the `own_profile` borrow,
+        // so the `&mut self` calls below don't conflict.
 
         // `display_name_input` is user-editable, so the modes diverge:
-        //   * Initial: write cached username + user_id, buttons disabled.
-        //   * AfterReapply: leave the input alone (preserve in-progress
-        //     edits), skip user_id (already restored in `on_after_apply`),
-        //     re-derive button enable from whether input still matches.
+        //   * Initial: write the cached username + user_id, buttons start disabled.
+        //   * AfterReapply: leave the input alone to preserve in-progress edits,
+        //     skip user_id (already restored in `on_after_apply`),
+        //     and re-derive the button enable state from whether the input still matches.
         let modified = match mode {
             PopulateMode::Initial => {
                 self.view.label(cx, ids!(user_id))

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use makepad_widgets::{text::selection::Cursor, *};
 
-use crate::{app::ConfirmDeleteAction, avatar_cache::{self}, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::user_profile::UserProfile, shared::{avatar::{AvatarState, AvatarWidgetExt}, confirmation_modal::ConfirmationModalContent, popup_list::{PopupKind, enqueue_popup_notification}, styles::*}, sliding_sync::{AccountDataAction, MatrixRequest, submit_async_request}, utils};
+use crate::{app::ConfirmDeleteAction, avatar_cache::{self}, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::user_profile::UserProfile, settings::PopulateMode, shared::{avatar::{AvatarState, AvatarWidgetExt}, confirmation_modal::ConfirmationModalContent, popup_list::{PopupKind, enqueue_popup_notification}, styles::*}, sliding_sync::{AccountDataAction, MatrixRequest, submit_async_request}, utils};
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -212,11 +212,39 @@ script_mod! {
 }
 
 /// The view containing all user account-related settings.
-#[derive(Script, ScriptHook, Widget)]
+#[derive(Script, Widget)]
 pub struct AccountSettings {
     #[deref] view: View,
 
     #[rust] own_profile: Option<UserProfile>,
+}
+
+impl ScriptHook for AccountSettings {
+    fn on_after_apply(
+        &mut self,
+        vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        // Restore the user_id label inline (during the apply walk, before any
+        // draw fires) so the user never sees the DSL placeholder flash.
+        // Anything that goes through `cx.with_vm` (button enable colors,
+        // avatar repaint) can't live here cuz the script VM isn't available
+        // from this `on_after_apply` — those get restored a tick later via
+        // `restore_after_reapply`.
+        if !apply.is_script_reapply() {
+            return;
+        }
+        let Some(own_profile) = self.own_profile.as_ref() else {
+            return;
+        };
+        let cached_user_id = own_profile.user_id.as_str().to_owned();
+        let cx = vm.cx_mut();
+        self.view
+            .label(cx, ids!(user_id))
+            .set_text(cx, &cached_user_id);
+    }
 }
 
 impl Widget for AccountSettings {
@@ -511,31 +539,69 @@ impl AccountSettings {
 
     /// Populates the account settings within the SettingsScreen.
     ///
-    /// If `new_profile` is `Some`, it replaces the cached profile and is
-    /// used to drive the UI. If `None`, the currently-cached profile in
-    /// `self.own_profile` is used — this is the path taken by
-    /// `Event::ScriptReapply`, which wipes DSL-bound widget state back to
-    /// `script_mod!` defaults; the `#[rust] own_profile` field survives
-    /// that reload, so no cache lookup or avatar fetch is needed.
+    /// If `new_profile` is `Some`, it replaces the cached profile.
+    /// Otherwise the existing `self.own_profile` is used.
+    ///
+    /// Don't call this from the `Event::ScriptReapply` path —
+    /// it unconditionally `set_text`s the `display_name_input`,
+    /// which would wipe out any in-progress edit the user has typed.
+    /// Use [`Self::restore_after_reapply`] there instead.
     pub fn populate(&mut self, cx: &mut Cx, new_profile: Option<UserProfile>) {
         if let Some(new_profile) = new_profile {
             self.own_profile = Some(new_profile);
         }
+        self.populate_inner(cx, PopulateMode::Initial);
+    }
+
+    /// Restores widget state after an `Event::ScriptReapply` walk has
+    /// reset DSL-bound fields back to the `script_mod!` defaults.
+    /// See [`PopulateMode::AfterReapply`] for what this re-applies and
+    /// what it deliberately leaves alone.
+    pub fn restore_after_reapply(&mut self, cx: &mut Cx) {
+        self.populate_inner(cx, PopulateMode::AfterReapply);
+    }
+
+    /// Shared core for `populate` and `restore_after_reapply`. The two
+    /// modes only differ at the text-input writes and the display-name
+    /// button enable logic — everything else (avatar repaint,
+    /// `reset_hover` sweep, redraw) is the same.
+    fn populate_inner(&mut self, cx: &mut Cx, mode: PopulateMode) {
         let Some(own_profile) = self.own_profile.as_ref() else {
-            error!("BUG: AccountSettings::populate() called with no cached profile.");
+            if matches!(mode, PopulateMode::Initial) {
+                error!("BUG: AccountSettings::populate() called with no cached profile.");
+            }
             return;
         };
 
-        self.view.label(cx, ids!(user_id))
-            .set_text(cx, own_profile.user_id.as_str());
-        self.view.text_input(cx, ids!(display_name_input))
-            .set_text(cx, own_profile.username.as_deref().unwrap_or_default());
-        // `own_profile`'s borrow ends here (NLL) — the &mut self calls below
-        // need the struct's field borrow on `own_profile` to have dropped.
+        let cached_user_id = own_profile.user_id.as_str().to_owned();
+        let cached_name = own_profile.username.clone().unwrap_or_default();
+        // We clone here so the `own_profile` borrow on `self` ends —
+        // the `&mut self` calls further down would otherwise conflict.
+
+        // `display_name_input` is user-editable, so the two modes have to
+        // diverge here:
+        //   * Initial: authoritatively write the cached username, set the
+        //     user_id label, and start the accept/cancel buttons disabled.
+        //   * AfterReapply: leave the input alone so any in-progress edit
+        //     survives, skip user_id (already restored above in
+        //     `on_after_apply`), and re-derive the button enable state from
+        //     whether the input still matches the cached username.
+        let modified = match mode {
+            PopulateMode::Initial => {
+                self.view.label(cx, ids!(user_id))
+                    .set_text(cx, &cached_user_id);
+                self.view.text_input(cx, ids!(display_name_input))
+                    .set_text(cx, &cached_name);
+                false
+            }
+            PopulateMode::AfterReapply => {
+                self.view.text_input(cx, ids!(display_name_input)).text() != cached_name
+            }
+        };
 
         Self::enable_display_name_buttons(
             cx,
-            false,
+            modified,
             &self.view.button(cx, ids!(accept_display_name_button)),
             &self.view.button(cx, ids!(cancel_display_name_button)),
         );
@@ -660,6 +726,12 @@ impl AccountSettingsRef {
     pub fn populate(&self, cx: &mut Cx, new_profile: Option<UserProfile>) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.populate(cx, new_profile);
+    }
+
+    /// See [`AccountSettings::restore_after_reapply()`].
+    pub fn restore_after_reapply(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.restore_after_reapply(cx);
     }
 }
 

--- a/src/settings/app_preferences.rs
+++ b/src/settings/app_preferences.rs
@@ -63,7 +63,7 @@ impl AppPreferences {
     /// copies.
     ///
     /// `cx.request_script_reapply()` then fires `Event::ScriptReapply`,
-    /// which walks the widget tree with `Apply::Reload`. Each Image's
+    /// which walks the widget tree with `Apply::ScriptReapply`. Each Image's
     /// `Size::script_apply` re-reads `max` from the shared `IMG_MSG_FIT`
     /// object and updates the widget's `walk.height`.
     ///

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -438,9 +438,13 @@ impl AppSettings {
             .set_selected_item(cx, prefs.view_mode.to_index());
 
         // Send-on-enter toggle (checked means the primary modifier + Enter sends).
+        // `Animate::No` routes through `animator_cut` so the shader uniform is
+        // always force-re-applied — `Animate::Yes` would early-out on
+        // `Event::ScriptReapply` paths where the animator's `current_state`
+        // still matches the target but the reload has reset the uniform.
         let send_toggle = self.view.check_box(cx, ids!(send_on_cmd_enter_toggle));
         send_toggle.set_text(SEND_SHORTCUT_TOGGLE_LABEL);
-        send_toggle.set_active(cx, !prefs.send_on_enter);
+        send_toggle.set_active(cx, !prefs.send_on_enter, Animate::No);
         Self::update_send_shortcut_description(cx, &self.view, prefs.send_on_enter);
 
         // Thumbnail radios.
@@ -450,10 +454,10 @@ impl AppSettings {
             ThumbnailMaxHeight::Unlimited => (false, false, true, false, String::new()),
             ThumbnailMaxHeight::Custom(v) => (false, false, false, true, v.to_string()),
         };
-        self.view.radio_button(cx, ids!(thumb_small_radio)).set_active(cx, small);
-        self.view.radio_button(cx, ids!(thumb_medium_radio)).set_active(cx, medium);
-        self.view.radio_button(cx, ids!(thumb_unlimited_radio)).set_active(cx, unlimited);
-        self.view.radio_button(cx, ids!(thumb_custom_radio)).set_active(cx, custom);
+        self.view.radio_button(cx, ids!(thumb_small_radio)).set_active(cx, small, Animate::No);
+        self.view.radio_button(cx, ids!(thumb_medium_radio)).set_active(cx, medium, Animate::No);
+        self.view.radio_button(cx, ids!(thumb_unlimited_radio)).set_active(cx, unlimited, Animate::No);
+        self.view.radio_button(cx, ids!(thumb_custom_radio)).set_active(cx, custom, Animate::No);
         self.view.text_input(cx, ids!(thumb_custom_input)).set_text(cx, &custom_text);
         Self::set_thumb_custom_input_state(cx, &self.view, custom);
     }

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -318,9 +318,9 @@ impl ScriptHook for AppSettings {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) {
-        // The apply walk just reset every code-set field here to its DSL
-        // default. Restore them inline (before any draw) — doing it later
-        // in `handle_event` produces a one-frame flicker.
+        // The apply walk just reset every code-set field here to its DSL default.
+        // Restore them inline before any draw fires, since doing it later
+        // in `handle_event` would produce a one-frame flicker.
         //
         // Prefs come from the global mirror cuz the apply walk runs with
         // an empty `Scope`. The mirror is kept in sync by `on_*_changed`
@@ -456,9 +456,9 @@ impl AppSettings {
     /// Populates the widget from the given prefs. Called on initial open
     /// or when fresh prefs arrive.
     ///
-    /// Don't call from `Event::ScriptReapply` — code-set fields get
-    /// handled in [`Self::on_after_apply`], and animator-driven fields
-    /// are restored by the codegen apply chain.
+    /// Don't call from `Event::ScriptReapply`. Code-set fields are handled
+    /// in [`Self::on_after_apply`], and animator-driven fields are restored
+    /// by the codegen apply chain.
     pub fn populate(&mut self, cx: &mut Cx, prefs: &AppPreferences) {
         Self::populate_safe(cx, &self.view, prefs);
 
@@ -488,11 +488,10 @@ impl AppSettings {
         self.view.text_input(cx, ids!(thumb_custom_input)).set_text(cx, &custom_text);
     }
 
-    /// Restores the code-set fields the apply walk just reset to DSL
-    /// defaults: toggle label, description, dropdown index, custom-input
-    /// read-only flag. None go through `cx.with_vm`, so this is safe to
-    /// call from `on_after_apply` — doing it inline is what prevents the
-    /// one-frame flicker.
+    /// Restores the code-set fields the apply walk just reset to DSL defaults:
+    /// toggle label, description, dropdown index, custom-input read-only flag.
+    /// None of these go through `cx.with_vm`, so it's safe to call from
+    /// `on_after_apply`. Doing it inline is what prevents the one-frame flicker.
     fn populate_safe(cx: &mut Cx, view: &View, prefs: &AppPreferences) {
         view.drop_down(cx, ids!(view_mode_dropdown))
             .set_selected_item(cx, prefs.view_mode.to_index());
@@ -515,9 +514,9 @@ impl AppSettings {
     }
 
     /// Sets `is_read_only` based on whether the custom radio is selected.
-    /// It's a plain `#[live] bool` the apply walk resets to the DSL
-    /// default, so we re-set it ourselves. Safe anywhere — just a field
-    /// write plus redraw.
+    /// It's a plain `#[live] bool` the apply walk resets to the DSL default,
+    /// so we re-set it ourselves. Safe anywhere, since it's just a field
+    /// write plus a redraw.
     fn set_thumb_custom_input_read_only(cx: &mut Cx, view: &View, enabled: bool) {
         view.text_input(cx, ids!(thumb_custom_input))
             .set_is_read_only(cx, !enabled);
@@ -525,10 +524,11 @@ impl AppSettings {
 
     /// Sets the disabled animator state.
     ///
-    /// **Not safe inside `on_after_apply`** — `set_disabled` goes through
+    /// **Not safe inside `on_after_apply`**. `set_disabled` goes through
     /// `animator_toggle` → `cx.with_vm`, which panics when the VM is
-    /// swapped out. Only call from outside an apply walk. ScriptReapply
-    /// doesn't need it — the codegen chain restores animator state itself.
+    /// swapped out. Only call this from outside an apply walk.
+    /// ScriptReapply doesn't need it, since the codegen chain restores
+    /// animator state itself.
     fn set_thumb_custom_input_disabled(cx: &mut Cx, view: &View, enabled: bool) {
         view.text_input(cx, ids!(thumb_custom_input))
             .set_disabled(cx, !enabled);

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -318,16 +318,13 @@ impl ScriptHook for AppSettings {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) {
-        // The apply walk just reset every code-set field in this subtree
-        // back to its DSL default — toggle label, description text,
-        // dropdown index, custom-input read-only flag. Restore them right
-        // here, during the apply walk, before any draw can fire. Doing it
-        // later in `handle_event(Event::ScriptReapply)` is too late and
-        // produces a one-frame flicker to the DSL defaults.
+        // The apply walk just reset every code-set field here to its DSL
+        // default. Restore them inline (before any draw) — doing it later
+        // in `handle_event` produces a one-frame flicker.
         //
-        // We pull prefs from the global mirror cuz the apply walk runs
-        // with an empty `Scope` (no `AppState`). The mirror is kept in
-        // sync by every `on_*_changed` call in `app_preferences.rs`.
+        // Prefs come from the global mirror cuz the apply walk runs with
+        // an empty `Scope`. The mirror is kept in sync by `on_*_changed`
+        // in `app_preferences.rs`.
         if !apply.is_script_reapply() {
             return;
         }
@@ -456,22 +453,18 @@ impl AppSettings {
         }
     }
 
-    /// Populates the widget from the given preferences. Called when the
-    /// settings screen is first shown or when fresh prefs arrive.
+    /// Populates the widget from the given prefs. Called on initial open
+    /// or when fresh prefs arrive.
     ///
-    /// Don't call this from the `Event::ScriptReapply` path — code-set
-    /// fields get handled in [`Self::on_after_apply`] during the apply
-    /// walk, and animator-driven fields get restored by the codegen
-    /// chain on their own.
+    /// Don't call from `Event::ScriptReapply` — code-set fields get
+    /// handled in [`Self::on_after_apply`], and animator-driven fields
+    /// are restored by the codegen apply chain.
     pub fn populate(&mut self, cx: &mut Cx, prefs: &AppPreferences) {
         Self::populate_safe(cx, &self.view, prefs);
 
-        // The animator setup below uses `set_active(Animate::No)`, which
-        // routes through `animator_cut` → `cx.with_vm`. That would panic
-        // if called from an `on_after_apply` hook, but it's fine here cuz
-        // we're outside any apply walk (settings open / fresh prefs).
-        // The ScriptReapply path doesn't need these calls anyway — the
-        // codegen apply chain restores animator state automatically.
+        // The animator setup below uses `set_active(Animate::No)` →
+        // `animator_cut` → `cx.with_vm`, which would panic from
+        // `on_after_apply`. Fine here cuz we're outside any apply walk.
         let send_toggle = self.view.check_box(cx, ids!(send_on_cmd_enter_toggle));
         send_toggle.set_active(cx, !prefs.send_on_enter, Animate::No);
 
@@ -485,25 +478,21 @@ impl AppSettings {
         self.view.radio_button(cx, ids!(thumb_medium_radio)).set_active(cx, medium, Animate::No);
         self.view.radio_button(cx, ids!(thumb_unlimited_radio)).set_active(cx, unlimited, Animate::No);
         self.view.radio_button(cx, ids!(thumb_custom_radio)).set_active(cx, custom, Animate::No);
-        // `populate_safe` above already set `is_read_only`; we pair it
-        // with the animator's disabled state here so the input lands in
-        // the right state on first paint. Both are needed on this initial
-        // path — only `is_read_only` is needed on ScriptReapply.
+        // `populate_safe` set `is_read_only`; pair it with the animator's
+        // disabled state here so the input lands in the right state on
+        // first paint. ScriptReapply only needs `is_read_only`.
         Self::set_thumb_custom_input_disabled(cx, &self.view, custom);
 
-        // We only write `thumb_custom_input`'s text on this initial path.
-        // `on_after_apply` deliberately leaves it alone so any in-progress
-        // edit the user is typing survives a ScriptReapply walk.
+        // Only write `thumb_custom_input`'s text on initial populate.
+        // `on_after_apply` leaves it alone so in-progress edits survive.
         self.view.text_input(cx, ids!(thumb_custom_input)).set_text(cx, &custom_text);
     }
 
-    /// Restores the code-set fields that the apply walk just reset
-    /// back to their DSL defaults: toggle label, description Label,
-    /// dropdown selected index, custom-input read-only flag. None of
-    /// these go through `cx.with_vm`, so it's safe to call from inside
-    /// an `on_after_apply` hook (which is exactly what we want — doing
-    /// it synchronously during the apply walk, before any draw, is what
-    /// prevents the one-frame flicker to DSL defaults).
+    /// Restores the code-set fields the apply walk just reset to DSL
+    /// defaults: toggle label, description, dropdown index, custom-input
+    /// read-only flag. None go through `cx.with_vm`, so this is safe to
+    /// call from `on_after_apply` — doing it inline is what prevents the
+    /// one-frame flicker.
     fn populate_safe(cx: &mut Cx, view: &View, prefs: &AppPreferences) {
         view.drop_down(cx, ids!(view_mode_dropdown))
             .set_selected_item(cx, prefs.view_mode.to_index());
@@ -525,24 +514,21 @@ impl AppSettings {
         view.label(cx, ids!(send_shortcut_description)).set_text(cx, text);
     }
 
-    /// Sets `thumb_custom_input.is_read_only` based on whether the custom
-    /// radio is selected. `is_read_only` is a plain `#[live] bool` that
-    /// the apply walk resets to the DSL default, so we have to re-set it
-    /// ourselves. Safe to call from anywhere — it's just a field write
-    /// plus a redraw, no `cx.with_vm`.
+    /// Sets `is_read_only` based on whether the custom radio is selected.
+    /// It's a plain `#[live] bool` the apply walk resets to the DSL
+    /// default, so we re-set it ourselves. Safe anywhere — just a field
+    /// write plus redraw.
     fn set_thumb_custom_input_read_only(cx: &mut Cx, view: &View, enabled: bool) {
         view.text_input(cx, ids!(thumb_custom_input))
             .set_is_read_only(cx, !enabled);
     }
 
-    /// Sets `thumb_custom_input`'s disabled animator state.
+    /// Sets the disabled animator state.
     ///
-    /// **NOT safe to call from inside `on_after_apply`** — `set_disabled`
-    /// goes through `animator_toggle` → `cx.with_vm`, which panics when
-    /// the script VM is already swapped out by the surrounding apply
-    /// walk. Only call this from outside an apply (settings open / fresh
-    /// prefs / action handlers). The ScriptReapply path doesn't need it
-    /// anyway — the codegen apply chain restores animator state itself.
+    /// **Not safe inside `on_after_apply`** — `set_disabled` goes through
+    /// `animator_toggle` → `cx.with_vm`, which panics when the VM is
+    /// swapped out. Only call from outside an apply walk. ScriptReapply
+    /// doesn't need it — the codegen chain restores animator state itself.
     fn set_thumb_custom_input_disabled(cx: &mut Cx, view: &View, enabled: bool) {
         view.text_input(cx, ids!(thumb_custom_input))
             .set_disabled(cx, !enabled);

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -4,7 +4,7 @@ use makepad_widgets::*;
 
 use crate::{
     app::AppState,
-    settings::app_preferences::{AppPreferences, ThumbnailMaxHeight, ViewModeOverride},
+    settings::app_preferences::{AppPreferences, AppPreferencesGlobal, ThumbnailMaxHeight, ViewModeOverride},
     shared::popup_list::{enqueue_popup_notification, PopupKind},
 };
 
@@ -305,9 +305,36 @@ script_mod! {
 /// Field-level state lives in [`AppState::app_prefs`]; this widget reads and
 /// writes that state in response to user interactions and emits
 /// [`AppPreferencesAction`]s so other widgets can apply changes live.
-#[derive(Script, ScriptHook, Widget)]
+#[derive(Script, Widget)]
 pub struct AppSettings {
     #[deref] view: View,
+}
+
+impl ScriptHook for AppSettings {
+    fn on_after_apply(
+        &mut self,
+        vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        // The apply walk just reset every code-set field in this subtree
+        // back to its DSL default — toggle label, description text,
+        // dropdown index, custom-input read-only flag. Restore them right
+        // here, during the apply walk, before any draw can fire. Doing it
+        // later in `handle_event(Event::ScriptReapply)` is too late and
+        // produces a one-frame flicker to the DSL defaults.
+        //
+        // We pull prefs from the global mirror cuz the apply walk runs
+        // with an empty `Scope` (no `AppState`). The mirror is kept in
+        // sync by every `on_*_changed` call in `app_preferences.rs`.
+        if !apply.is_script_reapply() {
+            return;
+        }
+        let cx = vm.cx_mut();
+        let prefs = cx.global::<AppPreferencesGlobal>().0.clone();
+        Self::populate_safe(cx, &self.view, &prefs);
+    }
 }
 
 impl Widget for AppSettings {
@@ -377,7 +404,8 @@ impl AppSettings {
                 _ => ThumbnailMaxHeight::default(),
             };
             let custom_now = matches!(new_thumb, ThumbnailMaxHeight::Custom(_));
-            Self::set_thumb_custom_input_state(cx, &self.view, custom_now);
+            Self::set_thumb_custom_input_read_only(cx, &self.view, custom_now);
+            Self::set_thumb_custom_input_disabled(cx, &self.view, custom_now);
             if new_thumb != app_state.app_prefs.thumbnail_max_height {
                 app_state.app_prefs.thumbnail_max_height = new_thumb;
                 app_state.app_prefs.on_thumbnail_max_height_changed(cx);
@@ -428,26 +456,25 @@ impl AppSettings {
         }
     }
 
-    /// Populates the widget from the given preferences.
+    /// Populates the widget from the given preferences. Called when the
+    /// settings screen is first shown or when fresh prefs arrive.
     ///
-    /// This should be called whenever the settings screen is shown.
+    /// Don't call this from the `Event::ScriptReapply` path — code-set
+    /// fields get handled in [`Self::on_after_apply`] during the apply
+    /// walk, and animator-driven fields get restored by the codegen
+    /// chain on their own.
     pub fn populate(&mut self, cx: &mut Cx, prefs: &AppPreferences) {
-        // View mode dropdown.
-        self.view
-            .drop_down(cx, ids!(view_mode_dropdown))
-            .set_selected_item(cx, prefs.view_mode.to_index());
+        Self::populate_safe(cx, &self.view, prefs);
 
-        // Send-on-enter toggle (checked means the primary modifier + Enter sends).
-        // `Animate::No` routes through `animator_cut` so the shader uniform is
-        // always force-re-applied — `Animate::Yes` would early-out on
-        // `Event::ScriptReapply` paths where the animator's `current_state`
-        // still matches the target but the reload has reset the uniform.
+        // The animator setup below uses `set_active(Animate::No)`, which
+        // routes through `animator_cut` → `cx.with_vm`. That would panic
+        // if called from an `on_after_apply` hook, but it's fine here cuz
+        // we're outside any apply walk (settings open / fresh prefs).
+        // The ScriptReapply path doesn't need these calls anyway — the
+        // codegen apply chain restores animator state automatically.
         let send_toggle = self.view.check_box(cx, ids!(send_on_cmd_enter_toggle));
-        send_toggle.set_text(SEND_SHORTCUT_TOGGLE_LABEL);
         send_toggle.set_active(cx, !prefs.send_on_enter, Animate::No);
-        Self::update_send_shortcut_description(cx, &self.view, prefs.send_on_enter);
 
-        // Thumbnail radios.
         let (small, medium, unlimited, custom, custom_text) = match prefs.thumbnail_max_height {
             ThumbnailMaxHeight::Small => (true, false, false, false, String::new()),
             ThumbnailMaxHeight::Medium => (false, true, false, false, String::new()),
@@ -458,8 +485,35 @@ impl AppSettings {
         self.view.radio_button(cx, ids!(thumb_medium_radio)).set_active(cx, medium, Animate::No);
         self.view.radio_button(cx, ids!(thumb_unlimited_radio)).set_active(cx, unlimited, Animate::No);
         self.view.radio_button(cx, ids!(thumb_custom_radio)).set_active(cx, custom, Animate::No);
+        // `populate_safe` above already set `is_read_only`; we pair it
+        // with the animator's disabled state here so the input lands in
+        // the right state on first paint. Both are needed on this initial
+        // path — only `is_read_only` is needed on ScriptReapply.
+        Self::set_thumb_custom_input_disabled(cx, &self.view, custom);
+
+        // We only write `thumb_custom_input`'s text on this initial path.
+        // `on_after_apply` deliberately leaves it alone so any in-progress
+        // edit the user is typing survives a ScriptReapply walk.
         self.view.text_input(cx, ids!(thumb_custom_input)).set_text(cx, &custom_text);
-        Self::set_thumb_custom_input_state(cx, &self.view, custom);
+    }
+
+    /// Restores the code-set fields that the apply walk just reset
+    /// back to their DSL defaults: toggle label, description Label,
+    /// dropdown selected index, custom-input read-only flag. None of
+    /// these go through `cx.with_vm`, so it's safe to call from inside
+    /// an `on_after_apply` hook (which is exactly what we want — doing
+    /// it synchronously during the apply walk, before any draw, is what
+    /// prevents the one-frame flicker to DSL defaults).
+    fn populate_safe(cx: &mut Cx, view: &View, prefs: &AppPreferences) {
+        view.drop_down(cx, ids!(view_mode_dropdown))
+            .set_selected_item(cx, prefs.view_mode.to_index());
+
+        view.check_box(cx, ids!(send_on_cmd_enter_toggle))
+            .set_text(SEND_SHORTCUT_TOGGLE_LABEL);
+        Self::update_send_shortcut_description(cx, view, prefs.send_on_enter);
+
+        let custom_active = matches!(prefs.thumbnail_max_height, ThumbnailMaxHeight::Custom(_));
+        Self::set_thumb_custom_input_read_only(cx, view, custom_active);
     }
 
     fn update_send_shortcut_description(cx: &mut Cx, view: &View, send_on_enter: bool) {
@@ -471,12 +525,30 @@ impl AppSettings {
         view.label(cx, ids!(send_shortcut_description)).set_text(cx, text);
     }
 
-    fn set_thumb_custom_input_state(cx: &mut Cx, view: &View, enabled: bool) {
-        let custom_input = view.text_input(cx, ids!(thumb_custom_input));
-        custom_input.set_disabled(cx, !enabled);
-        custom_input.set_is_read_only(cx, !enabled);
+    /// Sets `thumb_custom_input.is_read_only` based on whether the custom
+    /// radio is selected. `is_read_only` is a plain `#[live] bool` that
+    /// the apply walk resets to the DSL default, so we have to re-set it
+    /// ourselves. Safe to call from anywhere — it's just a field write
+    /// plus a redraw, no `cx.with_vm`.
+    fn set_thumb_custom_input_read_only(cx: &mut Cx, view: &View, enabled: bool) {
+        view.text_input(cx, ids!(thumb_custom_input))
+            .set_is_read_only(cx, !enabled);
+    }
+
+    /// Sets `thumb_custom_input`'s disabled animator state.
+    ///
+    /// **NOT safe to call from inside `on_after_apply`** — `set_disabled`
+    /// goes through `animator_toggle` → `cx.with_vm`, which panics when
+    /// the script VM is already swapped out by the surrounding apply
+    /// walk. Only call this from outside an apply (settings open / fresh
+    /// prefs / action handlers). The ScriptReapply path doesn't need it
+    /// anyway — the codegen apply chain restores animator state itself.
+    fn set_thumb_custom_input_disabled(cx: &mut Cx, view: &View, enabled: bool) {
+        view.text_input(cx, ids!(thumb_custom_input))
+            .set_disabled(cx, !enabled);
     }
 }
+
 
 impl AppSettingsRef {
     /// See [`AppSettings::populate`].

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -12,9 +12,9 @@ pub fn script_mod(vm: &mut ScriptVm) {
 }
 
 /// How a settings sub-widget should be (re)populated. Both modes re-apply
-/// animator-driven controls, `script_apply_eval` outputs, and code-derived
-/// text — they only differ on *user-mutable* text inputs (currently
-/// `display_name_input` and `thumb_custom_input`).
+/// animator-driven controls, `script_apply_eval` outputs, and code-derived text.
+/// They only differ on *user-mutable* text inputs (currently `display_name_input`
+/// and `thumb_custom_input`).
 #[derive(Clone, Copy)]
 pub(crate) enum PopulateMode {
     /// Full populate. Writes user-mutable inputs from the cached source

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -10,3 +10,26 @@ pub fn script_mod(vm: &mut ScriptVm) {
     app_settings::script_mod(vm);
     settings_screen::script_mod(vm);
 }
+
+/// How a settings sub-widget should be (re)populated.
+///
+/// Both modes re-apply animator-driven controls (dropdown index, toggle
+/// / radio active state), `script_apply_eval`-driven things (avatar
+/// image, button colors), and code-derived text (Labels, toggle labels).
+/// They only differ on *user-mutable* text inputs — currently
+/// `display_name_input` and `thumb_custom_input`.
+#[derive(Clone, Copy)]
+pub(crate) enum PopulateMode {
+    /// Full populate — authoritatively writes user-mutable inputs from
+    /// the cached source-of-truth and resets derived button states
+    /// (e.g. display-name accept/cancel) to their "not editing" defaults.
+    /// Used when the settings screen is first shown or when a fresh
+    /// profile / preference set arrives.
+    Initial,
+    /// Refresh after an `Apply::ScriptReapply` walk — same shape as
+    /// `Initial`, but leaves user-mutable inputs alone so any
+    /// in-progress edit survives. Buttons whose enabled state depends
+    /// on "input matches cached value" get re-derived from the current
+    /// input instead of forced to a known default.
+    AfterReapply,
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -11,25 +11,19 @@ pub fn script_mod(vm: &mut ScriptVm) {
     settings_screen::script_mod(vm);
 }
 
-/// How a settings sub-widget should be (re)populated.
-///
-/// Both modes re-apply animator-driven controls (dropdown index, toggle
-/// / radio active state), `script_apply_eval`-driven things (avatar
-/// image, button colors), and code-derived text (Labels, toggle labels).
-/// They only differ on *user-mutable* text inputs — currently
-/// `display_name_input` and `thumb_custom_input`.
+/// How a settings sub-widget should be (re)populated. Both modes re-apply
+/// animator-driven controls, `script_apply_eval` outputs, and code-derived
+/// text — they only differ on *user-mutable* text inputs (currently
+/// `display_name_input` and `thumb_custom_input`).
 #[derive(Clone, Copy)]
 pub(crate) enum PopulateMode {
-    /// Full populate — authoritatively writes user-mutable inputs from
-    /// the cached source-of-truth and resets derived button states
-    /// (e.g. display-name accept/cancel) to their "not editing" defaults.
-    /// Used when the settings screen is first shown or when a fresh
-    /// profile / preference set arrives.
+    /// Full populate. Writes user-mutable inputs from the cached source
+    /// of truth and resets derived button states (e.g. display-name
+    /// accept/cancel) to their "not editing" defaults. Used on initial
+    /// open or when fresh prefs / a fresh profile arrive.
     Initial,
-    /// Refresh after an `Apply::ScriptReapply` walk — same shape as
-    /// `Initial`, but leaves user-mutable inputs alone so any
-    /// in-progress edit survives. Buttons whose enabled state depends
-    /// on "input matches cached value" get re-derived from the current
-    /// input instead of forced to a known default.
+    /// Refresh after `Apply::ScriptReapply`. Same as `Initial` but leaves
+    /// user-mutable inputs alone (preserves in-progress edits) and
+    /// re-derives "edited" button states from the current input.
     AfterReapply,
 }

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -1,7 +1,7 @@
 
 use makepad_widgets::*;
 
-use crate::{app::AppState, home::navigation_tab_bar::{NavigationBarAction, get_own_profile}, profile::user_profile::UserProfile, settings::{account_settings::AccountSettingsWidgetExt, app_settings::AppSettingsWidgetExt}};
+use crate::{app::AppState, home::navigation_tab_bar::{NavigationBarAction, get_own_profile}, profile::user_profile::UserProfile, settings::{PopulateMode, account_settings::AccountSettingsWidgetExt, app_settings::AppSettingsWidgetExt}};
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -98,19 +98,16 @@ impl Widget for SettingsScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
 
-        // `Event::ScriptReapply` walks the widget tree with `Apply::Reload`,
-        // which snaps every DSL-bound widget field in this screen back to
-        // the defaults baked into the `script_mod!` blocks (dropdown index,
-        // toggle state, radio selection, user_id label, display_name input,
-        // avatar image). Any preference change that uses
-        // `cx.request_script_reapply()` to broadcast itself — currently the
-        // thumbnail-height radios — would therefore clobber the UI state
-        // of every unrelated control. Re-apply the cached preferences and
-        // profile so the screen stays in sync.
+        // The ScriptReapply walk preserves text fields (String /
+        // ArcStringMut bail out on it), but it still resets animator-driven
+        // controls and `script_apply_eval`-driven things (avatar image,
+        // button colors) back to their DSL defaults. So we re-apply just
+        // those here. Crucially, do NOT re-`set_text` any user-editable
+        // input — that would wipe out a partially-typed display name or
+        // custom thumbnail size.
         if let Event::ScriptReapply = event {
             if let Some(app_state) = scope.data.get::<AppState>() {
-                self.view.account_settings(cx, ids!(account_settings)).populate(cx, None);
-                self.view.app_settings(cx, ids!(app_settings)).populate(cx, &app_state.app_prefs);
+                self.populate_subwidgets(cx, PopulateMode::AfterReapply, None, app_state);
             }
         }
 
@@ -188,11 +185,40 @@ impl SettingsScreen {
             error!("Failed to get own profile for settings screen.");
             return;
         };
-        self.view.account_settings(cx, ids!(account_settings)).populate(cx, Some(profile));
-        self.view.app_settings(cx, ids!(app_settings)).populate(cx, &app_state.app_prefs);
+        self.populate_subwidgets(cx, PopulateMode::Initial, Some(profile), app_state);
         self.view.button(cx, ids!(close_button)).reset_hover(cx);
         cx.set_key_focus(self.view.area());
         self.redraw(cx);
+    }
+
+    /// Single place that decides which sub-widgets get (re)synced and how.
+    /// Both the initial-open path and the `Event::ScriptReapply` path
+    /// route through here, so adding a new sub-widget that participates
+    /// in either sync only requires editing this match.
+    ///
+    /// `AppSettings` is intentionally missing from the `AfterReapply` arm —
+    /// it restores itself synchronously from its own `on_after_apply` hook
+    /// (during the apply walk, before any draw fires), which is what
+    /// avoids the flicker the late path used to produce. `AccountSettings`
+    /// still needs the late path for its `script_apply_eval`-driven bits
+    /// (button colors, avatar repaint) cuz those can't run from inside an
+    /// `on_after_apply` (the VM is swapped out there).
+    fn populate_subwidgets(
+        &mut self,
+        cx: &mut Cx,
+        mode: PopulateMode,
+        profile: Option<UserProfile>,
+        app_state: &AppState,
+    ) {
+        match mode {
+            PopulateMode::Initial => {
+                self.view.account_settings(cx, ids!(account_settings)).populate(cx, profile);
+                self.view.app_settings(cx, ids!(app_settings)).populate(cx, &app_state.app_prefs);
+            }
+            PopulateMode::AfterReapply => {
+                self.view.account_settings(cx, ids!(account_settings)).restore_after_reapply(cx);
+            }
+        }
     }
 }
 

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -98,13 +98,11 @@ impl Widget for SettingsScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
 
-        // The ScriptReapply walk preserves text fields (String /
-        // ArcStringMut bail out on it), but it still resets animator-driven
-        // controls and `script_apply_eval`-driven things (avatar image,
-        // button colors) back to their DSL defaults. So we re-apply just
-        // those here. Crucially, do NOT re-`set_text` any user-editable
-        // input — that would wipe out a partially-typed display name or
-        // custom thumbnail size.
+        // ScriptReapply preserves text fields (String / ArcStringMut bail
+        // out), but still resets animator-driven controls and
+        // `script_apply_eval`-driven bits (avatar, button colors). Re-apply
+        // just those — never re-`set_text` user-editable inputs, that
+        // wipes in-progress edits.
         if let Event::ScriptReapply = event {
             if let Some(app_state) = scope.data.get::<AppState>() {
                 self.populate_subwidgets(cx, PopulateMode::AfterReapply, None, app_state);
@@ -191,18 +189,14 @@ impl SettingsScreen {
         self.redraw(cx);
     }
 
-    /// Single place that decides which sub-widgets get (re)synced and how.
-    /// Both the initial-open path and the `Event::ScriptReapply` path
-    /// route through here, so adding a new sub-widget that participates
-    /// in either sync only requires editing this match.
+    /// Single place deciding which sub-widgets get (re)synced and how.
+    /// Both the initial-open and `Event::ScriptReapply` paths route here.
     ///
-    /// `AppSettings` is intentionally missing from the `AfterReapply` arm —
-    /// it restores itself synchronously from its own `on_after_apply` hook
-    /// (during the apply walk, before any draw fires), which is what
-    /// avoids the flicker the late path used to produce. `AccountSettings`
-    /// still needs the late path for its `script_apply_eval`-driven bits
-    /// (button colors, avatar repaint) cuz those can't run from inside an
-    /// `on_after_apply` (the VM is swapped out there).
+    /// `AppSettings` is missing from `AfterReapply` on purpose — it
+    /// restores itself inline from `on_after_apply` to avoid the flicker
+    /// the late path used to produce. `AccountSettings` still needs the
+    /// late path for its `script_apply_eval`-driven bits (button colors,
+    /// avatar) cuz those can't run from inside `on_after_apply`.
     fn populate_subwidgets(
         &mut self,
         cx: &mut Cx,

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -98,6 +98,22 @@ impl Widget for SettingsScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
 
+        // `Event::ScriptReapply` walks the widget tree with `Apply::Reload`,
+        // which snaps every DSL-bound widget field in this screen back to
+        // the defaults baked into the `script_mod!` blocks (dropdown index,
+        // toggle state, radio selection, user_id label, display_name input,
+        // avatar image). Any preference change that uses
+        // `cx.request_script_reapply()` to broadcast itself — currently the
+        // thumbnail-height radios — would therefore clobber the UI state
+        // of every unrelated control. Re-apply the cached preferences and
+        // profile so the screen stays in sync.
+        if let Event::ScriptReapply = event {
+            if let Some(app_state) = scope.data.get::<AppState>() {
+                self.view.account_settings(cx, ids!(account_settings)).populate(cx, None);
+                self.view.app_settings(cx, ids!(app_settings)).populate(cx, &app_state.app_prefs);
+            }
+        }
+
         // Close the pane if:
         // 1. The close button is clicked,
         // 2. The back navigational gesture/action occurs (e.g., Back on Android),
@@ -172,7 +188,7 @@ impl SettingsScreen {
             error!("Failed to get own profile for settings screen.");
             return;
         };
-        self.view.account_settings(cx, ids!(account_settings)).populate(cx, profile);
+        self.view.account_settings(cx, ids!(account_settings)).populate(cx, Some(profile));
         self.view.app_settings(cx, ids!(app_settings)).populate(cx, &app_state.app_prefs);
         self.view.button(cx, ids!(close_button)).reset_hover(cx);
         cx.set_key_focus(self.view.area());

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -98,11 +98,10 @@ impl Widget for SettingsScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.view.handle_event(cx, event, scope);
 
-        // ScriptReapply preserves text fields (String / ArcStringMut bail
-        // out), but still resets animator-driven controls and
-        // `script_apply_eval`-driven bits (avatar, button colors). Re-apply
-        // just those — never re-`set_text` user-editable inputs, that
-        // wipes in-progress edits.
+        // ScriptReapply preserves text fields (String / ArcStringMut bail out),
+        // but still resets animator-driven controls and `script_apply_eval`-driven
+        // bits (avatar, button colors). Re-apply just those.
+        // Never re-`set_text` user-editable inputs here, that would wipe in-progress edits.
         if let Event::ScriptReapply = event {
             if let Some(app_state) = scope.data.get::<AppState>() {
                 self.populate_subwidgets(cx, PopulateMode::AfterReapply, None, app_state);
@@ -192,11 +191,11 @@ impl SettingsScreen {
     /// Single place deciding which sub-widgets get (re)synced and how.
     /// Both the initial-open and `Event::ScriptReapply` paths route here.
     ///
-    /// `AppSettings` is missing from `AfterReapply` on purpose — it
+    /// `AppSettings` is missing from `AfterReapply` on purpose, since it
     /// restores itself inline from `on_after_apply` to avoid the flicker
     /// the late path used to produce. `AccountSettings` still needs the
     /// late path for its `script_apply_eval`-driven bits (button colors,
-    /// avatar) cuz those can't run from inside `on_after_apply`.
+    /// avatar), cuz those can't run from inside `on_after_apply`.
     fn populate_subwidgets(
         &mut self,
         cx: &mut Cx,

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -200,8 +200,8 @@ script_mod! {
 
         metadata_view := View {
             width: Fill, height: Fill,
-            // Placeholder — real values are set in Rust via `script_apply_eval!`
-            // during `draw_walk` (the slide animation writes here too).
+            // Placeholder. Real values are set in Rust via `script_apply_eval!`
+            // during `draw_walk`, since the slide animation writes here too.
             margin: Inset{top: 20, left: 20, right: 20, bottom: 20}
             align: Align{x: 0.0, y: 1.0},
             metadata_rounded_view := RoundedView {
@@ -294,7 +294,7 @@ script_mod! {
         button_group_view := View {
             width: Fill, height: Fit
             flow: Right
-            // Placeholder — see `metadata_view` above.
+            // Placeholder, see `metadata_view` above.
             margin: Inset{top: 20, right: 20}
             align: Align{x: 1.0, y: 0.5},
 

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -200,10 +200,8 @@ script_mod! {
 
         metadata_view := View {
             width: Fill, height: Fill,
-            // Margins set here are placeholders — the actual values (including safe-area
-            // insets) are computed and applied in Rust during `draw_walk` via
-            // `script_apply_eval!`, because the slide-in/out animation also writes to
-            // these properties. See ImageViewer::draw_walk for the canonical values.
+            // Placeholder — real values are set in Rust via `script_apply_eval!`
+            // during `draw_walk` (the slide animation writes here too).
             margin: Inset{top: 20, left: 20, right: 20, bottom: 20}
             align: Align{x: 0.0, y: 1.0},
             metadata_rounded_view := RoundedView {
@@ -296,8 +294,7 @@ script_mod! {
         button_group_view := View {
             width: Fill, height: Fit
             flow: Right
-            // Margins set here are placeholders — actual values (including safe-area
-            // insets) are computed in Rust during `draw_walk` via `script_apply_eval!`.
+            // Placeholder — see `metadata_view` above.
             margin: Inset{top: 20, right: 20}
             align: Align{x: 1.0, y: 0.5},
 
@@ -745,16 +742,13 @@ impl Widget for ImageViewer {
             self.next_frame = cx.new_next_frame();
         }
 
-        // Use the animated `ui_overlay_slide` value to position the overlay views.
-        // slide=0.0 → fully visible (margins at their visible-state values).
-        // slide=1.0 → fully hidden (margins push views off-screen).
+        // Position the overlays from the animated `ui_overlay_slide`.
+        // 0.0 = fully visible, 1.0 = fully off-screen.
         //
-        // Each visible-state margin is `max(20.0, safe_inset)` so the overlays clear the
-        // device's Dynamic Island / notch / home indicator. ImageViewer is shown via
-        // Modal which calls `cx.begin_root_turtle_for_pass` and bypasses the window
-        // body's padding (modal.rs), so we MUST apply the safe insets here in Rust;
-        // setting them in the DSL has no effect because this `script_apply_eval!`
-        // overrides those values on every draw.
+        // Visible-state margin is `max(20.0, safe_inset)` so the overlays
+        // clear cutouts. Has to be done in Rust cuz Modal bypasses the
+        // window body's padding, and `script_apply_eval!` overrides the
+        // DSL values every draw anyway.
         let slide = self.ui_overlay_slide as f64;
         let insets = cx.display_context.safe_area_insets;
         let button_top_visible = 20.0_f64.max(insets.top);

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -4,6 +4,7 @@
 //! ImageViewerRef has 4 public methods, `configure_zoom`, `show_loading`, `show_loaded` and `reset`.
 use std::sync::{mpsc::Receiver, Arc};
 
+use bytesize::ByteSize;
 use chrono::{DateTime, Local};
 use makepad_widgets::{
     event::TouchUpdateEvent,
@@ -199,7 +200,11 @@ script_mod! {
 
         metadata_view := View {
             width: Fill, height: Fill,
-            margin: Inset{top: 20, left: 20, right: 20, bottom: 20},
+            // Margins set here are placeholders — the actual values (including safe-area
+            // insets) are computed and applied in Rust during `draw_walk` via
+            // `script_apply_eval!`, because the slide-in/out animation also writes to
+            // these properties. See ImageViewer::draw_walk for the canonical values.
+            margin: Inset{top: 20, left: 20, right: 20, bottom: 20}
             align: Align{x: 0.0, y: 1.0},
             metadata_rounded_view := RoundedView {
                 width: Fill, height: Fit
@@ -291,6 +296,8 @@ script_mod! {
         button_group_view := View {
             width: Fill, height: Fit
             flow: Right
+            // Margins set here are placeholders — actual values (including safe-area
+            // insets) are computed in Rust during `draw_walk` via `script_apply_eval!`.
             margin: Inset{top: 20, right: 20}
             align: Align{x: 1.0, y: 0.5},
 
@@ -739,18 +746,37 @@ impl Widget for ImageViewer {
         }
 
         // Use the animated `ui_overlay_slide` value to position the overlay views.
-        // slide=0.0 → fully visible (margins at their DSL defaults).
+        // slide=0.0 → fully visible (margins at their visible-state values).
         // slide=1.0 → fully hidden (margins push views off-screen).
+        //
+        // Each visible-state margin is `max(20.0, safe_inset)` so the overlays clear the
+        // device's Dynamic Island / notch / home indicator. ImageViewer is shown via
+        // Modal which calls `cx.begin_root_turtle_for_pass` and bypasses the window
+        // body's padding (modal.rs), so we MUST apply the safe insets here in Rust;
+        // setting them in the DSL has no effect because this `script_apply_eval!`
+        // overrides those values on every draw.
         let slide = self.ui_overlay_slide as f64;
-        let button_top = 20.0 - (slide * 220.0); // 20 → -200
-        let meta_bottom = 20.0 - (slide * 320.0); // 20 → -300
+        let insets = cx.display_context.safe_area_insets;
+        let button_top_visible = 20.0_f64.max(insets.top);
+        let button_right        = 20.0_f64.max(insets.right);
+        let meta_top            = 20.0_f64.max(insets.top);
+        let meta_left           = 20.0_f64.max(insets.left);
+        let meta_right          = 20.0_f64.max(insets.right);
+        let meta_bottom_visible = 20.0_f64.max(insets.bottom);
+        let button_top = button_top_visible - (slide * 220.0); // visible → -200
+        let meta_bottom = meta_bottom_visible - (slide * 320.0); // visible → -300
         let mut bg = self.view(cx, ids!(button_group_view));
         script_apply_eval!(cx, bg, {
-            margin +: { top: #(button_top), right: 20.0 }
+            margin +: { top: #(button_top), right: #(button_right) }
         });
         let mut mv = self.view(cx, ids!(metadata_view));
         script_apply_eval!(cx, mv, {
-            margin +: { top: 20.0, left: 20.0, right: 20.0, bottom: #(meta_bottom) }
+            margin +: {
+                top: #(meta_top),
+                left: #(meta_left),
+                right: #(meta_right),
+                bottom: #(meta_bottom),
+            }
         });
 
         self.view.draw_walk(cx, scope, walk)
@@ -1100,8 +1126,7 @@ impl ImageViewer {
     /// via `max_lines: 2` + `text_overflow: Ellipsis` in the layout.
     pub fn set_metadata(&mut self, cx: &mut Cx, metadata: &ImageViewerMetaData) {
         let meta_view = self.view.view(cx, ids!(metadata_view));
-        let human_readable_size = format_file_size(metadata.image_file_size);
-        let display_text = format!("{} ({})", metadata.image_name, human_readable_size);
+        let display_text = format!("{} ({})", metadata.image_name, ByteSize::b(metadata.image_file_size));
         meta_view
             .label(cx, ids!(image_name_and_size))
             .set_text(cx, &display_text);
@@ -1202,25 +1227,3 @@ pub struct ImageViewerMetaData {
     pub image_file_size: u64,
 }
 
-/// Convert bytes to human-readable file size format
-fn format_file_size(bytes: u64) -> String {
-    const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB"];
-
-    if bytes == 0 {
-        return "0 B".to_string();
-    }
-
-    let mut size = bytes as f64;
-    let mut unit_index = 0;
-
-    while size >= 1024.0 && unit_index < UNITS.len() - 1 {
-        size /= 1024.0;
-        unit_index += 1;
-    }
-
-    if unit_index == 0 {
-        format!("{} {}", bytes, UNITS[unit_index])
-    } else {
-        format!("{:.1} {}", size, UNITS[unit_index])
-    }
-}

--- a/src/shared/navigation_bar_button.rs
+++ b/src/shared/navigation_bar_button.rs
@@ -63,9 +63,9 @@ script_mod! {
             border_inset: uniform(vec4(0.0))
 
             // Fade `color_hover` in/out by scaling its own alpha rather than
-            // mix()ing toward `#0000`. mix()ing pulls RGB toward black, which
-            // combined with the dropping alpha makes the blend briefly DARKER
-            // mid-fade — visible as a flicker on hover-out.
+            // mix()ing toward `#0000`. mix()ing pulls RGB toward black,
+            // which combined with the dropping alpha makes the blend briefly
+            // DARKER mid-fade, visible as a flicker on hover-out.
             get_color: fn() -> vec4 {
                 let hover_color = vec4(self.color_hover.xyz, self.color_hover.w * self.hover)
                 return mix(hover_color, self.color_active, self.active)
@@ -204,8 +204,8 @@ impl Widget for NavigationBarButton {
                 }
             }
             // Reset if the finger drags off mid-press. Critical inside a
-            // `PortalList` — once it commits a drag-scroll it eats `FingerUp`
-            // from children, leaving the button stuck pressed otherwise.
+            // `PortalList`, since once it commits a drag-scroll it eats
+            // `FingerUp` from children, leaving the button stuck pressed.
             Hit::FingerMove(fe) if !fe.is_over => {
                 self.animator_play(cx, ids!(hover.off));
                 if !fe.device.has_hovers() {
@@ -221,7 +221,7 @@ impl Widget for NavigationBarButton {
                 if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
                     cx.widget_action(widget_uid, NavigationBarButtonAction::Clicked);
                 }
-                // Pick the resting state. On a mouse with cursor still over
+                // Pick the resting state. On a mouse with the cursor still over
                 // the button, stay on `hover.on`. Otherwise (touch, or release
                 // off the button) reset to `hover.off`. This also catches
                 // `is_over && !was_tap()` (e.g. release after a long press),

--- a/src/shared/navigation_bar_button.rs
+++ b/src/shared/navigation_bar_button.rs
@@ -54,7 +54,6 @@ script_mod! {
             hover: instance(0.0)
             active: instance(0.0)
 
-            color: instance(#0000)
             color_hover: instance((COLOR_NAVIGATION_TAB_BG_HOVER))
             color_active: instance((COLOR_NAVIGATION_TAB_BG_ACTIVE))
 
@@ -63,16 +62,15 @@ script_mod! {
             border_radius: uniform(4.0)
             border_inset: uniform(vec4(0.0))
 
+            // The "rest" state is fully transparent; we fade `color_hover` in/out
+            // by scaling its own alpha by `hover` rather than mix()ing toward a
+            // separate transparent constant. mix()ing toward `#0000` linearly
+            // interpolates the RGB toward black, which (combined with the
+            // changing alpha) makes the alpha-blended result momentarily DARKER
+            // mid-fade than at full hover — visible as a flicker on hover-out.
             get_color: fn() -> vec4 {
-                return mix(
-                    mix(
-                        self.color,
-                        self.color_hover,
-                        self.hover
-                    ),
-                    self.color_active,
-                    self.active
-                )
+                let hover_color = vec4(self.color_hover.xyz, self.color_hover.w * self.hover)
+                return mix(hover_color, self.color_active, self.active)
             }
 
             pixel: fn() {
@@ -97,15 +95,15 @@ script_mod! {
                 default: @off
                 off: AnimatorState{
                     from: {all: Forward {duration: 0.15}}
-                    apply: { draw_bg: {down: [{time: 0.0, value: 0.0}], hover: 0.0} }
+                    apply: { draw_bg: {hover: 0.0} }
                 }
                 on: AnimatorState{
                     from: {all: Snap}
-                    apply: { draw_bg: {down: [{time: 0.0, value: 0.0}], hover: 1.0} }
+                    apply: { draw_bg: {hover: 1.0} }
                 }
                 down: AnimatorState{
-                    from: {all: Forward {duration: 0.2}}
-                    apply: { draw_bg: {down: [{time: 0.0, value: 1.0}], hover: 1.0} }
+                    from: {all: Snap}
+                    apply: { draw_bg: {hover: 1.0} }
                 }
             }
             active: {
@@ -207,17 +205,44 @@ impl Widget for NavigationBarButton {
                     cx.widget_action(widget_uid, NavigationBarButtonAction::SecondaryClicked);
                 }
             }
+            // Reset to the off state if the finger/mouse drags off the button
+            // mid-press. This is critical for items inside a `PortalList`: once
+            // the list commits a drag-scroll, it suppresses `FingerUp` from
+            // reaching children, so without this branch the button would stay
+            // visually pressed forever after a tap-and-drag gesture.
+            Hit::FingerMove(fe) if !fe.is_over => {
+                self.animator_play(cx, ids!(hover.off));
+                if !fe.device.has_hovers() {
+                    emit_hover_out(self, cx);
+                }
+            }
             Hit::FingerLongPress(_) => {
                 self.animator_play(cx, ids!(hover.down));
                 emit_hover_in(self, cx);
                 cx.widget_action(widget_uid, NavigationBarButtonAction::SecondaryClicked);
             }
-            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
-                self.animator_play(cx, ids!(hover.on));
-                cx.widget_action(widget_uid, NavigationBarButtonAction::Clicked);
-            }
-            Hit::FingerUp(fe) if !fe.is_over => {
-                self.animator_play(cx, ids!(hover.off));
+            Hit::FingerUp(fe) => {
+                if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
+                    cx.widget_action(widget_uid, NavigationBarButtonAction::Clicked);
+                }
+                // Pick the resting visual state. On a hover-capable device (mouse),
+                // land on `hover.on` if the cursor is still over the button so it
+                // remains visibly hovered after a click. Otherwise — touch devices
+                // (no follow-up `FingerHoverOut`), or any release outside the
+                // button's bounds — reset to `hover.off`. This also covers the
+                // `is_over && !was_tap()` case (e.g. release after a long press),
+                // which previously left the animator stuck in `hover.down`.
+                if fe.device.has_hovers() && fe.is_over {
+                    self.animator_play(cx, ids!(hover.on));
+                } else {
+                    self.animator_play(cx, ids!(hover.off));
+                    // On touch, no FingerHoverOut follows, so dismiss any tooltip
+                    // that a long-press may have opened. (HoverIn is emitted from
+                    // FingerLongPress above.)
+                    if !fe.device.has_hovers() {
+                        emit_hover_out(self, cx);
+                    }
+                }
             }
             _ => {}
         }

--- a/src/shared/navigation_bar_button.rs
+++ b/src/shared/navigation_bar_button.rs
@@ -62,12 +62,10 @@ script_mod! {
             border_radius: uniform(4.0)
             border_inset: uniform(vec4(0.0))
 
-            // The "rest" state is fully transparent; we fade `color_hover` in/out
-            // by scaling its own alpha by `hover` rather than mix()ing toward a
-            // separate transparent constant. mix()ing toward `#0000` linearly
-            // interpolates the RGB toward black, which (combined with the
-            // changing alpha) makes the alpha-blended result momentarily DARKER
-            // mid-fade than at full hover — visible as a flicker on hover-out.
+            // Fade `color_hover` in/out by scaling its own alpha rather than
+            // mix()ing toward `#0000`. mix()ing pulls RGB toward black, which
+            // combined with the dropping alpha makes the blend briefly DARKER
+            // mid-fade — visible as a flicker on hover-out.
             get_color: fn() -> vec4 {
                 let hover_color = vec4(self.color_hover.xyz, self.color_hover.w * self.hover)
                 return mix(hover_color, self.color_active, self.active)
@@ -205,11 +203,9 @@ impl Widget for NavigationBarButton {
                     cx.widget_action(widget_uid, NavigationBarButtonAction::SecondaryClicked);
                 }
             }
-            // Reset to the off state if the finger/mouse drags off the button
-            // mid-press. This is critical for items inside a `PortalList`: once
-            // the list commits a drag-scroll, it suppresses `FingerUp` from
-            // reaching children, so without this branch the button would stay
-            // visually pressed forever after a tap-and-drag gesture.
+            // Reset if the finger drags off mid-press. Critical inside a
+            // `PortalList` — once it commits a drag-scroll it eats `FingerUp`
+            // from children, leaving the button stuck pressed otherwise.
             Hit::FingerMove(fe) if !fe.is_over => {
                 self.animator_play(cx, ids!(hover.off));
                 if !fe.device.has_hovers() {
@@ -225,20 +221,17 @@ impl Widget for NavigationBarButton {
                 if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
                     cx.widget_action(widget_uid, NavigationBarButtonAction::Clicked);
                 }
-                // Pick the resting visual state. On a hover-capable device (mouse),
-                // land on `hover.on` if the cursor is still over the button so it
-                // remains visibly hovered after a click. Otherwise — touch devices
-                // (no follow-up `FingerHoverOut`), or any release outside the
-                // button's bounds — reset to `hover.off`. This also covers the
-                // `is_over && !was_tap()` case (e.g. release after a long press),
-                // which previously left the animator stuck in `hover.down`.
+                // Pick the resting state. On a mouse with cursor still over
+                // the button, stay on `hover.on`. Otherwise (touch, or release
+                // off the button) reset to `hover.off`. This also catches
+                // `is_over && !was_tap()` (e.g. release after a long press),
+                // which used to leave the animator stuck in `hover.down`.
                 if fe.device.has_hovers() && fe.is_over {
                     self.animator_play(cx, ids!(hover.on));
                 } else {
                     self.animator_play(cx, ids!(hover.off));
-                    // On touch, no FingerHoverOut follows, so dismiss any tooltip
-                    // that a long-press may have opened. (HoverIn is emitted from
-                    // FingerLongPress above.)
+                    // No FingerHoverOut on touch, so manually dismiss any
+                    // long-press tooltip. (HoverIn is emitted above.)
                     if !fe.device.has_hovers() {
                         emit_hover_out(self, cx);
                     }

--- a/src/shared/popup_list.rs
+++ b/src/shared/popup_list.rs
@@ -331,10 +331,15 @@ script_mod! {
 
     // A widget that displays a vertical list of popups at the top right corner of the screen.
     // The progress bar slides from right to left.
+    // The margins are to ensure that popups don't get rendered in the device safe inset area.
     mod.widgets.PopupList = View {
         width: Fill,
         height: Fill,
-        margin: Inset{ top: 10 }
+        margin: Inset{
+            top: 10,
+            left: (mod.widgets.SAFE_INSET_PAD_LEFT),
+            right: (mod.widgets.SAFE_INSET_PAD_RIGHT),
+        }
         align: Align{x: 0.99, }
         popup_notification := mod.widgets.RobrixPopupNotificationRightToLeftProgress {}
     }

--- a/src/shared/room_filter_input_bar.rs
+++ b/src/shared/room_filter_input_bar.rs
@@ -64,9 +64,32 @@ script_mod! {
 /// A text input (with a search icon and cancel button) used to filter a list of rooms/spaces.
 ///
 /// See the module-level docs for more detail.
-#[derive(Script, ScriptHook, Widget)]
+#[derive(Script, Widget)]
 pub struct RoomFilterInputBar {
     #[deref] view: View,
+}
+
+impl ScriptHook for RoomFilterInputBar {
+    fn on_after_apply(
+        &mut self,
+        _vm: &mut ScriptVm,
+        apply: &Apply,
+        _scope: &mut Scope,
+        _value: ScriptValue,
+    ) {
+        // The clear button's visibility mirrors "the input has text" — that's
+        // runtime state, not something the DSL knows about. So when the
+        // widget tree is re-applied (e.g. after a preference change), the
+        // apply walk resets the button to the DSL's `visible: false` and we
+        // lose it. Re-derive visibility from the input's current text here
+        // so it survives.
+        if !apply.is_script_reapply() {
+            return;
+        }
+        let cx = _vm.cx_mut();
+        let has_text = !self.text_input(cx, ids!(input)).text().is_empty();
+        self.button(cx, ids!(clear_button)).set_visible(cx, has_text);
+    }
 }
 
 /// Actions emitted by the `RoomFilterInputBar` based on user interaction with it.

--- a/src/shared/room_filter_input_bar.rs
+++ b/src/shared/room_filter_input_bar.rs
@@ -77,7 +77,7 @@ impl ScriptHook for RoomFilterInputBar {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) {
-        // The clear button mirrors "input has text" — runtime state, not DSL.
+        // The clear button mirrors "input has text", which is runtime state, not DSL.
         // Re-derive it after every apply walk so the DSL's `visible: false`
         // doesn't reset it.
         if !apply.is_script_reapply() {

--- a/src/shared/room_filter_input_bar.rs
+++ b/src/shared/room_filter_input_bar.rs
@@ -77,12 +77,9 @@ impl ScriptHook for RoomFilterInputBar {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) {
-        // The clear button's visibility mirrors "the input has text" — that's
-        // runtime state, not something the DSL knows about. So when the
-        // widget tree is re-applied (e.g. after a preference change), the
-        // apply walk resets the button to the DSL's `visible: false` and we
-        // lose it. Re-derive visibility from the input's current text here
-        // so it survives.
+        // The clear button mirrors "input has text" — runtime state, not DSL.
+        // Re-derive it after every apply walk so the DSL's `visible: false`
+        // doesn't reset it.
         if !apply.is_script_reapply() {
             return;
         }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -158,7 +158,7 @@ async fn build_client(
         client,
         ClientSessionPersisted {
             homeserver: homeserver_url,
-            // Store the relative subfolder name only — the absolute path is
+            // Store the relative subfolder name only. The absolute path is
             // rebuilt on restore. Avoids baking in a sandbox path that goes
             // stale on iOS (container UUID changes across reinstalls).
             db_path: PathBuf::from(db_subfolder_name),
@@ -1993,8 +1993,8 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
     // Spawn the main async task that drives the Matrix client SDK and
     // monitors the related background tasks. (The `DEFAULT_SSO_CLIENT`
     // pre-build is gated inside that task on whether the user actually
-    // needs to log in — otherwise it leaves an orphaned sqlite db on
-    // disk every cold start.)
+    // needs to log in. Otherwise it leaves an orphaned sqlite db on disk
+    // every cold start.)
     rt_handle.spawn(start_matrix_client_login_and_sync(rt));
 
     Ok(rt_handle)
@@ -2341,8 +2341,8 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
     // Only pre-build `DEFAULT_SSO_CLIENT` if we'll actually show the login
     // screen. Building it eagerly during session restore just leaves an
     // orphaned sqlite db every cold start. If we skip the build, still
-    // notify so a later SSO attempt doesn't deadlock on the notifier —
-    // the SSO handler builds a fresh client itself if it's still `None`.
+    // notify so a later SSO attempt doesn't deadlock on the notifier.
+    // The SSO handler builds a fresh client itself if it's still `None`.
     if initial_client_opt.is_none() {
         rt.spawn(async move {
             match build_client(&Cli::default(), app_data_dir()).await {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -27,7 +27,7 @@ use tokio::{
     sync::{broadcast, mpsc::{Sender, UnboundedReceiver, UnboundedSender}, watch, Notify}, task::JoinHandle, time::error::Elapsed,
 };
 use url::Url;
-use std::{borrow::Cow, cmp::{max, min}, future::Future, hash::{BuildHasherDefault, DefaultHasher}, iter::Peekable, ops::{Deref, DerefMut, Not}, path:: Path, sync::{Arc, LazyLock, Mutex, atomic::{AtomicBool, Ordering}}, time::Duration};
+use std::{borrow::Cow, cmp::{max, min}, future::Future, hash::{BuildHasherDefault, DefaultHasher}, iter::Peekable, ops::{Deref, DerefMut, Not}, path::{Path, PathBuf}, sync::{Arc, LazyLock, Mutex, atomic::{AtomicBool, Ordering}}, time::Duration};
 use std::io;
 use hashbrown::{HashMap, HashSet};
 use crate::{
@@ -104,7 +104,8 @@ async fn build_client(
     // which allows multiple clients to run simultaneously.
     let now = chrono::Local::now();
     let db_subfolder_name: String = format!("db_{}", now.format("%F_%H_%M_%S_%f"));
-    let db_path = data_dir.join(db_subfolder_name);
+    let db_path = data_dir.join(&db_subfolder_name);
+    log!("Building new client with db at: {}", db_path.display());
 
     // Generate a random passphrase.
     let passphrase: String = {
@@ -157,7 +158,11 @@ async fn build_client(
         client,
         ClientSessionPersisted {
             homeserver: homeserver_url,
-            db_path,
+            // Store only the relative subfolder name. The absolute path is reconstructed
+            // on restore by joining this with the current `app_data_dir()`. This avoids
+            // baking in a sandbox path that becomes stale on iOS, where the app's
+            // container UUID changes across reinstalls/redeploys.
+            db_path: PathBuf::from(db_subfolder_name),
             passphrase,
         },
     ))
@@ -1985,23 +1990,12 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
         tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime")
     }).handle().clone();
 
-    // Proactively build a Matrix Client in the background so that the SSO Server
-    // can have a quicker start if needed (as it's rather slow to build this client).
-    rt_handle.spawn(async move {
-        match build_client(&Cli::default(), app_data_dir()).await {
-            Ok(client_and_session) => {
-                DEFAULT_SSO_CLIENT.lock().unwrap()
-                    .get_or_insert(client_and_session);
-            }
-            Err(e) => error!("Error: could not create DEFAULT_SSO_CLIENT object: {e}"),
-        };
-        DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
-        Cx::post_action(LoginAction::SsoPending(false));
-    });
-
     let rt = rt_handle.clone();
     // Spawn the main async task that drives the Matrix client SDK, which itself will
     // start and monitor other related background tasks.
+    // The proactive `DEFAULT_SSO_CLIENT` pre-build is gated inside that task on
+    // whether the user actually needs to log in — otherwise it would create an
+    // orphaned sqlite db on disk every cold start.
     rt_handle.spawn(start_matrix_client_login_and_sync(rt));
 
     Ok(rt_handle)
@@ -2344,6 +2338,29 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
     // On subsequent iterations of the login loop (after a post-auth setup failure), it is `None`,
     // which causes the loop to wait for the user to submit a new manual login request.
     let mut initial_client_opt = new_login_opt;
+
+    // Only proactively build the `DEFAULT_SSO_CLIENT` if we'll actually be showing
+    // the login screen. Building it eagerly when a session is being restored just
+    // creates an orphaned sqlite db on disk every cold start (the pre-built client
+    // is dropped by the post-login cleanup at line `DEFAULT_SSO_CLIENT.take()`).
+    // If we skip the build, still notify so any later SSO attempt doesn't deadlock
+    // on `DEFAULT_SSO_CLIENT_NOTIFIER.notified()`; the SSO handler already builds
+    // a fresh client when `DEFAULT_SSO_CLIENT` is `None`.
+    if initial_client_opt.is_none() {
+        rt.spawn(async move {
+            match build_client(&Cli::default(), app_data_dir()).await {
+                Ok(client_and_session) => {
+                    DEFAULT_SSO_CLIENT.lock().unwrap()
+                        .get_or_insert(client_and_session);
+                }
+                Err(e) => error!("Error: could not create DEFAULT_SSO_CLIENT object: {e}"),
+            };
+            DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
+            Cx::post_action(LoginAction::SsoPending(false));
+        });
+    } else {
+        DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
+    }
 
     'login_loop: loop {
         let (client, _sync_token) = match initial_client_opt.take() {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -158,10 +158,9 @@ async fn build_client(
         client,
         ClientSessionPersisted {
             homeserver: homeserver_url,
-            // Store only the relative subfolder name. The absolute path is reconstructed
-            // on restore by joining this with the current `app_data_dir()`. This avoids
-            // baking in a sandbox path that becomes stale on iOS, where the app's
-            // container UUID changes across reinstalls/redeploys.
+            // Store the relative subfolder name only — the absolute path is
+            // rebuilt on restore. Avoids baking in a sandbox path that goes
+            // stale on iOS (container UUID changes across reinstalls).
             db_path: PathBuf::from(db_subfolder_name),
             passphrase,
         },
@@ -1991,11 +1990,11 @@ pub fn start_matrix_tokio() -> Result<tokio::runtime::Handle> {
     }).handle().clone();
 
     let rt = rt_handle.clone();
-    // Spawn the main async task that drives the Matrix client SDK, which itself will
-    // start and monitor other related background tasks.
-    // The proactive `DEFAULT_SSO_CLIENT` pre-build is gated inside that task on
-    // whether the user actually needs to log in — otherwise it would create an
-    // orphaned sqlite db on disk every cold start.
+    // Spawn the main async task that drives the Matrix client SDK and
+    // monitors the related background tasks. (The `DEFAULT_SSO_CLIENT`
+    // pre-build is gated inside that task on whether the user actually
+    // needs to log in — otherwise it leaves an orphaned sqlite db on
+    // disk every cold start.)
     rt_handle.spawn(start_matrix_client_login_and_sync(rt));
 
     Ok(rt_handle)
@@ -2339,13 +2338,11 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
     // which causes the loop to wait for the user to submit a new manual login request.
     let mut initial_client_opt = new_login_opt;
 
-    // Only proactively build the `DEFAULT_SSO_CLIENT` if we'll actually be showing
-    // the login screen. Building it eagerly when a session is being restored just
-    // creates an orphaned sqlite db on disk every cold start (the pre-built client
-    // is dropped by the post-login cleanup at line `DEFAULT_SSO_CLIENT.take()`).
-    // If we skip the build, still notify so any later SSO attempt doesn't deadlock
-    // on `DEFAULT_SSO_CLIENT_NOTIFIER.notified()`; the SSO handler already builds
-    // a fresh client when `DEFAULT_SSO_CLIENT` is `None`.
+    // Only pre-build `DEFAULT_SSO_CLIENT` if we'll actually show the login
+    // screen. Building it eagerly during session restore just leaves an
+    // orphaned sqlite db every cold start. If we skip the build, still
+    // notify so a later SSO attempt doesn't deadlock on the notifier —
+    // the SSO handler builds a fresh client itself if it's still `None`.
     if initial_client_opt.is_none() {
         rt.spawn(async move {
             match build_client(&Cli::default(), app_data_dir()).await {


### PR DESCRIPTION
This is basically a giant collection of changes needed to make Robrix look nicer and work better on real iOS devices (iPhone and iPad).

* Redesigned all of the safe inset area handling so that we can properly color the safe inset areas according to whatever widget was there, mostly the Navigation Tab bar.
* Other "full-screen" or overlay widgets, like the popup notifications, image viewer, and more now also respect safe area insets, most importantly without messing up the nice layout on desktop.
* Make settings screen and add room screen look nice and imitate the exact layout of the main home screen, so that switching between them is sleek
* Fix issues (within makepad) to properly handle hover/down events on buttons in the navigation tab bar and spaces bar (portal list bug).
* Fix an issue on those same button-like widgets where hovering in or out of the button area would cause a strange flicker, and also where the down/hover-in animation might never be cleared on touch screen devices.
* on iOS (and now, all other platforms), use a *relative* path from the app data dir instead of an absolute path. Apparently iOS's app sandbox will give you a new absolute path on each app execution, so using a relative path is the only way to go.
* Make sure all widgets properly handle the Script Reapply event, mostly the settings pane. A full more proper fix is coming to Makepad next.