### PR TITLE
Various improvements on mobile. Make verification status easier, more obvious

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "bytes"
@@ -1941,9 +1941,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2945,12 +2945,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2989,15 +2989,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3005,22 +3005,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3034,7 +3034,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "ttf-parser",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3075,12 +3075,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3111,15 +3111,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3140,7 +3140,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3152,12 +3152,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3165,13 +3165,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3188,14 +3188,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3249,18 +3249,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "simd-adler32",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3663,7 +3663,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "mime"
@@ -4392,10 +4392,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
  "unicase 2.9.0",
 ]
 
@@ -5203,12 +5203,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_fixes)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5303,7 +5303,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "sealed"
@@ -5602,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "siphasher"
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "socket2"
@@ -6409,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "tungstenite"
@@ -6461,7 +6461,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-bidi"
@@ -6472,17 +6472,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-ident"
@@ -6493,7 +6493,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-normalization"
@@ -6513,12 +6513,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6529,7 +6529,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "unicode-width"
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6873,7 +6873,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6883,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "log",
  "pkg-config",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7029,7 +7029,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7147,7 +7147,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 
 [[package]]
 name = "windows-numerics"
@@ -7191,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_fixes#d72951d21ea2ed2abc2536ff70ad306229914a45"
+source = "git+https://github.com/kevinaboos/makepad?branch=touch_margin_dock#ddd79a460d41a487acc6ecb2c7addf555b83bb2d"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "more_fixes", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "more_fixes" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "touch_margin_dock", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "touch_margin_dock" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -18,7 +18,7 @@ script_mod! {
 
         width: Fill, height: Fill,
         flow: Down,
-        padding: Inset{top: 5, left: 15, right: 15, bottom: 20},
+        padding: Inset{top: 5, left: 15, right: 15, bottom: 0},
 
         title := TitleLabel {
             text: "Add/Explore Rooms and Spaces"
@@ -241,6 +241,11 @@ script_mod! {
                     text: "Cancel"
                 }
             }
+        }
+
+        View {
+            width: Fill
+            height: 20
         }
         
     }

--- a/src/home/light_themed_dock.rs
+++ b/src/home/light_themed_dock.rs
@@ -105,7 +105,7 @@ script_mod! {
         draw_button +: {
             color: #0
             color_hover: #FE8610
-            color_active: #FE8610
+            color_active: COLOR_PRIMARY
         }
 
         animator: Animator{

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -464,16 +464,21 @@ pub struct NavigationTabBar {
 
     /// The most recently applied view-mode override,
     #[rust] applied_view_mode: ViewModeOverride,
+
+    /// The tab currently visually marked as selected.
+    #[rust] selected_tab: SelectedTab,
 }
 
 impl ScriptHook for NavigationTabBar {
     fn on_after_new(&mut self, vm: &mut ScriptVm) {
         vm.with_cx_mut(|cx| {
-            // Programmatically select the Home button as active on startup,
-            // because animator default overrides in the DSL don't take effect.
-            self.view
-                .navigation_bar_button(cx, ids!(home_button))
-                .set_selected(cx, true);
+            self.apply_selected_tab(cx, None);
+        });
+    }
+
+    fn on_after_reload(&mut self, vm: &mut ScriptVm) {
+        vm.with_cx_mut(|cx| {
+            self.apply_selected_tab(cx, None);
         });
     }
 }
@@ -488,13 +493,17 @@ impl NavigationTabBar {
     }
 
     /// Updates which navigation tab button is visually marked as selected,
-    /// enforcing radio-button-like mutual exclusion across the four
-    /// navigation tab buttons.
-    fn apply_selected_tab(&mut self, cx: &mut Cx, tab: &SelectedTab) {
+    /// enforcing mutual exclusion across all buttons (like a radio button group).
+    ///
+    /// If `tab` is `None`, the existing selection is re-applied without changing it.
+    fn apply_selected_tab(&mut self, cx: &mut Cx, tab: Option<SelectedTab>) {
+        if let Some(t) = tab {
+            self.selected_tab = t;
+        }
         let home    = self.view.navigation_bar_button(cx, ids!(home_button));
         let add     = self.view.navigation_bar_button(cx, ids!(add_room_button));
         let profile = self.view.profile_icon(cx, ids!(profile_icon));
-        match tab {
+        match &self.selected_tab {
             SelectedTab::Home => {
                 home.set_selected(cx, true);
                 add.set_selected(cx, false);
@@ -528,11 +537,11 @@ impl Widget for NavigationTabBar {
             // Each click both updates the visual selection and emits the
             // corresponding `NavigationBarAction` for downstream handling.
             if self.view.navigation_bar_button(cx, ids!(home_button)).clicked(actions) {
-                self.apply_selected_tab(cx, &SelectedTab::Home);
+                self.apply_selected_tab(cx, Some(SelectedTab::Home));
                 cx.action(NavigationBarAction::GoToHome);
             }
             else if self.view.navigation_bar_button(cx, ids!(add_room_button)).clicked(actions) {
-                self.apply_selected_tab(cx, &SelectedTab::AddRoom);
+                self.apply_selected_tab(cx, Some(SelectedTab::AddRoom));
                 cx.action(NavigationBarAction::GoToAddRoom);
             }
             else {
@@ -543,7 +552,7 @@ impl Widget for NavigationTabBar {
                     .borrow()
                     .is_some_and(|p| p.inner.clicked(actions));
                 if profile_clicked {
-                    self.apply_selected_tab(cx, &SelectedTab::Settings);
+                    self.apply_selected_tab(cx, Some(SelectedTab::Settings));
                     cx.action(NavigationBarAction::OpenSettings);
                 }
             }
@@ -557,7 +566,7 @@ impl Widget for NavigationTabBar {
                 // If another widget programmatically selected a new tab,
                 // update our buttons' visual selection state accordingly.
                 if let Some(NavigationBarAction::TabSelected(tab)) = action.downcast_ref() {
-                    self.apply_selected_tab(cx, tab);
+                    self.apply_selected_tab(cx, Some(tab.clone()));
                     continue;
                 }
 

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -382,8 +382,8 @@ impl Widget for ProfileIcon {
                     .verification_badge(cx, ids!(verification_badge))
                     .tooltip_content();
                 let text = self.own_profile.as_ref().map_or_else(
-                    || format!("Not logged in.\n\n{}", verification_str),
-                    |p| format!("Logged in as \"{}\".\n\n{}", p.displayable_name(), verification_str)
+                    || String::from("Not logged in (or disconnected).\n\nClick/tap to access all settings."),
+                    |p| format!("Logged in {verification_str}as \"{}\".\n\nClick/tap to access all settings.", p.displayable_name()),
                 );
                 let mut options = CalloutTooltipOptions {
                     position: if effective_is_desktop(cx) { TooltipPosition::Right } else { TooltipPosition::Top },

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -90,7 +90,7 @@ script_mod! {
             align: Align{ x: 0.5 }
             draw_text +: {
                 color: (MESSAGE_TEXT_COLOR),
-                text_style: REGULAR_TEXT {font_size: 8, line_spacing: 1.0}
+                text_style: REGULAR_TEXT {font_size: 8, line_spacing: 1.1}
             }
         }
     }

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -1,8 +1,9 @@
 use std::cell::RefCell;
 
 use makepad_widgets::{text::selection::Cursor, *};
+use matrix_sdk::encryption::{identities::Device, VerificationState};
 
-use crate::{app::ConfirmDeleteAction, avatar_cache::{self}, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::user_profile::UserProfile, settings::PopulateMode, shared::{avatar::{AvatarState, AvatarWidgetExt}, confirmation_modal::ConfirmationModalContent, popup_list::{PopupKind, enqueue_popup_notification}, styles::*}, sliding_sync::{AccountDataAction, MatrixRequest, submit_async_request}, utils};
+use crate::{app::ConfirmDeleteAction, avatar_cache::{self}, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction}, profile::user_profile::UserProfile, settings::PopulateMode, shared::{avatar::{AvatarState, AvatarWidgetExt}, confirmation_modal::ConfirmationModalContent, popup_list::{PopupKind, enqueue_popup_notification}, styles::*}, sliding_sync::{get_client, submit_async_request, AccountDataAction, MatrixRequest}, utils, verification::VerificationStateAction};
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -18,15 +19,88 @@ script_mod! {
             text: "Account Settings"
         }
 
+        // Verification banners. Both stay hidden until we know the state.
+        verification_banner_verified := RoundedView {
+            visible: false
+            width: Fill {max: 450},
+            height: Fit
+            flow: Right
+            align: Align {y: 0.5}
+            margin: Inset{top: 10, bottom: 5}
+            padding: Inset{top: 10, bottom: 9, left: 12, right: 12}
+            show_bg: true
+            draw_bg +: {
+                color: (COLOR_BG_ACCEPT_GREEN)
+                border_color: (COLOR_FG_ACCEPT_GREEN)
+                border_size: 1.0
+                border_radius: 4.0
+            }
+            Label {
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true}
+                draw_text +: {
+                    color: (COLOR_FG_ACCEPT_GREEN),
+                    text_style: theme.font_bold { font_size: 11.5 },
+                }
+                text: "This device is verified and can access encrypted messages."
+            }
+        }
+
+        verification_banner_unverified := RoundedView {
+            visible: false
+            width: Fill {max: 478},
+            height: Fit
+            flow: Down,
+            align: Align {y: 0.5}
+            spacing: 0,
+            margin: Inset{top: 10, bottom: 5}
+            padding: Inset{top: 10, bottom: 13, left: 12, right: 12}
+            show_bg: true
+            draw_bg +: {
+                color: (COLOR_BG_DANGER_RED)
+                border_color: (COLOR_FG_DANGER_RED)
+                border_size: 1.0
+                border_radius: 4.0
+            }
+            Label {
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true}
+                draw_text +: {
+                    color: (COLOR_FG_DANGER_RED),
+                    text_style: theme.font_bold { font_size: 11.5 },
+                }
+                text: "This device is not verified and can't view encrypted messages."
+            }
+            Label {
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true}
+                margin: Inset { top: 4, bottom: 1}
+                draw_text +: {
+                    color: (MESSAGE_TEXT_COLOR),
+                    text_style: theme.font_regular { font_size: 11.5 },
+                }
+                text: "Verify it from another client using this info:"
+            }
+            // Filled in from Rust with the session name + device ID.
+            unverified_device_info_label := Label {
+                width: Fill, height: Fit
+                padding: Inset{left: 8}
+                flow: Flow.Right{wrap: true}
+                draw_text +: {
+                    color: (MESSAGE_TEXT_COLOR),
+                    text_style: theme.font_regular { font_size: 11.5 },
+                }
+                text: ""
+            }
+        }
+
         SubsectionLabel {
             text: "Your Avatar:"
         }
 
         View {
             width: Fill, height: Fit
-            // TODO: I'd like to use RightWrap here, but Makepad doesn't yet
-            //       support RightWrap with align: Align{y: 0.5}.
-            flow: Right,
+            flow: Right { wrap: true },
             align: Align{y: 0.5}
 
             our_own_avatar := Avatar {
@@ -48,7 +122,8 @@ script_mod! {
                 align: Align{y: 0.5}
                 padding: Inset{ left: 10, right: 10 }
                 spacing: 10
-
+                margin: Inset{top: 15}
+                
                 View {
                     width: Fit, height: Fit
                     flow: Right,
@@ -103,7 +178,8 @@ script_mod! {
 
         display_name_input := RobrixTextInput {
             margin: Inset{top: 3, left: 5, right: 5, bottom: 8},
-            width: 216, height: Fit
+            width: Fill { max: 226}, // to match the button width
+            height: Fit
             empty_text: "Add a display name..."
         }
 
@@ -169,10 +245,10 @@ script_mod! {
             user_id := Label {
                 width: Fill, height: Fit
                 flow: Flow.Right{wrap: true},
-                margin: Inset{top: 10}
+                margin: Inset{top: 9}
                 draw_text +: {
                     color: (MESSAGE_TEXT_COLOR),
-                    text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
+                    text_style: MESSAGE_TEXT_STYLE { font_size: 11.5 },
                 }
                 text: "You are not logged in."
             }
@@ -217,6 +293,8 @@ pub struct AccountSettings {
     #[deref] view: View,
 
     #[rust] own_profile: Option<UserProfile>,
+    #[rust(VerificationState::Unknown)] verification_state: VerificationState,
+    #[rust] own_device: Option<Device>,
 }
 
 impl ScriptHook for AccountSettings {
@@ -227,6 +305,17 @@ impl ScriptHook for AccountSettings {
         _scope: &mut Scope,
         _value: ScriptValue,
     ) {
+        // After apply, the DSL fields will be reset to their defaults,
+        // so we need to re-populate everything.
+        if let Some(client) = get_client() {
+            self.verification_state = client.encryption().verification_state().get();
+        }
+        if self.own_device.is_none() {
+            submit_async_request(MatrixRequest::GetOwnDevice);
+        }
+        let cx = vm.cx_mut();
+        self.update_verification_banner(cx);
+
         // Restore user_id inline so the DSL placeholder never flashes.
         // Anything that goes through `cx.with_vm` (button colors, avatar)
         // can't run here, so it's handled later in `restore_after_reapply`.
@@ -237,7 +326,6 @@ impl ScriptHook for AccountSettings {
             return;
         };
         let cached_user_id = own_profile.user_id.as_str().to_owned();
-        let cx = vm.cx_mut();
         self.view
             .label(cx, ids!(user_id))
             .set_text(cx, &cached_user_id);
@@ -301,6 +389,12 @@ impl MatchEvent for AccountSettings {
         let upload_avatar_button = self.view.button(cx, ids!(upload_avatar_button));
 
         for action in actions {
+            if let Some(VerificationStateAction::Update(state)) = action.downcast_ref() {
+                self.verification_state = *state;
+                self.update_verification_banner(cx);
+                continue;
+            }
+
             // Handle LogoutAction::InProgress to update button state
             if let Some(LogoutAction::InProgress(is_in_progress)) = action.downcast_ref() {
                 let logout_button = self.view.button(cx, ids!(logout_button));
@@ -378,6 +472,11 @@ impl MatchEvent for AccountSettings {
                         PopupKind::Error,
                         Some(4.0),
                     );
+                    continue;
+                }
+                Some(AccountDataAction::OwnDeviceFetched(device)) => {
+                    self.own_device = device.as_deref().cloned();
+                    self.update_verification_banner(cx);
                     continue;
                 }
                 _ => {}
@@ -605,6 +704,31 @@ impl AccountSettings {
         self.view.button(cx, ids!(copy_user_id_button)).reset_hover(cx);
         self.view.button(cx, ids!(manage_account_button)).reset_hover(cx);
         self.view.button(cx, ids!(logout_button)).reset_hover(cx);
+        self.view.redraw(cx);
+    }
+
+    /// Show verification info based on `self.verification_state`.
+    ///
+    /// If unknown, nothing will be shown.
+    fn update_verification_banner(&mut self, cx: &mut Cx) {
+        let (verified, unverified) = match self.verification_state {
+            VerificationState::Verified => (true, false),
+            VerificationState::Unverified => (false, true),
+            VerificationState::Unknown => (false, false),
+        };
+        self.view.view(cx, ids!(verification_banner_verified)).set_visible(cx, verified);
+        self.view.view(cx, ids!(verification_banner_unverified)).set_visible(cx, unverified);
+
+        // Refill the session info even if the banner is hidden, so it's
+        // already right if it shows up later.
+        let info_text = match self.own_device.as_ref() {
+            Some(device) => match device.display_name() {
+                Some(name) => format!("Session: \"{name}\",  Device ID: {}", device.device_id()),
+                None       => format!("Device ID: {}", device.device_id()),
+            },
+            None => String::new(),
+        };
+        self.view.label(cx, ids!(unverified_device_info_label)).set_text(cx, &info_text);
         self.view.redraw(cx);
     }
 

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -77,15 +77,12 @@ script_mod! {
 
     // A DropDown styled to match other Robrix settings controls.
     mod.widgets.RobrixSettingsDropDown = DropDownFlat {
-        width: 239, height: (mod.widgets.SETTINGS_BUTTON_HEIGHT),
+        width: 218, height: (mod.widgets.SETTINGS_BUTTON_HEIGHT),
         padding: Inset{top: 8, bottom: 8, left: 12, right: 30}
         margin: Inset{left: 5, top: 5, bottom: 5}
         align: Align{x: 0.0, y: 0.5}
 
-        // NOTE: PopupMenuPosition enum variants aren't exposed to script, so
-        // we can't request `BelowInput`. The popup uses the default
-        // OnSelected placement — styled to stay readable either way.
-        popup_menu: mod.widgets.RobrixSettingsPopupMenu{}
+        popup_menu: mod.widgets.RobrixSettingsPopupMenu {}
 
         draw_text +: {
             color: (MESSAGE_TEXT_COLOR),

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -54,17 +54,17 @@ script_mod! {
                 // The account settings section.
                 account_settings := AccountSettings {}
 
-                LineH { width: 400, padding: 10, margin: Inset{top: 20, bottom: 5} }
+                LineH { width: 425, padding: 10, margin: Inset{top: 20, bottom: 5} }
 
                 // The Robrix app settings section.
                 app_settings := AppSettings {}
 
-                LineH { width: 400, padding: 10, margin: Inset{top: 20, bottom: 5} }
+                LineH { width: 425, padding: 10, margin: Inset{top: 20, bottom: 5} }
 
                 // The TSP wallet settings section.
                 tsp_settings_screen := TspSettingsScreen {}
 
-                LineH { width: 400, padding: 10, margin: Inset{top: 20, bottom: 5} }
+                // LineH { width: 425, padding: 10, margin: Inset{top: 20, bottom: 5} }
 
                 // Add other settings sections here as needed.
                 // Don't forget to add a `show()` fn to those settings sections

--- a/src/shared/verification_badge.rs
+++ b/src/shared/verification_badge.rs
@@ -186,16 +186,15 @@ impl VerificationBadgeRef {
     pub fn tooltip_content(&self) -> (&'static str, Option<Vec4>) {
         match self.borrow().map(|v| v.verification_state) {
             Some(VerificationState::Verified) => (
-                "This device is fully verified.",
+                "and verified ",
                 Some(COLOR_FG_ACCEPT_GREEN),
             ),
             Some(VerificationState::Unverified) => (
-                "This device is unverified. To view your encrypted message history, \
-                please verify Robrix from another client.",
+                "but not verified ",
                 Some(COLOR_FG_DANGER_RED),
             ),
             _ => (
-                "Verification state is unknown.",
+                "",
                 None,
             ),
         }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -8,7 +8,7 @@ use imbl::Vector;
 use makepad_widgets::{error, log, warning, Cx, SignalToUI};
 use matrix_sdk_base::crypto::{DecryptionSettings, TrustRequirement};
 use matrix_sdk::{
-    config::RequestConfig, encryption::EncryptionSettings, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, RelationsOptions, RoomMember}, ruma::{
+    config::RequestConfig, encryption::{identities::Device, EncryptionSettings}, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, RelationsOptions, RoomMember}, ruma::{
         api::{Direction, client::{profile::{AvatarUrl, DisplayName}, receipt::create_receipt::v3::ReceiptType}}, events::{
             relation::RelationType,
             room::{
@@ -315,6 +315,9 @@ pub enum AccountDataAction {
     DisplayNameChanged(Option<String>),
     /// Failed to update the user's display name.
     DisplayNameChangeFailed(String),
+    /// Result of [`MatrixRequest::GetOwnDevice`], in a `Box` because `Device` is large.
+    /// * `None` if not logged in or the crypto store isn't ready yet.
+    OwnDeviceFetched(Option<Box<Device>>),
 }
 
 /// Actions emitted in response to a [`MatrixRequest::OpenOrCreateDirectMessage`].
@@ -563,6 +566,9 @@ pub enum MatrixRequest {
         /// * If `None`, the display name will be removed.
         new_display_name: Option<String>,
     },
+    /// Request to fetch our own [`Device`].
+    /// The response is delivered via [`AccountDataAction::OwnDeviceFetched`].
+    GetOwnDevice,
     /// Request to fetch an Avatar image from the server.
     /// Upon completion of the async media request, the `on_fetched` function
     /// will be invoked with the content of an `AvatarUpdate`.
@@ -1343,6 +1349,20 @@ async fn matrix_worker_task(
                             Cx::post_action(AccountDataAction::DisplayNameChangeFailed(err_msg));
                         }
                     }
+                });
+            }
+
+            MatrixRequest::GetOwnDevice => {
+                let Some(client) = get_client() else { continue };
+                let _get_own_device_task = Handle::current().spawn(async move {
+                    let device = match client.encryption().get_own_device().await {
+                        Ok(device) => device,
+                        Err(e) => {
+                            error!("Failed to get own device: {e:?}");
+                            None
+                        }
+                    };
+                    Cx::post_action(AccountDataAction::OwnDeviceFetched(device.map(Box::new)));
                 });
             }
 

--- a/src/tsp_dummy/mod.rs
+++ b/src/tsp_dummy/mod.rs
@@ -24,25 +24,8 @@ script_mod! {
 
 
     mod.widgets.TspSettingsScreen = View {
-        width: Fill, height: Fit
+        width: Fill, height: 20
         flow: Down
-        align: Align{x: 0}
-
-        TitleLabel {
-            text: "TSP Wallet Settings"
-        }
-
-        Label {
-            width: Fill, height: Fit
-            flow: Flow.Right{wrap: true},
-            align: Align{x: 0}
-            margin: Inset{top: 10, bottom: 10}
-            draw_text +: {
-                color: (MESSAGE_TEXT_COLOR),
-                text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
-            }
-            text: "TSP features are not included in this build.\nTo use TSP, build Robrix with the 'tsp' feature enabled."
-        }
     }
 
     mod.widgets.CreateWalletModal = View {


### PR DESCRIPTION
- Hide missing TSP settings message, as it's confusing/pointless
- Improve bottom spacing in AddRoom screen
- Add verification status/instructions to AccountSettings page
   -  This is a lot better than a tooltip that shows on the ProfileIcon, which was getting too long and couldn't convey all the necessary details in a nice manner, especially on mobile or smaller screens.
- Update for makepad fixes. Tweak nav bar buttons, dock buttons
- Make splitter and dock buttons easier to grab on touch screens.
- Ensure that the selected nav bar button always remains properly selected across rotation and other script reload/re-appply operations.