### PR TITLE
🎨 Palette: Add tooltips to RoomInputBar buttons

### DIFF
--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -215,6 +215,60 @@ impl Widget for RoomInputBar {
             _ => {}
         }
 
+        let location_button_area = self.button(cx, ids!(location_button)).area();
+        match event.hits(cx, location_button_area) {
+            Hit::FingerHoverIn(_) | Hit::FingerLongPress(_) => {
+                cx.widget_action(
+                    self.widget_uid(),
+                    TooltipAction::HoverIn {
+                        text: "Send location".to_string(),
+                        widget_rect: location_button_area.rect(cx),
+                        options: CalloutTooltipOptions {
+                            position: TooltipPosition::Top,
+                            ..Default::default()
+                        },
+                    },
+                );
+            }
+            Hit::FingerHoverOut(_) => {
+                cx.widget_action(
+                    self.widget_uid(),
+                    TooltipAction::HoverOut,
+                );
+            }
+            _ => {}
+        }
+
+        let send_message_button_area = self.button(cx, ids!(send_message_button)).area();
+        match event.hits(cx, send_message_button_area) {
+            Hit::FingerHoverIn(_) | Hit::FingerLongPress(_) => {
+                let text_input_is_empty = self.mentionable_text_input(cx, ids!(mentionable_text_input)).text().trim().is_empty();
+                let tooltip_text = if text_input_is_empty {
+                    "Message is empty"
+                } else {
+                    "Send message"
+                };
+                cx.widget_action(
+                    self.widget_uid(),
+                    TooltipAction::HoverIn {
+                        text: tooltip_text.to_string(),
+                        widget_rect: send_message_button_area.rect(cx),
+                        options: CalloutTooltipOptions {
+                            position: TooltipPosition::Top,
+                            ..Default::default()
+                        },
+                    },
+                );
+            }
+            Hit::FingerHoverOut(_) => {
+                cx.widget_action(
+                    self.widget_uid(),
+                    TooltipAction::HoverOut,
+                );
+            }
+            _ => {}
+        }
+
         if let Event::Actions(actions) = event {
             // Handle changes to the `send_on_enter` preference.
             for action in actions {


### PR DESCRIPTION
💡 What: Added tooltips to the location and send message buttons in `RoomInputBar`. The send button's tooltip text dynamically updates based on whether the input text area is empty.
🎯 Why: Icon-only buttons without labels can be confusing or ambiguous for users, particularly when relying on screen readers or when trying to figure out if an action is currently disabled.
📸 Before/After: Not applicable (tooltip popovers added on hover/long-press).
♿ Accessibility: Provides necessary text equivalents for icon-only buttons via tooltips triggered by both hover and long-press actions, thereby addressing an accessibility issue in the chat interface.

---
*PR created automatically by Jules for task [3079644250968298212](https://jules.google.com/task/3079644250968298212) started by @kevinaboos*