### PR TITLE
Fix app menu bar properly within Makepad, restore Cmd+Q for quit

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,12 +3,13 @@
 [target.'cfg(all())']
 rustflags = ["--cfg", "ruma_identifiers_storage=\"Arc\""]
 
-## Override the macOS bundle metadata that Makepad's `platform/build.rs` writes
-## next to the binary for unbundled `cargo run` launches. macOS uses CFBundleName
-## from that Info.plist as the application menu bar title, overriding the title
-## set on the first NSMenu submenu — without this, the menu shows
-## "MakepadStdinLoop" instead of "Robrix".
+## Pin the macOS bundle identifier that Makepad's `platform/build.rs` writes
+## next to the binary for unbundled `cargo run` launches, so dev builds share
+## the same identity as proper bundled releases (see `packaging/Info.plist`).
+## Otherwise macOS treats them as separate apps for saved window positions,
+## permission grants, etc. Bundle *name* doesn't need an override — Makepad's
+## default derives "Robrix" from the workspace directory name. `force = true`
+## so IDE/CI wrappers that pre-set the var (often to empty) can't shadow it.
 [env]
-MAKEPAD_BUNDLE_NAME = "Robrix"
-MAKEPAD_BUNDLE_IDENTIFIER = "org.robius.robrix"
+MAKEPAD_BUNDLE_IDENTIFIER = { value = "rs.robius.robrix", force = true }
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,13 +3,7 @@
 [target.'cfg(all())']
 rustflags = ["--cfg", "ruma_identifiers_storage=\"Arc\""]
 
-## Pin the macOS bundle identifier that Makepad's `platform/build.rs` writes
-## next to the binary for unbundled `cargo run` launches, so dev builds share
-## the same identity as proper bundled releases (see `packaging/Info.plist`).
-## Otherwise macOS treats them as separate apps for saved window positions,
-## permission grants, etc. Bundle *name* doesn't need an override — Makepad's
-## default derives "Robrix" from the workspace directory name. `force = true`
-## so IDE/CI wrappers that pre-set the var (often to empty) can't shadow it.
+## Override the bundle/package ID that Makepad uses by default with Robrix's ID.
 [env]
 MAKEPAD_BUNDLE_IDENTIFIER = { value = "rs.robius.robrix", force = true }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "bytes"
@@ -1954,9 +1954,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
 ]
 
 [[package]]
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2958,12 +2958,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3002,15 +3002,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3018,22 +3018,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3047,7 +3047,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "ttf-parser",
 ]
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3080,7 +3080,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3088,12 +3088,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3124,15 +3124,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3154,7 +3154,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3166,12 +3166,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3179,13 +3179,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3202,14 +3202,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3228,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3263,18 +3263,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "simd-adler32",
 ]
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3677,7 +3677,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "mime"
@@ -4430,10 +4430,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
- "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
  "unicase 2.9.0",
 ]
 
@@ -5257,12 +5257,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5357,7 +5357,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "sealed"
@@ -5656,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "siphasher"
@@ -5682,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "socket2"
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "tungstenite"
@@ -6515,7 +6515,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-bidi"
@@ -6526,17 +6526,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-ident"
@@ -6547,7 +6547,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-normalization"
@@ -6567,12 +6567,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6583,7 +6583,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "unicode-width"
@@ -6915,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6937,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6946,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6956,7 +6956,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "log",
  "pkg-config",
@@ -7064,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7116,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7201,7 +7201,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 
 [[package]]
 name = "windows-numerics"
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#e0549dc502ee8dbdb4a35100fd0919f32bf01e40"
+source = "git+https://github.com/kevinaboos/makepad?branch=fix_app_menu_bar#8f8e82db56687a64db831e433ff448d70aa2047a"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "fix_app_menu_bar", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "fix_app_menu_bar" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
@@ -201,7 +204,7 @@ debug-assertions = false
 ## Configuration for `cargo packager`
 [package.metadata.packager]
 product_name = "Robrix"
-identifier = "org.robius.robrix"
+identifier = "rs.robius.robrix"
 category = "SocialNetworking"
 authors = [
     "Project Robius <contact@robius.rs>",

--- a/packaging/Info.plist
+++ b/packaging/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string>Robrix.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.robius.robrix</string>
+	<string>rs.robius.robrix</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -37,7 +37,7 @@
 				<string>matrix</string>
 			</array>
 			<key>CFBundleURLName</key>
-			<string>org.robius.robrix robrix</string>
+			<string>rs.robius.robrix robrix</string>
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 		</dict>

--- a/src/app.rs
+++ b/src/app.rs
@@ -42,17 +42,6 @@ script_mod! {
                     }
                 }
 
-                // Replace Makepad's stock WindowMenu (File/Edit/View/...) with a
-                // minimal Robrix app menu. The first submenu is what macOS shows
-                // as the application menu next to the Apple logo (its title is
-                // taken from CFBundleName — see `.cargo/config.toml`), but the
-                // items inside are what the user actually sees on click.
-                window_menu := WindowMenu {
-                    main := MenuItem.Main{items:[@app_menu]}
-                    app_menu := MenuItem.Sub { name:"Robrix" items:[@quit] }
-                    quit := MenuItem.Item { name:"Quit Robrix" key: KeyCode.KeyQ enabled: true }
-                }
-
                 body +: {
                     // Only TOP is applied here, since top is shared by every screen
                     // and no bar owns it. Bottom/left/right are delegated to whatever

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -61,31 +61,32 @@ script_mod! {
                     font_size: 9.3
                     max_lines: 2
                     text_overflow: Ellipsis
-                    text_style_normal +: { font_size: 9.3 }
-                    text_style_italic +: { font_size: 9.3 }
-                    text_style_bold +: { font_size: 9.3 }
-                    text_style_bold_italic +: { font_size: 9.3 }
-                    text_style_fixed +: { font_size: 9.3 }
-                    // Scale down the pill (title font, avatar size, avatar text)
-                    // by the same factor as the message font (9.3 / 11).
+                    text_style_normal +: { font_size: 9.3, line_spacing: 1.32 }
+                    text_style_italic +: { font_size: 9.3, line_spacing: 1.32 }
+                    text_style_bold +: { font_size: 9.3, line_spacing: 1.32 }
+                    text_style_bold_italic +: { font_size: 9.3, line_spacing: 1.32 }
+                    text_style_fixed +: { font_size: 9.3, line_spacing: 1.32 }
+                    // Scale down the pill (title font, avatar size, avatar text) to fit.
                     a +: {
                         matrix_link_view +: {
                             matrix_link +: {
                                 pill_bg +: {
-                                    draw_bg +: { border_radius: 5.0 }
+                                    margin: Inset{top: 1}
+                                    padding: Inset{ left: 4.5, right: 3.0, bottom: -3.5, top: -3.5 }
+                                    draw_bg +: { border_radius: 4.5 }
                                     avatar +: {
-                                        width: 13.53, height: 13.53,
+                                        width: 13.0, height: 13.0,
                                         text_view +: {
                                             text +: {
                                                 draw_text +: {
-                                                    text_style +: { font_size: 7.61 }
+                                                    text_style +: { font_size: 6 }
                                                 }
                                             }
                                         }
                                     }
                                     title +: {
                                         draw_text +: {
-                                            text_style +: { font_size: 9.3 }
+                                            text_style +: { font_size: 8.5 }
                                         }
                                     }
                                 }
@@ -99,7 +100,7 @@ script_mod! {
                     max_lines: 2
                     text_overflow: Ellipsis
                     draw_text +: {
-                        text_style: theme.font_regular { font_size: 9.3 },
+                        text_style: theme.font_regular { font_size: 9.3, line_spacing: 1.32 },
                     }
                     text: "[No recent messages]"
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub mod utils;
 pub mod temp_storage;
 pub mod location;
 
-pub const APP_QUALIFIER: &str = "org";
+pub const APP_QUALIFIER: &str = "rs";
 pub const APP_ORGANIZATION: &str = "robius";
 pub const APP_NAME: &str = "robrix";
 


### PR DESCRIPTION
Other included fixes:
* Change bundle identifier to "rs.robius.robrix", which is our new chosen ID for both the Apple app store and Google Play store, so we're going for consistency here.
* Fix pill size/styling in rooms list entries so that they don't get cut off on the bottom, or have their top part be partially visible if they wrap to the next line