### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerabilities in state event previews

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix missing HTML escaping in State Event previews
+**Vulnerability:** User-controlled strings inside `AnyOtherStateEventContentChange` variants (room aliases, version, guest access, history visibility, tombstone replacement) were concatenated directly into the HTML without sanitization, leading to a Cross-Site Scripting (XSS) vulnerability.
+**Learning:** Always explicitly check for HTML rendering contexts and use `htmlize::escape_text` before injecting user-provided strings into views. The use of `Cow::Borrowed` paired with `.into()` allows efficient zero-allocation returns for text values that don't need escaping.
+**Prevention:** Developers and reviewers should ensure that all newly added user-facing dynamic fields run through sanitization functions when evaluated in an HTML context.

--- a/src/event_preview.rs
+++ b/src/event_preview.rs
@@ -453,7 +453,12 @@ pub fn text_preview_of_other_state(
             let mut s = String::from("set this room's aliases to ");
             let last_alias = content.aliases.len() - 1;
             for (i, alias) in content.aliases.iter().enumerate() {
-                s.push_str(alias.as_str());
+                let a = if format_as_html {
+                    htmlize::escape_text(alias.as_str()).into()
+                } else {
+                    Cow::Borrowed(alias.as_str())
+                };
+                s.push_str(&a);
                 if i != last_alias {
                     s.push_str(", ");
                 }
@@ -465,12 +470,21 @@ pub fn text_preview_of_other_state(
             Some(String::from("set this room's avatar picture."))
         }
         AnyOtherStateEventContentChange::RoomCanonicalAlias(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("set the main address of this room to {}.",
-                content.alias.as_ref().map(|a| a.as_str()).unwrap_or("none")
-            ))
+            let alias = content.alias.as_ref().map(|a| a.as_str()).unwrap_or("none");
+            let a = if format_as_html {
+                htmlize::escape_text(alias).into()
+            } else {
+                Cow::Borrowed(alias)
+            };
+            Some(format!("set the main address of this room to {}.", a))
         }
         AnyOtherStateEventContentChange::RoomCreate(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("created this room (v{}).", content.room_version.as_str()))
+            let v = if format_as_html {
+                htmlize::escape_text(content.room_version.as_str()).into()
+            } else {
+                Cow::Borrowed(content.room_version.as_str())
+            };
+            Some(format!("created this room (v{}).", v))
         }
         AnyOtherStateEventContentChange::RoomEncryption(_) => {
             Some(String::from("enabled encryption in this room."))
@@ -479,19 +493,31 @@ pub fn text_preview_of_other_state(
             Some(match &content.guest_access {
                 GuestAccess::CanJoin => String::from("has allowed guests to join this room."),
                 GuestAccess::Forbidden => String::from("has forbidden guests from joining this room."),
-                custom => format!("has set custom guest access rules for this room: {}", custom.as_str()),
+                custom => {
+                    let c = if format_as_html {
+                        htmlize::escape_text(custom.as_str()).into()
+                    } else {
+                        Cow::Borrowed(custom.as_str())
+                    };
+                    format!("has set custom guest access rules for this room: {}", c)
+                }
             })
         }
         AnyOtherStateEventContentChange::RoomHistoryVisibility(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("set this room's history to be visible by {}",
-                match &content.history_visibility {
-                    HistoryVisibility::Invited => "invited users, since they were invited.",
-                    HistoryVisibility::Joined => "joined users, since they joined.",
-                    HistoryVisibility::Shared => "joined users, for all of time.",
-                    HistoryVisibility::WorldReadable => "anyone for all time.",
-                    custom => custom.as_str(),
-                },
-            ))
+            let v = match &content.history_visibility {
+                HistoryVisibility::Invited => Cow::Borrowed("invited users, since they were invited."),
+                HistoryVisibility::Joined => Cow::Borrowed("joined users, since they joined."),
+                HistoryVisibility::Shared => Cow::Borrowed("joined users, for all of time."),
+                HistoryVisibility::WorldReadable => Cow::Borrowed("anyone for all time."),
+                custom => {
+                    if format_as_html {
+                        htmlize::escape_text(custom.as_str()).into()
+                    } else {
+                        Cow::Borrowed(custom.as_str())
+                    }
+                }
+            };
+            Some(format!("set this room's history to be visible by {}", v))
         }
         AnyOtherStateEventContentChange::RoomJoinRules(StateEventContentChange::Original { content, .. }) => {
             Some(match &content.join_rule {
@@ -501,7 +527,14 @@ pub fn text_preview_of_other_state(
                 JoinRule::Restricted(_) => String::from("set this room to be joinable by invite only or with restrictions."),
                 JoinRule::KnockRestricted(_) => String::from("set this room to be joinable by invite only or requestable with restrictions."),
                 JoinRule::Invite  => String::from("set this room to be joinable by invite only."),
-                custom => format!("set custom join rules for this room: {}", custom.as_str()),
+                custom => {
+                    let c = if format_as_html {
+                        htmlize::escape_text(custom.as_str()).into()
+                    } else {
+                        Cow::Borrowed(custom.as_str())
+                    };
+                    format!("set custom join rules for this room: {}", c)
+                }
             })
         }
         AnyOtherStateEventContentChange::RoomPinnedEvents(StateEventContentChange::Original { content, .. }) => {
@@ -522,7 +555,13 @@ pub fn text_preview_of_other_state(
             Some(String::from("set the server access control list for this room."))
         }
         AnyOtherStateEventContentChange::RoomTombstone(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("closed this room and upgraded it to {}", content.replacement_room.matrix_to_uri()))
+            let uri = content.replacement_room.matrix_to_uri().to_string();
+            let u = if format_as_html {
+                htmlize::escape_text(&uri).into()
+            } else {
+                Cow::Borrowed(uri.as_str())
+            };
+            Some(format!("closed this room and upgraded it to {}", u))
         }
         AnyOtherStateEventContentChange::RoomTopic(StateEventContentChange::Original { content, .. }) => {
             let topic = if format_as_html {

--- a/src/event_preview.rs
+++ b/src/event_preview.rs
@@ -454,7 +454,7 @@ pub fn text_preview_of_other_state(
             let last_alias = content.aliases.len() - 1;
             for (i, alias) in content.aliases.iter().enumerate() {
                 let a = if format_as_html {
-                    htmlize::escape_text(alias.as_str()).into()
+                    htmlize::escape_text(alias.as_str())
                 } else {
                     Cow::Borrowed(alias.as_str())
                 };
@@ -472,7 +472,7 @@ pub fn text_preview_of_other_state(
         AnyOtherStateEventContentChange::RoomCanonicalAlias(StateEventContentChange::Original { content, .. }) => {
             let alias = content.alias.as_ref().map(|a| a.as_str()).unwrap_or("none");
             let a = if format_as_html {
-                htmlize::escape_text(alias).into()
+                htmlize::escape_text(alias)
             } else {
                 Cow::Borrowed(alias)
             };
@@ -480,7 +480,7 @@ pub fn text_preview_of_other_state(
         }
         AnyOtherStateEventContentChange::RoomCreate(StateEventContentChange::Original { content, .. }) => {
             let v = if format_as_html {
-                htmlize::escape_text(content.room_version.as_str()).into()
+                htmlize::escape_text(content.room_version.as_str())
             } else {
                 Cow::Borrowed(content.room_version.as_str())
             };
@@ -495,7 +495,7 @@ pub fn text_preview_of_other_state(
                 GuestAccess::Forbidden => String::from("has forbidden guests from joining this room."),
                 custom => {
                     let c = if format_as_html {
-                        htmlize::escape_text(custom.as_str()).into()
+                        htmlize::escape_text(custom.as_str())
                     } else {
                         Cow::Borrowed(custom.as_str())
                     };
@@ -511,7 +511,7 @@ pub fn text_preview_of_other_state(
                 HistoryVisibility::WorldReadable => Cow::Borrowed("anyone for all time."),
                 custom => {
                     if format_as_html {
-                        htmlize::escape_text(custom.as_str()).into()
+                        htmlize::escape_text(custom.as_str())
                     } else {
                         Cow::Borrowed(custom.as_str())
                     }
@@ -529,7 +529,7 @@ pub fn text_preview_of_other_state(
                 JoinRule::Invite  => String::from("set this room to be joinable by invite only."),
                 custom => {
                     let c = if format_as_html {
-                        htmlize::escape_text(custom.as_str()).into()
+                        htmlize::escape_text(custom.as_str())
                     } else {
                         Cow::Borrowed(custom.as_str())
                     };
@@ -557,7 +557,7 @@ pub fn text_preview_of_other_state(
         AnyOtherStateEventContentChange::RoomTombstone(StateEventContentChange::Original { content, .. }) => {
             let uri = content.replacement_room.matrix_to_uri().to_string();
             let u = if format_as_html {
-                htmlize::escape_text(&uri).into()
+                htmlize::escape_text(&uri)
             } else {
                 Cow::Borrowed(uri.as_str())
             };


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-controlled fields within `AnyOtherStateEventContentChange` (such as room aliases, room versions, custom guest access and history visibility rules, and tombstone replacement URIs) were being concatenated directly into HTML previews without being sanitized. This could allow an attacker to inject arbitrary HTML into the preview rendering of timeline events if a malicious payload was set.
🎯 Impact: Exploitation could lead to Cross-Site Scripting (XSS) allowing a malicious actor to inject code or break the UI layout when viewing compromised state events.
🔧 Fix: Wrapped the extraction logic for user-provided fields in `text_preview_of_other_state` with `htmlize::escape_text` when formatting as HTML. Used zero-allocation `Cow::Borrowed` when escaping is not needed.
✅ Verification: Ran `cargo check` and `cargo test --lib` to ensure the program compiles cleanly and all unit tests pass without regressions.

---
*PR created automatically by Jules for task [1905180717600848654](https://jules.google.com/task/1905180717600848654) started by @kevinaboos*