### PR TITLE
Add room preview cache, mostly used for pill widgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "bytes"
@@ -1941,9 +1941,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -2790,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2945,12 +2945,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2989,15 +2989,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3005,22 +3005,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3034,7 +3034,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "ttf-parser",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3075,12 +3075,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3111,15 +3111,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3140,7 +3140,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3152,12 +3152,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3165,13 +3165,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3188,14 +3188,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3249,18 +3249,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "simd-adler32",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3663,7 +3663,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "mime"
@@ -4392,10 +4392,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicase 2.9.0",
 ]
 
@@ -5203,12 +5203,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5303,7 +5303,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "sealed"
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "siphasher"
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "socket2"
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "tungstenite"
@@ -6461,7 +6461,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-bidi"
@@ -6472,17 +6472,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-ident"
@@ -6493,7 +6493,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-normalization"
@@ -6513,12 +6513,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6529,7 +6529,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "unicode-width"
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6873,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6883,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "log",
  "pkg-config",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7147,7 +7147,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 
 [[package]]
 name = "windows-numerics"
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=script_reapply_variant#4c9c85d94ae650d4ab2eafd615a88fe62ccf753f"
+source = "git+https://github.com/makepad/makepad?branch=dev#30385ae3c6d451a8260ddea9429885c81ccc27dc"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,9 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "script_reapply_variant", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "script_reapply_variant" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use makepad_widgets::*;
 use matrix_sdk::{RoomState, ruma::{OwnedEventId, OwnedRoomId, RoomId}};
 use serde::{Deserialize, Serialize};
 use crate::{
-    avatar_cache::clear_avatar_cache, home::{
+    avatar_cache::clear_avatar_cache, room_preview_cache::clear_room_preview_cache, home::{
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
     }, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
@@ -566,6 +566,7 @@ fn clear_all_app_state(cx: &mut Cx) {
     clear_all_invited_rooms(cx);
     clear_timeline_states(cx);
     clear_avatar_cache(cx);
+    clear_room_preview_cache(cx);
 }
 
 impl AppMain for App {

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -5,7 +5,7 @@ use makepad_widgets::*;
 use matrix_sdk::RoomState;
 use ruma::{IdParseError, MatrixToUri, MatrixUri, OwnedRoomOrAliasId, OwnedServerName, matrix_uri::MatrixId, room::{JoinRuleSummary, RoomType}};
 
-use crate::{app::AppStateAction, home::invite_screen::JoinRoomResultAction, room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction}, shared::{avatar::AvatarWidgetRefExt, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, submit_async_request}, utils};
+use crate::{app::AppStateAction, home::invite_screen::JoinRoomResultAction, room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction}, shared::{avatar::AvatarWidgetRefExt, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, RoomPreviewResponseMode, submit_async_request}, utils};
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -402,7 +402,11 @@ impl Widget for AddRoomScreen {
                             room_or_alias_id: room_or_alias_id.clone(),
                             via: via.clone(),
                         };
-                        submit_async_request(MatrixRequest::GetRoomPreview { room_or_alias_id, via });
+                        submit_async_request(MatrixRequest::GetRoomPreview {
+                            room_or_alias_id,
+                            via,
+                            response_mode: RoomPreviewResponseMode::Action,
+                        });
                     }
                     Err(e) => {
                         let err_str = format!("Could not parse the text as a valid room address.\nError: {e}.");

--- a/src/home/rooms_list_header.rs
+++ b/src/home/rooms_list_header.rs
@@ -12,6 +12,7 @@ use crate::{
     avatar_cache,
     home::navigation_tab_bar::{NavigationBarAction, SelectedTab},
     profile::user_profile_cache,
+    room_preview_cache,
     shared::{
         image_viewer::{ImageViewerAction, ImageViewerError, LoadState},
         popup_list::{PopupKind, enqueue_popup_notification},
@@ -138,6 +139,7 @@ impl Widget for RoomsListHeader {
                             // by RoomScreen in response to the StateUpdate action.
                             user_profile_cache::clear_all_pending_requests();
                             avatar_cache::clear_all_pending_and_failed_requests();
+                            room_preview_cache::clear_all_pending_requests();
                             // Now that we're no longer offline, we also need to tell the
                             // ProfileIcon to refresh itself and fetch our own user's profile again.
                             SignalToUI::set_ui_signal();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod tsp_dummy;
 pub mod sliding_sync;
 pub mod space_service_sync;
 pub mod avatar_cache;
+pub mod room_preview_cache;
 pub mod media_cache;
 pub mod verification;
 

--- a/src/room_preview_cache.rs
+++ b/src/room_preview_cache.rs
@@ -1,17 +1,11 @@
-//! A cache of resolved room previews, keyed on the room ID or alias used to
-//! reach the room.
+//! A cache of room previews keyed by room ID or alias.
 //!
-//! The cache stores a thinned-down [`FetchedRoomPreview`] — currently just
-//! the room's [`RoomNameId`] (ID + display name) and an [`AvatarState`] —
-//! which is the subset needed by `RobrixHtmlLink` widgets to draw room /
-//! alias / event link pills without re-querying the server each time. All
-//! three of `MatrixId::Room`, `MatrixId::RoomAlias`, and `MatrixId::Event`
-//! resolve to room-level metadata via the same `client.get_room_preview()`
-//! call, so they share entries here. User-link pills are served by the user
-//! profile cache and don't go through this cache.
+//! The cache currently just stores part of the room preview info:
+//! the room's ID, display name, and avatar.
 //!
-//! Entries are good for 24 hours; on read, expired `Loaded` entries are
-//! refetched. The cache is only accessible from the main UI thread.
+//! Currently we treate cache entries as stale after 24 hours, but this
+//! is a placeholder for proper invalidation based on subscribing to
+//! updates for any rooms in the cache.
 
 use crossbeam_queue::SegQueue;
 use hashbrown::hash_map::{HashMap, RawEntryMut};
@@ -30,13 +24,12 @@ use crate::{
     utils::RoomNameId,
 };
 
-/// How long a `Loaded` entry stays valid before being refetched on next read.
-const CACHE_ENTRY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const CACHE_ENTRY_LIFETIME: Duration = Duration::from_secs(24 * 60 * 60);
 
 thread_local! {
     /// A cache of resolved room previews, indexed by room-or-alias ID.
     ///
-    /// To be of any use, this cache must only be accessed by the main UI thread.
+    /// This cache must only be accessed by the main UI thread.
     static ROOM_PREVIEW_CACHE: RefCell<HashMap<OwnedRoomOrAliasId, CacheEntry>>
         = RefCell::new(HashMap::new());
 }
@@ -57,28 +50,28 @@ enum CacheEntryState {
     },
 }
 
-/// What the caller of [`get_or_fetch_room_preview`] learns about a room.
+/// A room preview entry as returned to the caller of [`get_or_fetch_room_preview`].
 #[derive(Clone, Debug)]
 pub enum CachedRoomPreview {
-    /// Resolved info; safe to display the pill with this name and avatar.
+    /// The preview is loaded and ready to display.
     Loaded {
         room_name_id: RoomNameId,
         room_avatar: AvatarState,
     },
-    /// A fetch is in flight; the widget should show a fallback in the meantime.
+    /// A fetch is in flight; show a fallback while waiting.
     Requested,
 }
 
 /// An update sent from the matrix worker thread once a room preview fetch completes.
 ///
-/// Carries the full [`FetchedRoomPreview`] for forward-compatibility; the
-/// cache thins it down to [`RoomNameId`] + [`AvatarState`] on insert.
+/// Carries the full [`FetchedRoomPreview`] so we can later widen what the
+/// cache stores without changing the worker side.
 pub struct RoomPreviewUpdate {
     pub room_or_alias_id: OwnedRoomOrAliasId,
     pub fetched: FetchedRoomPreview,
 }
 
-/// The queue of room preview updates waiting to be processed by the UI thread.
+/// The queue of room preview updates waiting to be processed by the UI thread's event handler.
 static PENDING_ROOM_PREVIEW_UPDATES: SegQueue<RoomPreviewUpdate> = SegQueue::new();
 
 /// Enqueues a new room preview update and signals the UI that an update is available.
@@ -87,11 +80,11 @@ pub fn enqueue_room_preview_update(update: RoomPreviewUpdate) {
     SignalToUI::set_ui_signal();
 }
 
-/// Drains all pending room preview updates into the cache.
+/// Processes all pending room preview updates in the queue.
 ///
-/// This function requires passing in a reference to `Cx`, which isn't used,
-/// but acts as a guarantee that this function must only be called by the
-/// main UI thread.
+/// This function requires passing in a reference to `Cx`,
+/// which isn't used, but acts as a guarantee that this function
+/// must only be called by the main UI thread.
 pub fn process_room_preview_updates(_cx: &mut Cx) {
     ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
         while let Some(update) = PENDING_ROOM_PREVIEW_UPDATES.pop() {
@@ -110,12 +103,12 @@ pub fn process_room_preview_updates(_cx: &mut Cx) {
     });
 }
 
-/// Maps a [`FetchedRoomAvatar`] (the form returned by the worker, which has
-/// already attempted to fetch any avatar bytes) into an [`AvatarState`] for
-/// the cache. `Image(bytes)` becomes `Loaded(bytes)`; `Text(_)` becomes
-/// `Known(None)` — at this layer we don't distinguish "no avatar set" from
-/// "avatar fetch failed", since the consuming widget renders the same
-/// text fallback either way.
+/// Maps a [`FetchedRoomAvatar`] (which has already attempted to fetch any
+/// avatar bytes on the worker side) into an [`AvatarState`] for the cache.
+///
+/// `Image(bytes)` becomes `Loaded(bytes)`. `Text(_)` becomes `Known(None)`:
+/// at this layer we don't distinguish "no avatar set" from "avatar fetch
+/// failed", since the consuming widget renders the same text fallback either way.
 fn fetched_room_avatar_to_avatar_state(avatar: FetchedRoomAvatar) -> AvatarState {
     match avatar {
         FetchedRoomAvatar::Image(bytes) => AvatarState::Loaded(bytes),
@@ -123,33 +116,38 @@ fn fetched_room_avatar_to_avatar_state(avatar: FetchedRoomAvatar) -> AvatarState
     }
 }
 
-/// Returns the cached preview for the given room link, or kicks off a fetch
-/// if absent or expired.
+/// Returns the cached preview for the given room ID or alias if it exists,
+/// or submits a request to fetch it from the server if it isn't already cached.
 ///
-/// This function requires passing in a reference to `Cx`, which isn't used,
-/// but acts as a guarantee that this function must only be called by the
-/// main UI thread.
+/// If a request has already been submitted, it will not re-submit a duplicate request
+/// and will simply return `CachedRoomPreview::Requested`. If the cached entry is
+/// older than `CACHE_ENTRY_LIFETIME`, a fresh fetch is submitted and the entry is
+/// reset to `Requested`.
+///
+/// This function requires passing in a reference to `Cx`,
+/// which isn't used, but acts as a guarantee that this function
+/// must only be called by the main UI thread.
 pub fn get_or_fetch_room_preview(
     _cx: &mut Cx,
     room_or_alias_id: &RoomOrAliasId,
     via: &[OwnedServerName],
 ) -> CachedRoomPreview {
     ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
-        // `raw_entry_mut().from_key(&borrowed)` looks up by reference, so we
-        // only allocate an owned key on insert (vacant or stale-overwrite).
+        // raw_entry_mut lets us look up by `&RoomOrAliasId` without cloning;
+        // we only allocate an owned key on insert.
         match cache.raw_entry_mut().from_key(room_or_alias_id) {
             RawEntryMut::Occupied(mut occupied) => {
                 // Fast path: a fresh `Loaded` entry is returned as-is.
                 if let CacheEntryState::Loaded { room_name_id, room_avatar } = &occupied.get().state {
-                    if occupied.get().loaded_at.elapsed() < CACHE_ENTRY_TTL {
+                    if occupied.get().loaded_at.elapsed() < CACHE_ENTRY_LIFETIME {
                         return CachedRoomPreview::Loaded {
                             room_name_id: room_name_id.clone(),
                             room_avatar: room_avatar.clone(),
                         };
                     }
                 }
-                // Otherwise: a stale `Loaded` (refetch + overwrite) or an
-                // already in-flight `Requested` (no-op; prior fetch will land).
+                // Otherwise it's a stale `Loaded` (refetch and overwrite) or an
+                // already-in-flight `Requested` (do nothing; prior fetch will land).
                 if matches!(occupied.get().state, CacheEntryState::Loaded { .. }) {
                     submit_async_request(MatrixRequest::GetRoomPreview {
                         room_or_alias_id: room_or_alias_id.to_owned(),
@@ -182,21 +180,21 @@ pub fn get_or_fetch_room_preview(
     })
 }
 
-/// Removes all `Requested` entries so they can be re-fetched after a network
-/// recovery. Mirrors the same affordance on `user_profile_cache` and
-/// `avatar_cache`: in-flight requests submitted while offline likely failed
-/// silently, leaving stale `Requested` entries that would otherwise block
-/// re-fetching forever.
+/// Removes all `Requested` entries from the room preview cache,
+/// allowing them to be re-fetched.
+///
+/// This should be called when the app transitions from offline back to online,
+/// because any in-flight requests that were submitted while offline have likely
+/// failed, leaving stale entries that permanently block re-fetching.
 pub fn clear_all_pending_requests() {
     ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
         cache.retain(|_, entry| !matches!(entry.state, CacheEntryState::Requested));
     });
 }
 
-/// Clears the entire cache. Called on logout.
-///
-/// This function requires passing in a reference to `Cx`, which acts as a
-/// guarantee that this thread-local cache is cleared on the main UI thread.
+/// Clears the room preview cache.
+/// This function requires passing in a reference to `Cx`,
+/// which acts as a guarantee that this thread-local cache is cleared on the main UI thread.
 pub fn clear_room_preview_cache(_cx: &mut Cx) {
     ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| cache.clear());
 }

--- a/src/room_preview_cache.rs
+++ b/src/room_preview_cache.rs
@@ -1,0 +1,202 @@
+//! A cache of resolved room previews, keyed on the room ID or alias used to
+//! reach the room.
+//!
+//! The cache stores a thinned-down [`FetchedRoomPreview`] — currently just
+//! the room's [`RoomNameId`] (ID + display name) and an [`AvatarState`] —
+//! which is the subset needed by `RobrixHtmlLink` widgets to draw room /
+//! alias / event link pills without re-querying the server each time. All
+//! three of `MatrixId::Room`, `MatrixId::RoomAlias`, and `MatrixId::Event`
+//! resolve to room-level metadata via the same `client.get_room_preview()`
+//! call, so they share entries here. User-link pills are served by the user
+//! profile cache and don't go through this cache.
+//!
+//! Entries are good for 24 hours; on read, expired `Loaded` entries are
+//! refetched. The cache is only accessible from the main UI thread.
+
+use crossbeam_queue::SegQueue;
+use hashbrown::hash_map::{HashMap, RawEntryMut};
+use makepad_widgets::{Cx, SignalToUI};
+use matrix_sdk::OwnedServerName;
+use ruma::{OwnedRoomOrAliasId, RoomOrAliasId};
+use std::{
+    cell::RefCell,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    room::{FetchedRoomAvatar, FetchedRoomPreview},
+    shared::avatar::AvatarState,
+    sliding_sync::{submit_async_request, MatrixRequest, RoomPreviewResponseMode},
+    utils::RoomNameId,
+};
+
+/// How long a `Loaded` entry stays valid before being refetched on next read.
+const CACHE_ENTRY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+thread_local! {
+    /// A cache of resolved room previews, indexed by room-or-alias ID.
+    ///
+    /// To be of any use, this cache must only be accessed by the main UI thread.
+    static ROOM_PREVIEW_CACHE: RefCell<HashMap<OwnedRoomOrAliasId, CacheEntry>>
+        = RefCell::new(HashMap::new());
+}
+
+struct CacheEntry {
+    state: CacheEntryState,
+    /// When this entry was inserted into the cache.
+    loaded_at: Instant,
+}
+
+enum CacheEntryState {
+    /// A fetch has been issued and we're waiting for it to complete.
+    Requested,
+    /// The room preview has been successfully loaded.
+    Loaded {
+        room_name_id: RoomNameId,
+        room_avatar: AvatarState,
+    },
+}
+
+/// What the caller of [`get_or_fetch_room_preview`] learns about a room.
+#[derive(Clone, Debug)]
+pub enum CachedRoomPreview {
+    /// Resolved info; safe to display the pill with this name and avatar.
+    Loaded {
+        room_name_id: RoomNameId,
+        room_avatar: AvatarState,
+    },
+    /// A fetch is in flight; the widget should show a fallback in the meantime.
+    Requested,
+}
+
+/// An update sent from the matrix worker thread once a room preview fetch completes.
+///
+/// Carries the full [`FetchedRoomPreview`] for forward-compatibility; the
+/// cache thins it down to [`RoomNameId`] + [`AvatarState`] on insert.
+pub struct RoomPreviewUpdate {
+    pub room_or_alias_id: OwnedRoomOrAliasId,
+    pub fetched: FetchedRoomPreview,
+}
+
+/// The queue of room preview updates waiting to be processed by the UI thread.
+static PENDING_ROOM_PREVIEW_UPDATES: SegQueue<RoomPreviewUpdate> = SegQueue::new();
+
+/// Enqueues a new room preview update and signals the UI that an update is available.
+pub fn enqueue_room_preview_update(update: RoomPreviewUpdate) {
+    PENDING_ROOM_PREVIEW_UPDATES.push(update);
+    SignalToUI::set_ui_signal();
+}
+
+/// Drains all pending room preview updates into the cache.
+///
+/// This function requires passing in a reference to `Cx`, which isn't used,
+/// but acts as a guarantee that this function must only be called by the
+/// main UI thread.
+pub fn process_room_preview_updates(_cx: &mut Cx) {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
+        while let Some(update) = PENDING_ROOM_PREVIEW_UPDATES.pop() {
+            let RoomPreviewUpdate { room_or_alias_id, fetched } = update;
+            cache.insert(
+                room_or_alias_id,
+                CacheEntry {
+                    state: CacheEntryState::Loaded {
+                        room_name_id: fetched.room_name_id,
+                        room_avatar: fetched_room_avatar_to_avatar_state(fetched.room_avatar),
+                    },
+                    loaded_at: Instant::now(),
+                },
+            );
+        }
+    });
+}
+
+/// Maps a [`FetchedRoomAvatar`] (the form returned by the worker, which has
+/// already attempted to fetch any avatar bytes) into an [`AvatarState`] for
+/// the cache. `Image(bytes)` becomes `Loaded(bytes)`; `Text(_)` becomes
+/// `Known(None)` — at this layer we don't distinguish "no avatar set" from
+/// "avatar fetch failed", since the consuming widget renders the same
+/// text fallback either way.
+fn fetched_room_avatar_to_avatar_state(avatar: FetchedRoomAvatar) -> AvatarState {
+    match avatar {
+        FetchedRoomAvatar::Image(bytes) => AvatarState::Loaded(bytes),
+        FetchedRoomAvatar::Text(_) => AvatarState::Known(None),
+    }
+}
+
+/// Returns the cached preview for the given room link, or kicks off a fetch
+/// if absent or expired.
+///
+/// This function requires passing in a reference to `Cx`, which isn't used,
+/// but acts as a guarantee that this function must only be called by the
+/// main UI thread.
+pub fn get_or_fetch_room_preview(
+    _cx: &mut Cx,
+    room_or_alias_id: &RoomOrAliasId,
+    via: &[OwnedServerName],
+) -> CachedRoomPreview {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
+        // `raw_entry_mut().from_key(&borrowed)` looks up by reference, so we
+        // only allocate an owned key on insert (vacant or stale-overwrite).
+        match cache.raw_entry_mut().from_key(room_or_alias_id) {
+            RawEntryMut::Occupied(mut occupied) => {
+                // Fast path: a fresh `Loaded` entry is returned as-is.
+                if let CacheEntryState::Loaded { room_name_id, room_avatar } = &occupied.get().state {
+                    if occupied.get().loaded_at.elapsed() < CACHE_ENTRY_TTL {
+                        return CachedRoomPreview::Loaded {
+                            room_name_id: room_name_id.clone(),
+                            room_avatar: room_avatar.clone(),
+                        };
+                    }
+                }
+                // Otherwise: a stale `Loaded` (refetch + overwrite) or an
+                // already in-flight `Requested` (no-op; prior fetch will land).
+                if matches!(occupied.get().state, CacheEntryState::Loaded { .. }) {
+                    submit_async_request(MatrixRequest::GetRoomPreview {
+                        room_or_alias_id: room_or_alias_id.to_owned(),
+                        via: via.to_vec(),
+                        response_mode: RoomPreviewResponseMode::RoomPreviewCache,
+                    });
+                    occupied.insert(CacheEntry {
+                        state: CacheEntryState::Requested,
+                        loaded_at: Instant::now(),
+                    });
+                }
+                CachedRoomPreview::Requested
+            }
+            RawEntryMut::Vacant(vacant) => {
+                submit_async_request(MatrixRequest::GetRoomPreview {
+                    room_or_alias_id: room_or_alias_id.to_owned(),
+                    via: via.to_vec(),
+                    response_mode: RoomPreviewResponseMode::RoomPreviewCache,
+                });
+                vacant.insert(
+                    room_or_alias_id.to_owned(),
+                    CacheEntry {
+                        state: CacheEntryState::Requested,
+                        loaded_at: Instant::now(),
+                    },
+                );
+                CachedRoomPreview::Requested
+            }
+        }
+    })
+}
+
+/// Removes all `Requested` entries so they can be re-fetched after a network
+/// recovery. Mirrors the same affordance on `user_profile_cache` and
+/// `avatar_cache`: in-flight requests submitted while offline likely failed
+/// silently, leaving stale `Requested` entries that would otherwise block
+/// re-fetching forever.
+pub fn clear_all_pending_requests() {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| {
+        cache.retain(|_, entry| !matches!(entry.state, CacheEntryState::Requested));
+    });
+}
+
+/// Clears the entire cache. Called on logout.
+///
+/// This function requires passing in a reference to `Cx`, which acts as a
+/// guarantee that this thread-local cache is cleared on the main UI thread.
+pub fn clear_room_preview_cache(_cx: &mut Cx) {
+    ROOM_PREVIEW_CACHE.with_borrow_mut(|cache| cache.clear());
+}

--- a/src/room_preview_cache.rs
+++ b/src/room_preview_cache.rs
@@ -3,7 +3,7 @@
 //! The cache currently just stores part of the room preview info:
 //! the room's ID, display name, and avatar.
 //!
-//! Currently we treate cache entries as stale after 24 hours, but this
+//! Currently we treat cache entries as stale after 24 hours, but this
 //! is a placeholder for proper invalidation based on subscribing to
 //! updates for any rooms in the cache.
 

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -1,11 +1,13 @@
 //! A `HtmlOrPlaintext` view can display either plaintext or rich HTML content.
 
+use std::sync::Arc;
+
 use makepad_widgets::*;
-use matrix_sdk::{ruma::{matrix_uri::MatrixId, MatrixToUri, MatrixUri, OwnedMxcUri}, OwnedServerName};
+use matrix_sdk::{ruma::{matrix_uri::MatrixId, MatrixToUri, MatrixUri, RoomOrAliasId}, OwnedServerName};
 
-use crate::{avatar_cache::{self, AvatarCacheEntry}, profile::user_profile_cache, sliding_sync::{current_user_id, submit_async_request, MatrixRequest}, utils};
+use crate::{avatar_cache::{self, AvatarCacheEntry}, profile::user_profile_cache, room_preview_cache::{self, CachedRoomPreview}, sliding_sync::current_user_id, utils};
 
-use super::avatar::AvatarWidgetExt;
+use super::avatar::{AvatarState, AvatarWidgetExt};
 
 /// The color of the text used to print the spoiler reason before the hidden text.
 const COLOR_SPOILER_REASON: Vec4 = vec4(0.6, 0.6, 0.6, 1.0);
@@ -305,12 +307,12 @@ impl RobrixHtmlLink {
         if let Some(mut pill) = self.matrix_link_pill(cx, ids!(matrix_link)).borrow_mut() {
             pill.populate_pill(cx, self.url.clone(), matrix_id, via, self.text.as_ref());
         }
-        let mlv_ref = self.view(cx, ids!(matrix_link_view));
-        mlv_ref.set_visible(cx, true);
-        let Some(mut mlv) = mlv_ref.borrow_mut() else {
+        let matrix_link_view_ref = self.view(cx, ids!(matrix_link_view));
+        matrix_link_view_ref.set_visible(cx, true);
+        let Some(mut matrix_link_view) = matrix_link_view_ref.borrow_mut() else {
             return DrawStep::done();
         };
-        mlv.draw_walk(cx, scope, walk)
+        matrix_link_view.draw_walk(cx, scope, walk)
     }
 
     /// Draws the inner `HtmlLink` as inline wrapping text.
@@ -345,47 +347,25 @@ impl RobrixHtmlLink {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub enum MatrixLinkPillState {
-    Requested,
-    Loaded {
-        matrix_id: MatrixId,
-        name: String,
-        avatar_url: Option<OwnedMxcUri>,
-    },
-    #[default]
-    None,
-}
-
 /// A pill-shaped widget that shows a Matrix link as an avatar and a title.
 ///
-/// This can be a link to a user, a room, or a message in a room.
+/// This can be a link to a user, a room, or an event in a room.
 #[derive(Script, ScriptHook, Widget)]
 struct MatrixLinkPill {
     #[deref] view: View,
 
     #[rust] matrix_id: Option<MatrixId>,
     #[rust] via: Vec<OwnedServerName>,
-    #[rust] state: MatrixLinkPillState,
     #[rust] url: String,
 }
 
 impl Widget for MatrixLinkPill {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, _scope: &mut Scope) {
-        if let Event::Actions(actions) = event {
-            for action in actions {
-                if let Some(loaded @ MatrixLinkPillState::Loaded { matrix_id, .. }) = action.downcast_ref() {
-                    if self.matrix_id.as_ref() == Some(matrix_id) {
-                        self.state = loaded.clone();
-                        self.redraw(cx);
-                    }
-                }
+        if matches!(event, Event::Signal) {
+            room_preview_cache::process_room_preview_updates(cx);
+            if self.matrix_id.is_some() {
+                self.redraw(cx);
             }
-        }
-
-        // Redraw upon a UI Signal to catch updates to a user profile.
-        if matches!(event, Event::Signal) && matches!(self.matrix_id, Some(MatrixId::User(_))) {
-            self.redraw(cx);
         }
 
         // Handle hover (to set the cursor) and click in a single hit-test,
@@ -417,13 +397,6 @@ impl Widget for MatrixLinkPill {
         self.view.draw_walk(cx, scope, walk)
     }
 
-    fn text(&self) -> String {
-        match &self.state {
-            MatrixLinkPillState::Loaded { name, .. } => name.clone(),
-            _ => String::new(),
-        }
-    }
-
     fn set_text(&mut self, cx: &mut Cx, v: &str) {
         self.label(cx, ids!(title)).set_text(cx, v);
     }
@@ -453,39 +426,46 @@ impl MatrixLinkPill {
 
         // Handle a user ID link by querying the user profile cache.
         if let MatrixId::User(user_id) = matrix_id {
-
-            let (name, avatar_uri) = match user_profile_cache::with_user_profile(
+            let (name, avatar_state) = match user_profile_cache::with_user_profile(
                 cx,
                 user_id.clone(),
                 None,
                 true,
                 |profile, _| { (profile.displayable_name().to_owned(), profile.avatar_state.clone()) }
             ) {
-                Some((name, avatar)) => (name, avatar.uri().cloned()),
-                None => (user_id.to_string(), None),
+                Some(pair) => pair,
+                None => (user_id.to_string(), AvatarState::Unknown),
             };
             self.set_text(cx, &name);
-            self.populate_avatar(cx, avatar_uri.as_ref(), &name);
+            self.populate_avatar(cx, &avatar_state, &name);
             return;
         }
 
-        // Handle room ID or alias
-        match &self.state {
-            MatrixLinkPillState::Loaded { name, avatar_url, .. } => {
+        // Handle a room ID, alias, or event link by querying the room preview cache.
+        let room_or_alias_id: Option<&RoomOrAliasId> = match matrix_id {
+            MatrixId::Room(room_id) => Some((&**room_id).into()),
+            MatrixId::RoomAlias(alias) => Some((&**alias).into()),
+            MatrixId::Event(room_or_alias, _) => Some(room_or_alias),
+            _ => None,
+        };
+        if let Some(room_or_alias_id) = room_or_alias_id {
+            if let CachedRoomPreview::Loaded { room_name_id, room_avatar } =
+                room_preview_cache::get_or_fetch_room_preview(cx, room_or_alias_id, via)
+            {
+                // `RoomNameId::Display` would print "Room ID !xyz:server" for
+                // empty names; the pill should show just the bare room ID
+                // instead, matching the pre-cache behavior.
+                let resolved_name = if room_name_id.is_empty() {
+                    room_name_id.room_id().as_str().to_owned()
+                } else {
+                    room_name_id.to_string()
+                };
                 // For @room mentions, show "@room" as the title, not the room name.
-                let display_name = if is_room_mention { "@room" } else { name.as_str() };
+                let display_name = if is_room_mention { "@room" } else { resolved_name.as_str() };
                 self.label(cx, ids!(title)).set_text(cx, display_name);
-                self.populate_avatar(cx, avatar_url.as_ref(), display_name);
+                self.populate_avatar(cx, &room_avatar, display_name);
                 return;
             }
-            MatrixLinkPillState::None => {
-                submit_async_request(MatrixRequest::GetMatrixRoomLinkPillInfo {
-                    matrix_id: matrix_id.clone(),
-                    via: via.to_vec(),
-                });
-                self.state = MatrixLinkPillState::Requested;
-            }
-            MatrixLinkPillState::Requested => { }
         }
         // While waiting for the async request to complete, show "@room" or the room ID/alias.
         let fallback_name = if is_room_mention {
@@ -499,36 +479,40 @@ impl MatrixLinkPill {
             }
         };
         self.set_text(cx, &fallback_name);
-        self.populate_avatar(cx, None, &fallback_name);
+        self.populate_avatar(cx, &AvatarState::Unknown, &fallback_name);
     }
 
-    fn populate_avatar(&self, cx: &mut Cx, avatar_url: Option<&OwnedMxcUri>, display_name: &str) {
+    /// Renders the pill avatar from the given [`AvatarState`], falling back to
+    /// a text avatar built from `display_name` when no image is available.
+    ///
+    /// Handles all paths the pill needs:
+    /// * `Loaded(bytes)` — paint bytes directly (room link cache).
+    /// * `Known(Some(uri))` — fetch bytes via [`avatar_cache`] (user link).
+    /// * `Known(None)` / `Unknown` / `Failed` — text fallback.
+    fn populate_avatar(&self, cx: &mut Cx, avatar: &AvatarState, display_name: &str) {
         let avatar_ref = self.avatar(cx, ids!(avatar));
-        if let Some(avatar_url) = avatar_url {
-            if let AvatarCacheEntry::Loaded(data) = avatar_cache::get_or_fetch_avatar(cx, avatar_url) {
-                let res = avatar_ref.show_image(
-                    cx,
-                    None, // Don't make this avatar clickable
-                    |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, &data),
-                );
-                if res.is_ok() {
-                    return;
-                }
+        let bytes: Option<Arc<[u8]>> = match avatar {
+            AvatarState::Loaded(data) => Some(data.clone()),
+            AvatarState::Known(Some(uri)) => match avatar_cache::get_or_fetch_avatar(cx, uri) {
+                AvatarCacheEntry::Loaded(data) => Some(data),
+                _ => None,
+            },
+            _ => None,
+        };
+        if let Some(data) = bytes {
+            let res = avatar_ref.show_image(
+                cx,
+                None, // Don't make this avatar clickable
+                |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, &data),
+            );
+            if res.is_ok() {
+                return;
             }
         }
         avatar_ref.show_text(cx, None, None, display_name);
     }
 }
 
-impl MatrixLinkPillRef {
-    pub fn get_matrix_id(&self) -> Option<MatrixId> {
-        self.borrow().and_then(|inner| inner.matrix_id.clone())
-    }
-
-    pub fn get_via(&self) -> Vec<OwnedServerName> {
-        self.borrow().map(|inner| inner.via.clone()).unwrap_or_default()
-    }
-}
 
 /// A widget used to display a single HTML `<span>` tag or a `<font>` tag.
 #[derive(Script, Widget)]

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -378,16 +378,13 @@ impl std::fmt::Display for TimelineKind {
     }
 }
 
-/// How the worker should deliver the result of a [`MatrixRequest::GetRoomPreview`].
+/// The desired response for a [`MatrixRequest::GetRoomPreview`].
 #[derive(Clone, Debug)]
 pub enum RoomPreviewResponseMode {
-    /// Posts a [`RoomPreviewAction::Fetched`] action with the result, success
-    /// or error. Used by interactive flows like the "join room" UI.
+    /// Posts a [`RoomPreviewAction::Fetched`] action with the result.
     Action,
-    /// Stores the result in the [`crate::room_preview_cache`] on success;
-    /// logs and drops on error (the cache entry stays `Requested` until
-    /// `clear_all_pending_requests()` is called on offline→online recovery).
-    /// Used by `RobrixHtmlLink` pills.
+    /// Enqueues the result to be inserted into the [`crate::room_preview_cache`],
+    /// if successful.
     RoomPreviewCache,
 }
 

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -14,7 +14,7 @@ use matrix_sdk::{
             room::{
                 message::RoomMessageEventContent, power_levels::RoomPowerLevels, MediaSource
             }, MessageLikeEventType, StateEventType
-        }, matrix_uri::MatrixId, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, uint
+        }, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, uint
     }, sliding_sync::VersionBuilder, Client, ClientBuildError, Error, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
 };
 use matrix_sdk_ui::{
@@ -33,11 +33,11 @@ use hashbrown::{HashMap, HashSet};
 use crate::{
     app::AppStateAction, app_data_dir, avatar_cache::AvatarUpdate, event_preview::{BeforeText, TextPreview, text_preview_of_raw_timeline_event, text_preview_of_timeline_item}, home::{
         add_room::KnockResultAction, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::{LinkPreviewData, LinkPreviewDataNonNumeric, LinkPreviewRateLimitResponse}, room_screen::{InviteResultAction, TimelineUpdate}, rooms_list::{self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails
-    }, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state}, profile::{
+    }, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, room_preview_cache::{enqueue_room_preview_update, RoomPreviewUpdate}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state}, profile::{
         user_profile::UserProfile,
         user_profile_cache::{UserProfileUpdate, enqueue_user_profile_update},
     }, room::{FetchedRoomAvatar, FetchedRoomPreview, RoomPreviewAction}, shared::{
-        avatar::AvatarState, html_or_plaintext::MatrixLinkPillState, jump_to_bottom_button::UnreadMessageCount, popup_list::{PopupKind, enqueue_popup_notification}
+        avatar::AvatarState, jump_to_bottom_button::UnreadMessageCount, popup_list::{PopupKind, enqueue_popup_notification}
     }, space_service_sync::space_service_loop, utils::{self, AVATAR_THUMBNAIL_FORMAT, RoomNameId, VecDiff, avatar_from_room_name}, verification::add_verification_event_handlers_and_sync_client
 };
 
@@ -378,6 +378,19 @@ impl std::fmt::Display for TimelineKind {
     }
 }
 
+/// How the worker should deliver the result of a [`MatrixRequest::GetRoomPreview`].
+#[derive(Clone, Debug)]
+pub enum RoomPreviewResponseMode {
+    /// Posts a [`RoomPreviewAction::Fetched`] action with the result, success
+    /// or error. Used by interactive flows like the "join room" UI.
+    Action,
+    /// Stores the result in the [`crate::room_preview_cache`] on success;
+    /// logs and drops on error (the cache entry stays `Requested` until
+    /// `clear_all_pending_requests()` is called on offline→online recovery).
+    /// Used by `RobrixHtmlLink` pills.
+    RoomPreviewCache,
+}
+
 /// The set of requests for async work that can be made to the worker thread.
 #[allow(clippy::large_enum_variant)]
 pub enum MatrixRequest {
@@ -462,10 +475,13 @@ pub enum MatrixRequest {
     /// Request to fetch the preview (basic info) for the given room,
     /// either one that is joined locally or one that is unknown.
     ///
-    /// Emits a [`RoomPreviewAction::Fetched`] when the fetch operation has completed.
+    /// On completion, the result is dispatched according to `response_mode`:
+    /// either as a [`RoomPreviewAction::Fetched`] action, or by enqueueing
+    /// a cache update into the [`crate::room_preview_cache`].
     GetRoomPreview {
         room_or_alias_id: OwnedRoomOrAliasId,
         via: Vec<OwnedServerName>,
+        response_mode: RoomPreviewResponseMode,
     },
     /// Request to fetch the full details (the room preview) of a tombstoned room.
     GetSuccessorRoomDetails {
@@ -550,8 +566,6 @@ pub enum MatrixRequest {
         /// * If `None`, the display name will be removed.
         new_display_name: Option<String>,
     },
-    /// Request to resolve a room alias into a room ID and the servers that know about that room.
-    ResolveRoomAlias(OwnedRoomAliasId),
     /// Request to fetch an Avatar image from the server.
     /// Upon completion of the async media request, the `on_fetched` function
     /// will be invoked with the content of an `AvatarUpdate`.
@@ -657,13 +671,6 @@ pub enum MatrixRequest {
         timeline_kind: TimelineKind,
         event_id: OwnedEventId,
         pin: bool,
-    },
-    /// Sends a request to obtain the room's pill link info for the given Matrix ID.
-    ///
-    /// The MatrixLinkPillInfo::Loaded variant is sent back to the main UI thread via.
-    GetMatrixRoomLinkPillInfo {
-        matrix_id: MatrixId,
-        via: Vec<OwnedServerName>
     },
     /// Request to fetch URL preview from the Matrix homeserver.
     GetUrlPreview {
@@ -1090,11 +1097,22 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::GetRoomPreview { room_or_alias_id, via } => {
+            MatrixRequest::GetRoomPreview { room_or_alias_id, via, response_mode } => {
                 let Some(client) = get_client() else { continue };
                 let _fetch_task = Handle::current().spawn(async move {
                     let res = fetch_room_preview_with_avatar(&client, &room_or_alias_id, via).await;
-                    Cx::post_action(RoomPreviewAction::Fetched(res));
+                    match response_mode {
+                        RoomPreviewResponseMode::Action => {
+                            Cx::post_action(RoomPreviewAction::Fetched(res));
+                        }
+                        RoomPreviewResponseMode::RoomPreviewCache => match res {
+                            Ok(fetched) => enqueue_room_preview_update(RoomPreviewUpdate {
+                                room_or_alias_id,
+                                fetched,
+                            }),
+                            Err(e) => log!("Failed to get room preview for {room_or_alias_id:?}: {e:?}"),
+                        },
+                    }
                 });
             }
 
@@ -1562,16 +1580,6 @@ async fn matrix_worker_task(
                 spawn_sso_server(brand, homeserver_url, identity_provider_id, login_sender.clone()).await;
             }
 
-            MatrixRequest::ResolveRoomAlias(room_alias) => {
-                let Some(client) = get_client() else { continue };
-                let _resolve_task = Handle::current().spawn(async move {
-                    log!("Sending resolve room alias request for {room_alias}...");
-                    let res = client.resolve_room_alias(&room_alias).await;
-                    log!("Resolved room alias {room_alias} to: {res:?}");
-                    todo!("Send the resolved room alias back to the UI thread somehow.");
-                });
-            }
-
             MatrixRequest::FetchAvatar { mxc_uri, on_fetched } => {
                 let Some(client) = get_client() else { continue };
                 Handle::current().spawn(async move {
@@ -1797,33 +1805,6 @@ async fn matrix_worker_task(
                     match sender.send(TimelineUpdate::PinResult { event_id, pin, result }) {
                         Ok(_) => SignalToUI::set_ui_signal(),
                         Err(_) => log!("Failed to send UI update for pin event."),
-                    }
-                });
-            }
-
-            MatrixRequest::GetMatrixRoomLinkPillInfo { matrix_id, via } => {
-                let Some(client) = get_client() else { continue };
-                let _fetch_matrix_link_pill_info_task = Handle::current().spawn(async move {
-                    let room_or_alias_id: Option<&RoomOrAliasId> = match &matrix_id {
-                        MatrixId::Room(room_id) => Some((&**room_id).into()),
-                        MatrixId::RoomAlias(room_alias_id) => Some((&**room_alias_id).into()),
-                        MatrixId::Event(room_or_alias_id, _event_id) => Some(room_or_alias_id),
-                        _ => {
-                            log!("MatrixLinkRoomPillInfoRequest: Unsupported MatrixId type: {matrix_id:?}");
-                            return;
-                        }
-                    };
-                    if let Some(room_or_alias_id) = room_or_alias_id {
-                        match client.get_room_preview(room_or_alias_id, via).await {
-                            Ok(preview) => Cx::post_action(MatrixLinkPillState::Loaded {
-                                matrix_id: matrix_id.clone(),
-                                name: preview.name.unwrap_or_else(|| room_or_alias_id.to_string()),
-                                avatar_url: preview.avatar_url
-                            }),
-                            Err(_e) => {
-                                log!("Failed to get room link pill info for {room_or_alias_id:?}: {_e:?}");
-                            }
-                        };
                     }
                 });
             }


### PR DESCRIPTION
Avoids redundant requests to resolve a room alias or ID into a full fetched room preview (so that pill elements can be fully drawn).