### PR TITLE
Fix logout + re-login flow, plus issues on iOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4910,6 +4910,7 @@ dependencies = [
  "imbl",
  "imghdr",
  "indexmap 2.13.0",
+ "libc",
  "linkify",
  "makepad-code-editor",
  "makepad-widgets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ hashbrown = { version = "0.16", features = ["raw-entry"] }
 htmlize = "1.0.5"
 indexmap = "2.6.0"
 imghdr = "0.7.0"
+libc = "0.2"
 linkify = "0.10.0"
 matrix-sdk-base = { git = "https://github.com/project-robius/matrix-rust-sdk", branch = "space_room_suggested" }
 matrix-sdk = { git = "https://github.com/project-robius/matrix-rust-sdk", branch = "space_room_suggested", default-features = false, features = [

--- a/src/app.rs
+++ b/src/app.rs
@@ -191,6 +191,19 @@ impl MatchEvent for App {
         // only init logging/tracing once
         let _ = tracing_subscriber::fmt::try_init();
 
+        // On iOS (and potentially other devices), there is a very low limit
+        // (albeit a soft limit) on max file descriptors, as little as 256.
+        // We increase that preemptively to avoid running out later due to sqlite ops.
+        #[cfg(unix)]
+        unsafe {
+            let mut rlim = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+            if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) == 0 && rlim.rlim_cur < 4096 {
+                let new_soft = (4096 as libc::rlim_t).min(rlim.rlim_max);
+                let bumped = libc::rlimit { rlim_cur: new_soft, rlim_max: rlim.rlim_max };
+                libc::setrlimit(libc::RLIMIT_NOFILE, &bumped);
+            }
+        }
+
         // Initialize the project directory here from the main UI thread
         // such that background threads/tasks will be able to can access it.
         let _app_data_dir = crate::app_data_dir();

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -570,6 +570,14 @@ impl Widget for NavigationTabBar {
                     continue;
                 }
 
+                // Upon login (mostly re-login), go back to the home tab
+                // because the profile/settings tab will have been selected upon logout.
+                if let Some(LoginAction::LoginSuccess) = action.downcast_ref() {
+                    self.apply_selected_tab(cx, Some(SelectedTab::Home));
+                    cx.action(NavigationBarAction::GoToHome);
+                    continue;
+                }
+
                 if let Some(AppPreferencesAction::ViewModeChanged(new_mode)) = action.downcast_ref() {
                     if *new_mode != self.applied_view_mode {
                         self.apply_view_mode(*new_mode);

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -28,6 +28,7 @@ use crate::{
     home::{
         navigation_tab_bar::{NavigationBarAction, SelectedTab}, room_context_menu::RoomContextMenuDetails, rooms_list_entry::RoomsListEntryAction, space_lobby::{SpaceLobbyAction, SpaceLobbyEntryWidgetExt}
     },
+    logout::logout_confirm_modal::LogoutAction,
     room::{
         FetchedRoomAvatar,
         room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria, SortFn},
@@ -1253,6 +1254,29 @@ impl Widget for RoomsList {
         // Second, handle any other actions that came from other widgets/components.
         if let Event::Actions(actions) = event {
             for action in actions {
+                // Clear widget state upon logout.
+                if let Some(LogoutAction::ClearAppState { .. }) = action.downcast_ref() {
+                    self.invited_rooms.borrow_mut().clear();
+                    self.all_joined_rooms.clear();
+                    self.all_known_rooms_order.clear();
+                    self.selected_space = None;
+                    self.space_request_sender = None;
+                    self.space_map.clear();
+                    self.hidden_rooms.clear();
+                    self.displayed_invited_rooms.clear();
+                    self.invited_rooms_indexes = Default::default();
+                    self.displayed_direct_rooms.clear();
+                    self.direct_rooms_indexes = Default::default();
+                    self.displayed_regular_rooms.clear();
+                    self.regular_rooms_indexes = Default::default();
+                    self.current_active_room = None;
+                    self.max_known_rooms = None;
+                    self.status = String::new();
+                    self.update_status();
+                    self.redraw(cx);
+                    continue;
+                }
+
                 // Only handle filter changes from the home screen's filter bar,
                 // not from any other RoomFilterInputBar instance (e.g., SpaceLobbyScreen's).
                 if let Some(MainFilterAction::Changed(keywords)) = action.downcast_ref() {

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -13,7 +13,7 @@ use matrix_sdk::{RoomDisplayName, RoomState};
 use ruma::{OwnedRoomAliasId, OwnedRoomId, room::JoinRuleSummary};
 
 use crate::{
-    home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetRefExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction}, utils::{self, RoomNameId}
+    home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetRefExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction}, utils::{self, RoomNameId}
 };
 
 script_mod! {
@@ -326,7 +326,7 @@ pub struct SpacesBar {
     #[rust] all_joined_spaces: HashMap<OwnedRoomId, JoinedSpaceInfo>,
 
     /// The currently-active filter function for the list of spaces.
-    ///
+///
     /// Note: for performance reasons, this does not get automatically applied
     /// when its value changes. Instead, you must manually invoke it on the set of `all_joined_spaces`
     /// in order to update the set of `displayed_spaces` accordingly.
@@ -403,6 +403,17 @@ impl Widget for SpacesBar {
                         self.apply_view_mode(*new_mode);
                         self.view.redraw(cx);
                     }
+                    continue;
+                }
+
+                // Clear widget state upon logout.
+                if let Some(LogoutAction::ClearAppState { .. }) = action.downcast_ref() {
+                    self.all_joined_spaces.clear();
+                    self.displayed_spaces.clear();
+                    self.display_filter = Default::default();
+                    self.selected_space = None;
+                    self.is_filtered = false;
+                    self.redraw(cx);
                     continue;
                 }
             }

--- a/src/logout/logout_errors.rs
+++ b/src/logout/logout_errors.rs
@@ -29,8 +29,6 @@ pub enum UnrecoverableError {
     ComponentsCleared,
     /// Failed after point of no return
     PostPointOfNoReturnFailure(String),
-    /// Runtime restart failed
-    RuntimeRestartFailed,
 }
 
 impl fmt::Display for LogoutError {

--- a/src/logout/logout_state_machine.rs
+++ b/src/logout/logout_state_machine.rs
@@ -23,10 +23,6 @@
 //!                                                                           ↓
 //!                                                                   CleaningAppState (70%)
 //!                                                                           ↓
-//!                                                                   ShuttingDownTasks (80%)
-//!                                                                           ↓
-//!                                                                   RestartingRuntime (90%)
-//!                                                                           ↓
 //!                                                                     Completed (100%)
 //!                                                                           ↓
 //!                                                                        Failed
@@ -68,10 +64,11 @@
 //! 3. **LoggingOutFromServer**: Call `client.matrix_auth().logout()` (60s timeout)
 //! 4. **PointOfNoReturn**: Set global flags, delete saved user ID
 //! 5. **ClosingTabs**: Close desktop tabs via `MainDesktopUiAction::CloseAllTabs`
-//! 6. **CleaningAppState**: Clear global resources and notify UI cleanup
-//! 7. **ShuttingDownTasks**: Call `shutdown_background_tasks()`
-//! 8. **RestartingRuntime**: Call `start_matrix_tokio()` for next login
-//! 9. **Completed**: Send `LogoutAction::LogoutSuccess`
+//! 6. **CleaningAppState**: Drops globals and signals `LOGOUT_NOTIFY`. The
+//!    login loop in `start_matrix_client_login_and_sync` does the actual
+//!    teardown of per-session tasks. The tokio runtime stays alive, since
+//!    tearing it down here would race with the new client's SQLite setup.
+//! 7. **Completed**: Send `LogoutAction::LogoutSuccess`
 //!
 //! ## Usage
 //!
@@ -94,7 +91,7 @@ use crate::persistence::delete_latest_user_id;
 use crate::sliding_sync::clear_app_state;
 use crate::{
     home::main_desktop_ui::MainDesktopUiAction,
-    sliding_sync::{get_client, get_sync_service, shutdown_background_tasks, start_matrix_tokio},
+    sliding_sync::{get_client, get_sync_service},
 };
 use super::logout_confirm_modal::{LogoutAction, ClearedComponentType};
 use super::logout_errors::{LogoutError, RecoverableError, UnrecoverableError};
@@ -114,12 +111,8 @@ pub enum LogoutState {
     PointOfNoReturn,
     /// Closing UI tabs (desktop only)
     ClosingTabs,
-    /// Cleaning up application state
+    /// Cleaning up application state.
     CleaningAppState,
-    /// Shutting down background tasks
-    ShuttingDownTasks,
-    /// Restarting the Matrix runtime
-    RestartingRuntime,
     /// Logout completed successfully
     Completed,
     /// Logout failed with error
@@ -407,35 +400,7 @@ impl LogoutStateMachine {
             self.handle_error(&error).await;
             return Err(anyhow!(error));
         }
-        
-        // Shutdown tasks
-        self.transition_to(
-            LogoutState::ShuttingDownTasks,
-            "Shutting down background tasks...".to_string(),
-            80
-        ).await?;
-        
-        self.shutdown_background_tasks();
-        
-        // Restart runtime
-        self.transition_to(
-            LogoutState::RestartingRuntime,
-            "Restarting Matrix runtime...".to_string(),
-            90
-        ).await?;
-        
-        if let Err(e) = self.restart_runtime(){
-            let error = LogoutError::Unrecoverable(UnrecoverableError::RuntimeRestartFailed);
-            self.transition_to(
-                LogoutState::Failed(error.clone()),
-                format!("Failed to restart runtime: {}", e),
-                0
-            ).await?;
-            self.handle_error(&error).await;
-            return Err(anyhow!(error));
-        }
-        
-        // Success!
+
         self.transition_to(
             LogoutState::Completed,
             "Logout completed successfully".to_string(),
@@ -517,16 +482,6 @@ impl LogoutStateMachine {
             }
             Err(_) => Err(anyhow!("Timed out waiting for tabs to close")),
         }
-    }
-    
-    fn shutdown_background_tasks(&self) {
-        shutdown_background_tasks();
-    }
-    
-    fn restart_runtime(&self) -> Result<()> {
-        start_matrix_tokio()
-            .map(|_| ())
-            .map_err(|e| anyhow!("Failed to restart runtime: {}", e))
     }
     
     /// Handle errors by posting appropriate actions

--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -126,6 +126,141 @@ pub async fn most_recent_user_id() -> Option<OwnedUserId> {
     .ok()
 }
 
+/// Resolves the path that `restore_session()` would actually open.
+fn resolve_db_path(stored: PathBuf) -> PathBuf {
+    if !stored.is_absolute() {
+        return app_data_dir().join(stored);
+    }
+    if stored.exists() {
+        return stored;
+    }
+    let Some(name) = stored.file_name() else {
+        return stored;
+    };
+    // iOS sandbox UUID changes across reinstalls; the absolute path
+    // baked into the session is now stale. Use the basename instead.
+    app_data_dir().join(name)
+}
+
+/// Returns the set of `db` paths referenced by any saved session file.
+///
+/// This basically scans every saved user session dir, not just the most recent one,
+/// to help ensure that db dirs don't get orphaned on the filesystem forever.
+async fn collect_referenced_db_paths() -> std::collections::HashSet<PathBuf> {
+    use std::collections::HashSet;
+    let mut paths = HashSet::new();
+    let data_dir = app_data_dir();
+
+    let Ok(mut entries) = tokio::fs::read_dir(data_dir).await else {
+        return paths;
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.starts_with("db_") {
+            continue;
+        }
+        let session_file = path.join("persistent_state").join("session");
+        let Ok(bytes) = tokio::fs::read(&session_file).await else {
+            continue;
+        };
+        let session: FullSessionPersisted = match serde_json::from_slice(&bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                log!("collect_referenced_db_paths: skipping unparseable session file {}: {e}",
+                    session_file.display(),
+                );
+                continue;
+            }
+        };
+        paths.insert(resolve_db_path(session.client_session.db_path));
+    }
+
+    paths
+}
+
+/// Deletes `db_*` subdirs not referenced by any saved session. Only touches
+/// entries that match the `db_*` prefix and that came from
+/// `read_dir(app_data_dir())`, so it can't escape the data dir even with a
+/// malicious session file.
+pub async fn cleanup_orphan_db_dirs() {
+    let data_dir = app_data_dir();
+    let active = collect_referenced_db_paths().await;
+
+    let mut entries = match tokio::fs::read_dir(data_dir).await {
+        Ok(e) => e,
+        Err(e) => {
+            log!("cleanup_orphan_db_dirs: could not read data dir {}: {e}", data_dir.display());
+            return;
+        }
+    };
+
+    let mut deleted = 0usize;
+    let mut bytes_freed = 0u64;
+    let mut kept = 0usize;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("db_") {
+            continue;
+        }
+        if active.contains(&path) {
+            kept += 1;
+            log!("cleanup_orphan_db_dirs: preserving referenced db dir: {}", path.display());
+            continue;
+        }
+        let size = dir_size_bytes(&path).await.unwrap_or(0);
+        match tokio::fs::remove_dir_all(&path).await {
+            Ok(()) => {
+                deleted += 1;
+                bytes_freed += size;
+                log!(
+                    "cleanup_orphan_db_dirs: deleted orphaned db dir ({} bytes): {}",
+                    size,
+                    path.display(),
+                );
+            }
+            Err(e) => {
+                log!(
+                    "cleanup_orphan_db_dirs: failed to delete {}: {e}",
+                    path.display(),
+                );
+            }
+        }
+    }
+
+    if deleted > 0 || kept > 0 {
+        log!(
+            "cleanup_orphan_db_dirs: deleted {deleted} orphan(s), freed {bytes_freed} bytes; kept {kept} active referenced",
+        );
+    }
+}
+
+/// Recursive size sum, best-effort. Just for the cleanup log line.
+async fn dir_size_bytes(path: &std::path::Path) -> Option<u64> {
+    let mut total = 0u64;
+    let mut entries = tokio::fs::read_dir(path).await.ok()?;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let Ok(md) = entry.metadata().await else {
+            continue;
+        };
+        if md.is_file() {
+            total = total.saturating_add(md.len());
+        } else if md.is_dir() {
+            // matrix-sdk-sqlite doesn't nest subdirectories, but be safe.
+            if let Some(sub) = Box::pin(dir_size_bytes(&entry.path())).await {
+                total = total.saturating_add(sub);
+            }
+        }
+    }
+    Some(total)
+}
+
 /// Save which user was the most recently logged in.
 async fn save_latest_user_id(user_id: &UserId) -> anyhow::Result<()> {
     tokio::fs::write(
@@ -179,36 +314,25 @@ pub async fn restore_session(
         title: "Connecting to homeserver".into(),
         status: status_str,
     });
-    // Resolve the db path against the current `app_data_dir()`. Legacy
-    // sessions stored an absolute path that may now be stale on iOS
-    // (sandbox UUID changes across reinstalls), so if it's gone, fall
-    // back to its basename joined with the current data dir.
-    let db_path = if client_session.db_path.is_absolute() {
-        if client_session.db_path.exists() {
-            client_session.db_path.clone()
-        } else if let Some(name) = client_session.db_path.file_name() {
-            let relocated = app_data_dir().join(name);
-            log!(
-                "Stored db_path '{}' no longer exists; using '{}'",
-                client_session.db_path.display(),
-                relocated.display(),
-            );
-            relocated
-        } else {
-            client_session.db_path.clone()
-        }
-    } else {
-        app_data_dir().join(&client_session.db_path)
-    };
+    let original_stored = client_session.db_path.clone();
+    let db_path = resolve_db_path(client_session.db_path);
+    if db_path != original_stored {
+        log!(
+            "Stored db_path '{}' relocated to '{}'",
+            original_stored.display(),
+            db_path.display(),
+        );
+    }
     log!(
         "Restoring session for {user_id} with db at: {} (stored as: {})",
         db_path.display(),
-        client_session.db_path.display(),
+        original_stored.display(),
     );
+    let store_config = crate::sliding_sync::build_sqlite_store_config(&db_path, &client_session.passphrase);
     // Build the client with the previous settings from the session.
     let client = Client::builder()
         .homeserver_url(client_session.homeserver)
-        .sqlite_store(db_path, Some(&client_session.passphrase))
+        .sqlite_store_with_config_and_cache_path(store_config, None::<&std::path::Path>)
         .with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
             with_subscriptions: true,
         })

--- a/src/persistence/matrix_state.rs
+++ b/src/persistence/matrix_state.rs
@@ -170,7 +170,7 @@ async fn collect_referenced_db_paths() -> std::collections::HashSet<PathBuf> {
         let session: FullSessionPersisted = match serde_json::from_slice(&bytes) {
             Ok(s) => s,
             Err(e) => {
-                log!("collect_referenced_db_paths: skipping unparseable session file {}: {e}",
+                log!("collect_referenced_db_paths: skipping unparsable session file {}: {e}",
                     session_file.display(),
                 );
                 continue;

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4544,7 +4544,7 @@ impl UserPowerLevels {
 
 /// Drops session state and signals the login loop to wait for re-login.
 /// Keeps `REQUEST_SENDER` alive, and also the `matrix_worker_task
-/// whic needs to keep running to receive the next login request.
+/// which needs to keep running to receive the next login request.
 pub async fn clear_app_state(config: &LogoutConfig) -> Result<()> {
     CLIENT.lock().unwrap().take();
     SYNC_SERVICE.lock().unwrap().take();

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -98,6 +98,16 @@ impl From<LoginByPassword> for Cli {
 }
 
 
+/// Shared SQLite store config for both `build_client` and `restore_session`,
+/// so both code paths can't drift.
+pub fn build_sqlite_store_config(
+    db_path: &Path,
+    passphrase: &str,
+) -> matrix_sdk::SqliteStoreConfig {
+    matrix_sdk::SqliteStoreConfig::with_low_memory_config(db_path)
+        .passphrase(Some(passphrase))
+}
+
 /// Build a new client.
 async fn build_client(
     cli: &Cli,
@@ -109,6 +119,15 @@ async fn build_client(
     let db_subfolder_name: String = format!("db_{}", now.format("%F_%H_%M_%S_%f"));
     let db_path = data_dir.join(&db_subfolder_name);
     log!("Building new client with db at: {}", db_path.display());
+
+    // Eagerly creat the db dir to avoid any issues within the matrix SDK.
+    if let Err(e) = tokio::fs::create_dir_all(&db_path).await {
+        error!(
+            "Failed to pre-create db directory at {}: {e}. Continuing anyway; \
+             matrix-sdk-sqlite will retry the create internally.",
+            db_path.display(),
+        );
+    }
 
     // Generate a random passphrase.
     let passphrase: String = {
@@ -124,10 +143,12 @@ async fn build_client(
         .unwrap_or("https://matrix-client.matrix.org/");
         // .unwrap_or("https://matrix.org/");
 
+    let store_config = build_sqlite_store_config(&db_path, &passphrase);
+
     let mut builder = Client::builder()
         .server_name_or_homeserver_url(homeserver_url)
         // Use a sqlite database to persist the client's encryption setup.
-        .sqlite_store(&db_path, Some(&passphrase))
+        .sqlite_store_with_config_and_cache_path(store_config, None::<&std::path::Path>)
         .with_threading_support(matrix_sdk::ThreadingSupport::Enabled {
             with_subscriptions: true,
         })
@@ -154,7 +175,6 @@ async fn build_client(
         RequestConfig::new()
             .timeout(std::time::Duration::from_secs(60))
     );
-
     let client = builder.build().await?;
     let homeserver_url =  client.homeserver().to_string();
     Ok((
@@ -2149,6 +2169,9 @@ static TOKEN_EXPIRED: AtomicBool = AtomicBool::new(false);
 /// Notifies the main monitoring loop to wake up and check `TOKEN_EXPIRED`.
 static TOKEN_EXPIRED_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
 
+/// Wakes the monitoring loop on logout, see `is_logout_in_progress()`.
+static LOGOUT_NOTIFY: LazyLock<Notify> = LazyLock::new(Notify::new);
+
 
 /// Get a reference to the current sync service, if available.
 pub fn get_sync_service() -> Option<Arc<SyncService>> {
@@ -2277,11 +2300,28 @@ impl RoomListServiceRoomInfo {
     }
 }
 
+/// Aborts all handles in parallel, then awaits each so their Drop chain
+/// (Arcs, channels, etc.) finishes before we move on.
+async fn abort_and_await_handles(handles: &mut Vec<JoinHandle<()>>) {
+    for h in handles.iter() {
+        h.abort();
+    }
+    for h in handles.drain(..) {
+        // Skip handles we've already consumed, as those would block forever.
+        if !h.is_finished() {
+            let _ = h.await;
+        }
+    }
+}
+
 /// Performs the Matrix client login or session restore, and starts the main sync service.
 ///
 /// After starting the sync service, this also starts the main room list service loop
 /// and the main space service loop.
 async fn start_matrix_client_login_and_sync(rt: Handle) {
+    // Run clean up before anything else, like creating new db dirs.
+    persistence::cleanup_orphan_db_dirs().await;
+
     // Create a channel for sending requests from the main UI thread to a background worker task.
     let (sender, receiver) = tokio::sync::mpsc::unbounded_channel::<MatrixRequest>();
     REQUEST_SENDER.lock().unwrap().replace(sender);
@@ -2428,14 +2468,18 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             error!("BUG: unexpectedly replaced an existing client when initializing the matrix client.");
         }
 
+        // Track all async tasks so we can nicely clean them up with abort+await.
+        // Generally anything that holds a reference to `Client` should be here.
+        let mut subscriber_task_handles: Vec<JoinHandle<()>> = Vec::new();
+
         // Listen for changes to our verification status and incoming verification requests.
-        add_verification_event_handlers_and_sync_client(client.clone());
+        subscriber_task_handles.push(add_verification_event_handlers_and_sync_client(client.clone()));
 
         // Listen for updates to the ignored user list.
-        handle_ignore_user_list_subscriber(client.clone());
+        subscriber_task_handles.push(handle_ignore_user_list_subscriber(client.clone()));
 
         // Listen for session changes, e.g., when the access token becomes invalid.
-        handle_session_changes(client.clone());
+        subscriber_task_handles.push(handle_session_changes(client.clone()));
 
         Cx::post_action(LoginAction::Status {
             title: "Connecting".into(),
@@ -2460,6 +2504,7 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                 // Clear the stored client so the next login attempt doesn't trigger the
                 // "unexpectedly replaced an existing client" warning.
                 let _ = CLIENT.lock().unwrap().take();
+                abort_and_await_handles(&mut subscriber_task_handles).await;
                 continue 'login_loop;
             }
         };
@@ -2472,9 +2517,10 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
         Cx::post_action(LoginAction::LoginSuccess);
 
         // Attempt to load the previously-saved app state.
+        // One-shot, drops on its own; not tracked.
         handle_load_app_state(logged_in_user_id.to_owned());
-        handle_sync_indicator_subscriber(&sync_service);
-        handle_sync_service_state_subscriber(sync_service.state());
+        subscriber_task_handles.push(handle_sync_indicator_subscriber(&sync_service));
+        subscriber_task_handles.push(handle_sync_service_state_subscriber(sync_service.state()));
         sync_service.start().await;
 
         let room_list_service = sync_service.room_list_service();
@@ -2488,14 +2534,21 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
 
         // Now, this task becomes an infinite loop that monitors the state of the
         // three core matrix-related background tasks that we just spawned above.
-        // If the access token expires (TOKEN_EXPIRED is set), this loop will break
-        // and we'll clean up and `continue 'login_loop` to wait for re-login.
         #[allow(clippy::never_loop)] // unsure if needed, just following tokio's examples.
         loop {
             tokio::select! {
-                // Wake up immediately when the access token has been rejected,
-                // so we can tear down this session and wait for re-login.
+                // If we were notified but it got canceled, check the TOKEN_EXPIRED bool.
                 _ = TOKEN_EXPIRED_NOTIFY.notified() => {
+                    if !TOKEN_EXPIRED.load(Ordering::Acquire) {
+                        continue;
+                    }
+                    break;
+                }
+                _ = LOGOUT_NOTIFY.notified() => {
+                    if !is_logout_in_progress() {
+                        continue;
+                    }
+                    log!("Login loop received logout signal");
                     break;
                 }
                 result = &mut matrix_worker_task_handle => {
@@ -2577,19 +2630,54 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             }
         }
 
-        // If the monitoring loop broke because the access token expired,
-        // clean up the current session state and loop back to wait for re-login.
-        if TOKEN_EXPIRED.load(Ordering::Acquire) {
-            log!("Token expired; cleaning up session state and waiting for re-login.");
-            // Abort the background tasks that depend on the now-invalid session.
+        let was_token_expired = TOKEN_EXPIRED.load(Ordering::Acquire);
+        let was_logout = is_logout_in_progress();
+        if was_token_expired || was_logout {
+            if was_token_expired {
+                log!("Token expired; cleaning up session state and waiting for re-login.");
+            } else {
+                log!("Logout in progress; cleaning up session state and waiting for re-login.");
+            }
+            // `is_finished()` skips handles already consumed by the select!
+            // above; awaiting them again would block forever.
             room_list_service_task.abort();
             space_service_task.abort();
-            // Clear the stored client and sync service so re-login starts fresh.
+            for h in &subscriber_task_handles {
+                h.abort();
+            }
+            if !room_list_service_task.is_finished() {
+                let _ = room_list_service_task.await;
+            }
+            if !space_service_task.is_finished() {
+                let _ = space_service_task.await;
+            }
+            for h in subscriber_task_handles.drain(..) {
+                if !h.is_finished() {
+                    let _ = h.await;
+                }
+            }
+            // No-ops if `clear_app_state` already cleared these.
             let _ = CLIENT.lock().unwrap().take();
             let _ = SYNC_SERVICE.lock().unwrap().take();
             continue 'login_loop;
         }
-        // For non-token-related breaks (logout, fatal errors), exit the function.
+        // Unexpected break (e.g. matrix_worker_task panicked).
+        room_list_service_task.abort();
+        space_service_task.abort();
+        for h in &subscriber_task_handles {
+            h.abort();
+        }
+        if !room_list_service_task.is_finished() {
+            let _ = room_list_service_task.await;
+        }
+        if !space_service_task.is_finished() {
+            let _ = space_service_task.await;
+        }
+        for h in subscriber_task_handles.drain(..) {
+            if !h.is_finished() {
+                let _ = h.await;
+            }
+        }
         return;
     }
 }
@@ -3208,7 +3296,9 @@ async fn current_ignore_user_list(client: &Client) -> Option<HashSet<OwnedUserId
     Some(ignored_users)
 }
 
-fn handle_ignore_user_list_subscriber(client: Client) {
+/// This function spawns a task that captures a strong `Client` ref,
+/// so the caller should abort+await it upon logout to ensure the Client gets dropped.
+fn handle_ignore_user_list_subscriber(client: Client) -> JoinHandle<()> {
     let mut subscriber = client.subscribe_to_ignore_user_list_changes();
     log!("Initial ignored-user list is: {:?}", subscriber.get());
     Handle::current().spawn(async move {
@@ -3243,7 +3333,7 @@ fn handle_ignore_user_list_subscriber(client: Client) {
 
             first_update = false;
         }
-    });
+    })
 }
 
 /// Asynchronously loads and restores the app state from persistent storage for the given user.
@@ -3297,7 +3387,7 @@ fn is_invalid_token_error(e: &sync_service::Error) -> bool {
 /// When the homeserver rejects the access token with a 401 `M_UNKNOWN_TOKEN` error
 /// (e.g., the token was revoked or expired), this emits a [`LoginAction::LoginFailure`]
 /// so the user is prompted to log in again.
-fn handle_session_changes(client: Client) {
+fn handle_session_changes(client: Client) -> JoinHandle<()> {
     let mut receiver = client.subscribe_to_session_changes();
     Handle::current().spawn(async move {
         loop {
@@ -3326,10 +3416,10 @@ fn handle_session_changes(client: Client) {
                 }
             }
         }
-    });
+    })
 }
 
-fn handle_sync_service_state_subscriber(mut subscriber: Subscriber<sync_service::State>) {
+fn handle_sync_service_state_subscriber(mut subscriber: Subscriber<sync_service::State>) -> JoinHandle<()> {
     log!("Initial sync service state is {:?}", subscriber.get());
     Handle::current().spawn(async move {
         while let Some(state) = subscriber.next().await {
@@ -3371,20 +3461,21 @@ fn handle_sync_service_state_subscriber(mut subscriber: Subscriber<sync_service:
                 other => Cx::post_action(RoomsListHeaderAction::StateUpdate(other)),
             }
         }
-    });
+    })
 }
 
-fn handle_sync_indicator_subscriber(sync_service: &SyncService) {
+fn handle_sync_indicator_subscriber(sync_service: &SyncService) -> JoinHandle<()> {
     /// Duration for sync indicator delay before showing
     const SYNC_INDICATOR_DELAY: Duration = Duration::from_millis(100);
     /// Duration for sync indicator delay before hiding
     const SYNC_INDICATOR_HIDE_DELAY: Duration = Duration::from_millis(200);
-    let sync_indicator_stream = sync_service.room_list_service()
+    let sync_indicator_stream = sync_service
+        .room_list_service()
         .sync_indicator(
             SYNC_INDICATOR_DELAY,
             SYNC_INDICATOR_HIDE_DELAY
         );
-    
+
     Handle::current().spawn(async move {
        let mut sync_indicator_stream = std::pin::pin!(sync_indicator_stream);
 
@@ -3395,7 +3486,7 @@ fn handle_sync_indicator_subscriber(sync_service: &SyncService) {
             };
             Cx::post_action(RoomsListHeaderAction::SetSyncStatus(is_syncing));
         }
-    });
+    })
 }
 
 fn handle_room_list_service_loading_state(mut loading_state: Subscriber<RoomListLoadingState>) {
@@ -4451,25 +4542,19 @@ impl UserPowerLevels {
 }
 
 
-/// Shuts down the current Tokio runtime completely and takes ownership to ensure proper cleanup.
-pub fn shutdown_background_tasks() {
-    if let Some(runtime) = TOKIO_RUNTIME.lock().unwrap().take() {
-        runtime.shutdown_background();
-    }
-}
-
+/// Drops session state and signals the login loop to wait for re-login.
+/// Keeps `REQUEST_SENDER` alive, and also the `matrix_worker_task
+/// whic needs to keep running to receive the next login request.
 pub async fn clear_app_state(config: &LogoutConfig) -> Result<()> {
-    // Clear resources normally, allowing them to be properly dropped
-    // This prevents memory leaks when users logout and login again without closing the app
     CLIENT.lock().unwrap().take();
     SYNC_SERVICE.lock().unwrap().take();
-    REQUEST_SENDER.lock().unwrap().take();
     IGNORED_USERS.lock().unwrap().clear();
     ALL_JOINED_ROOMS.lock().unwrap().clear();
+    LOGOUT_NOTIFY.notify_one();
 
     let on_clear_appstate = Arc::new(Notify::new());
     Cx::post_action(LogoutAction::ClearAppState { on_clear_appstate: on_clear_appstate.clone() });
-    
+
     match tokio::time::timeout(config.app_state_cleanup_timeout, on_clear_appstate.notified()).await {
         Ok(_) => {
             log!("Received signal that UI-side app state was cleaned successfully");

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -22,10 +22,11 @@ pub enum VerificationStateAction {
     None,
 }
 
-pub fn add_verification_event_handlers_and_sync_client(client: Client) {
+
+pub fn add_verification_event_handlers_and_sync_client(client: Client) -> tokio::task::JoinHandle<()> {
     let mut verification_state_subscriber = client.encryption().verification_state();
     log!("Initial verification state is {:?}", verification_state_subscriber.get());
-    Handle::current().spawn(async move {
+    let verification_state_handle = Handle::current().spawn(async move {
         while let Some(state) = verification_state_subscriber.next().await {
             log!("Received a verification state update: {state:?}");
             Cx::post_action(VerificationStateAction::Update(state));
@@ -70,6 +71,8 @@ pub fn add_verification_event_handlers_and_sync_client(client: Client) {
             }
         }
     );
+
+    verification_state_handle
 }
 
 


### PR DESCRIPTION
iOS apparently has a limit of 256 file descriptors, which is hilariously low and was being hit due to lots of SDK usage of sqlite.

Also fix various login + logout issues on all platforms. Generally things are much more robust & correct when handling a logout.