### PR TITLE
Rework SSO/Oauth flow on iOS to avoid hang on login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "bytes"
@@ -1474,7 +1474,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1620,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1941,9 +1941,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -2779,9 +2779,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2790,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2945,12 +2945,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2989,15 +2989,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3005,22 +3005,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3034,7 +3034,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "ttf-parser",
 ]
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3067,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3075,12 +3075,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3111,15 +3111,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "hilog-sys",
  "makepad-android-state",
  "makepad-apple-sys",
@@ -3140,7 +3140,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3152,12 +3152,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3165,13 +3165,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3188,14 +3188,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3249,18 +3249,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "simd-adler32",
 ]
@@ -3268,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3663,7 +3663,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "mime"
@@ -3944,6 +3944,18 @@ checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-authentication-services"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f920a0a975e281f298fab2312374a288e742f7375e8797397fd5c274b486b58"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
 ]
 
@@ -4392,10 +4404,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicase 2.9.0",
 ]
 
@@ -4815,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "robius-directories"
 version = "6.0.0"
-source = "git+https://github.com/project-robius/robius#87ea5c1e155d618a5902cae477d9603abe3f64c4"
+source = "git+https://github.com/project-robius/robius#9fc3d48e4c07f8954d9fcb54964d5e640bf6ed87"
 dependencies = [
  "dirs-sys",
  "jni",
@@ -4825,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "robius-location"
 version = "0.2.0"
-source = "git+https://github.com/project-robius/robius#87ea5c1e155d618a5902cae477d9603abe3f64c4"
+source = "git+https://github.com/project-robius/robius#9fc3d48e4c07f8954d9fcb54964d5e640bf6ed87"
 dependencies = [
  "android-build",
  "cfg-if",
@@ -4840,7 +4852,7 @@ dependencies = [
 [[package]]
 name = "robius-open"
 version = "0.2.0"
-source = "git+https://github.com/project-robius/robius#87ea5c1e155d618a5902cae477d9603abe3f64c4"
+source = "git+https://github.com/project-robius/robius#9fc3d48e4c07f8954d9fcb54964d5e640bf6ed87"
 dependencies = [
  "block2",
  "cfg-if",
@@ -4861,6 +4873,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "947db6944188cbab806d657f70ec5c55ec9f169d3cab83ac2d04801bd25a2826"
 dependencies = [
  "robius-android-env",
+]
+
+[[package]]
+name = "robius-web-auth-session"
+version = "0.2.0"
+source = "git+https://github.com/project-robius/robius#9fc3d48e4c07f8954d9fcb54964d5e640bf6ed87"
+dependencies = [
+ "block2",
+ "cfg-if",
+ "dispatch2",
+ "objc2",
+ "objc2-authentication-services",
+ "objc2-foundation",
+ "objc2-ui-kit",
 ]
 
 [[package]]
@@ -4899,6 +4925,7 @@ dependencies = [
  "robius-location",
  "robius-open",
  "robius-use-makepad",
+ "robius-web-auth-session",
  "ruma",
  "sanitize-filename",
  "serde",
@@ -5105,7 +5132,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5173,7 +5200,7 @@ dependencies = [
  "security-framework 3.5.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5203,12 +5230,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5303,7 +5330,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "sealed"
@@ -5602,7 +5629,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "siphasher"
@@ -5628,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "socket2"
@@ -5979,7 +6006,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6409,7 +6436,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "tungstenite"
@@ -6461,7 +6488,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-bidi"
@@ -6472,17 +6499,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-ident"
@@ -6493,7 +6520,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-normalization"
@@ -6513,12 +6540,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6529,7 +6556,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "unicode-width"
@@ -6861,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6873,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6883,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6892,7 +6919,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6902,7 +6929,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "log",
  "pkg-config",
@@ -6981,7 +7008,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7010,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7029,7 +7056,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7062,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7083,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7147,7 +7174,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 
 [[package]]
 name = "windows-numerics"
@@ -7191,7 +7218,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7208,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=dedup_fonts_mobile#72dff84b4be544277fcf886fca88a0a2c64f8882"
+source = "git+https://github.com/makepad/makepad?branch=dev#ecff7b816bf1bdc292256858882201d113287f41"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,8 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
-
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "dedup_fonts_mobile", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "dedup_fonts_mobile" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
@@ -103,6 +100,11 @@ reqwest = { version = "0.12", default-features = false, optional = true, feature
     "http2",
     "macos-system-configuration",
 ] }
+
+
+## For OAuth/SSO login on iOS, via `ASWebAuthenticationSession`. Ugh....
+[target.'cfg(target_os = "ios")'.dependencies]
+robius-web-auth-session = { git = "https://github.com/project-robius/robius" }
 
 
 [features]

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -485,6 +485,17 @@ impl MatchEvent for LoginScreen {
             }
         }
 
+        // On iOS there's no redirect server, so the cancel button dismisses
+        // the auth sheet instead. Its completion handler takes the normal
+        // SSO failure path, which resets state for the next attempt.
+        #[cfg(target_os = "ios")]
+        if self.sso_pending {
+            let login_status_modal_button = login_status_modal_inner.button_ref(cx);
+            if login_status_modal_button.clicked(actions) {
+                crate::sliding_sync::cancel_active_sso_auth_session();
+            }
+        }
+
         // Handle any of the SSO login buttons being clicked
         for (view_ref, brand) in self.view_set(cx, button_set).iter().zip(&provider_brands) {
             if view_ref.finger_up(actions).is_some() && !self.sso_pending {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -15,11 +15,14 @@ use matrix_sdk::{
                 message::RoomMessageEventContent, power_levels::RoomPowerLevels, MediaSource
             }, MessageLikeEventType, StateEventType
         }, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, uint
-    }, sliding_sync::VersionBuilder, Client, ClientBuildError, Error, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
+    }, sliding_sync::VersionBuilder, Client, ClientBuildError, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
 };
+#[cfg(not(target_os = "ios"))]
+use matrix_sdk::Error;
 use matrix_sdk_ui::{
     RoomListService, Timeline, encryption_sync_service, room_list_service::{RoomListItem, RoomListLoadingState, SyncIndicator, filters}, sync_service::{self, SyncService}, timeline::{LatestEventValue, RoomExt, TimelineEventItemId, TimelineFocus, TimelineItem, TimelineReadReceiptTracking, TimelineDetails}
 };
+#[cfg(not(target_os = "ios"))]
 use robius_open::Uri;
 use ruma::{OwnedRoomOrAliasId, RoomId, events::tag::Tags};
 use tokio::{
@@ -1953,6 +1956,25 @@ static DEFAULT_SSO_CLIENT: Mutex<Option<(Client, ClientSessionPersisted)>> = Mut
 
 /// Used to notify the SSO login task that the async creation of the `DEFAULT_SSO_CLIENT` has finished.
 static DEFAULT_SSO_CLIENT_NOTIFIER: LazyLock<Arc<Notify>> = LazyLock::new(|| Arc::new(Notify::new()));
+
+/// Handle to the in-flight `ASWebAuthenticationSession`. Set when the auth
+/// sheet is presented, cleared by the completion callback or by
+/// [`cancel_active_sso_auth_session`].
+#[cfg(target_os = "ios")]
+static ACTIVE_SSO_AUTH_SESSION: Mutex<Option<robius_web_auth_session::AuthSessionHandle>> =
+    Mutex::new(None);
+
+/// Dismiss the iOS auth sheet. The completion callback fires with
+/// `UserCancelled`, which surfaces as a `LoginFailure` and resets all
+/// SSO state so the next attempt works. No-op if nothing's running.
+#[cfg(target_os = "ios")]
+pub fn cancel_active_sso_auth_session() {
+    if let Ok(mut slot) = ACTIVE_SSO_AUTH_SESSION.lock() {
+        if let Some(handle) = slot.take() {
+            handle.cancel();
+        }
+    }
+}
 
 /// Blocks the current thread until the given future completes.
 ///
@@ -4094,36 +4116,52 @@ async fn spawn_sso_server(
         };
 
         let mut is_logged_in = false;
-        Cx::post_action(LoginAction::Status {
-            title: "Opening your browser...".into(),
-            status: "Please finish logging in using your browser, and then come back to Robrix.".into(),
-        });
-        match client
-            .matrix_auth()
-            .login_sso(|sso_url: String| async move {
-                let url = Url::parse(&sso_url)?;
-                for (key, value) in url.query_pairs() {
-                    if key == "redirectUrl" {
-                        let redirect_url = Url::parse(&value)?;
-                        Cx::post_action(LoginAction::SsoSetRedirectUrl(redirect_url));
-                        break
+
+        // Desktop's `login_sso` uses a local HTTP server for the OAuth
+        // redirect, which iOS suspends when Robrix backgrounds for Safari.
+        // iOS uses ASWebAuthenticationSession to keep the app foregrounded.
+        #[cfg(not(target_os = "ios"))]
+        let login_result = {
+            Cx::post_action(LoginAction::Status {
+                title: "Opening your browser...".into(),
+                status: "Please finish logging in using your browser, and then come back to Robrix.".into(),
+            });
+            client
+                .matrix_auth()
+                .login_sso(|sso_url: String| async move {
+                    let url = Url::parse(&sso_url)?;
+                    for (key, value) in url.query_pairs() {
+                        if key == "redirectUrl" {
+                            let redirect_url = Url::parse(&value)?;
+                            Cx::post_action(LoginAction::SsoSetRedirectUrl(redirect_url));
+                            break
+                        }
                     }
+                    Uri::new(&sso_url).open().map_err(|err|
+                        Error::Io(io::Error::other(format!("Unable to open SSO login url. Error: {:?}", err)))
+                    )
+                })
+                .identity_provider_id(&identity_provider_id)
+                .initial_device_display_name(&format!("robrix-sso-{brand}"))
+                .await
+        };
+        #[cfg(target_os = "ios")]
+        let login_result = {
+            Cx::post_action(LoginAction::Status {
+                title: "Opening in-app authentication...".into(),
+                status: "Please complete login in the authentication sheet that appeared.".into(),
+            });
+            run_ios_sso_flow(&client, &identity_provider_id, &brand).await
+        };
+
+        match login_result.inspect(|_| {
+            if let Some(client) = get_client() {
+                if client.matrix_auth().logged_in() {
+                    is_logged_in = true;
+                    log!("Already logged in, ignore login with sso");
                 }
-                Uri::new(&sso_url).open().map_err(|err|
-                    Error::Io(io::Error::other(format!("Unable to open SSO login url. Error: {:?}", err)))
-                )
-            })
-            .identity_provider_id(&identity_provider_id)
-            .initial_device_display_name(&format!("robrix-sso-{brand}"))
-            .await
-            .inspect(|_| {
-                if let Some(client) = get_client() {
-                    if client.matrix_auth().logged_in() {
-                        is_logged_in = true;
-                        log!("Already logged in, ignore login with sso");
-                    }
-                }
-            }) {
+            }
+        }) {
             Ok(identity_provider_res) => {
                 if !is_logged_in {
                     if let Err(e) = login_sender.send(LoginRequest::LoginBySSOSuccess(client, client_session)).await {
@@ -4153,6 +4191,87 @@ async fn spawn_sso_server(
         DEFAULT_SSO_CLIENT_NOTIFIER.notify_one();
         Cx::post_action(LoginAction::SsoPending(false));
     });
+}
+
+
+/// Drives iOS SSO via `ASWebAuthenticationSession`. Gets the SSO URL with a
+/// `robrix://` redirect, opens it in the auth sheet, and feeds the callback
+/// URL through `login_with_sso_callback` to finish.
+#[cfg(target_os = "ios")]
+async fn run_ios_sso_flow(
+    client: &Client,
+    identity_provider_id: &str,
+    brand: &str,
+) -> std::result::Result<
+    matrix_sdk::ruma::api::client::session::login::v3::Response,
+    matrix_sdk::Error,
+> {
+    use tokio::sync::oneshot;
+
+    // Session-scoped scheme, so no Info.plist registration needed. Synapse
+    // doesn't validate redirectUrl, so the URL shape is up to us.
+    const REDIRECT_URL: &str = "robrix://login";
+    const CALLBACK_SCHEME: &str = "robrix";
+
+    let auth = client.matrix_auth();
+    let sso_url = auth
+        .get_sso_login_url(REDIRECT_URL, Some(identity_provider_id))
+        .await?;
+
+    // Bridge the OS completion callback into a Rust oneshot. Mutex<Option>
+    // guards against the OS double-firing, and the same callback clears
+    // ACTIVE_SSO_AUTH_SESSION so cancel becomes a no-op once auth is done.
+    let (tx, rx) = oneshot::channel::<robius_web_auth_session::Result<String>>();
+    let tx = std::sync::Mutex::new(Some(tx));
+
+    let handle = robius_web_auth_session::AuthSession::new(&sso_url, CALLBACK_SCHEME)
+        .start(move |result| {
+            if let Ok(mut slot) = ACTIVE_SSO_AUTH_SESSION.lock() {
+                *slot = None;
+            }
+            if let Some(tx) = tx.lock().unwrap().take() {
+                let _ = tx.send(result);
+            }
+        })
+        .map_err(|e| {
+            matrix_sdk::Error::Io(io::Error::other(format!(
+                "Failed to start ASWebAuthenticationSession: {e}"
+            )))
+        })?;
+
+    // Publish the cancel handle so the modal's Cancel button can reach it.
+    // Cleared by the completion callback above.
+    if let Ok(mut slot) = ACTIVE_SSO_AUTH_SESSION.lock() {
+        *slot = Some(handle);
+    }
+
+    let callback_url_str = rx
+        .await
+        .map_err(|_| {
+            matrix_sdk::Error::Io(io::Error::other(
+                "ASWebAuthenticationSession completion handler dropped without firing",
+            ))
+        })?
+        .map_err(|e| {
+            matrix_sdk::Error::Io(io::Error::other(format!(
+                "ASWebAuthenticationSession failed: {e}"
+            )))
+        })?;
+
+    let callback_url = Url::parse(&callback_url_str).map_err(|e| {
+        matrix_sdk::Error::Io(io::Error::other(format!(
+            "Invalid SSO callback URL ({callback_url_str:?}): {e}"
+        )))
+    })?;
+
+    auth.login_with_sso_callback(callback_url.into())
+        .map_err(|e| {
+            matrix_sdk::Error::Io(io::Error::other(format!(
+                "Failed to parse SSO callback for loginToken: {e}"
+            )))
+        })?
+        .initial_device_display_name(&format!("robrix-sso-{brand}"))
+        .await
 }
 
 


### PR DESCRIPTION
Apparently, when you click the link to login, Robrix spawns (via the matrix SDK) some sockets to listen for the SSO reply, but iOS kills those socket connections while your browser is in the foreground and Robrix is in the background. So it never gets to listen for the response...

Great. We fix that by following iOS's native `ASWebAuthenticationSession` approach, which we introduce a new `robius-web-auth-session` crate to abstract that / wrap it in Rust.

This works better -- it looks cleaner, works with native browser passwords or Apple passwords & passkeys, and is safer.

Still annoying that we have to do it in a platform-specific way, but perhaps we can wrap that in a better abstraction later to avoid introducing platform-specific code within Robrix itself.