### PR TITLE
Support arbitrary UI zoom at runtime via DPI factor override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "bytes"
@@ -1954,9 +1954,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
 ]
 
 [[package]]
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2958,12 +2958,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3002,15 +3002,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3018,22 +3018,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3047,7 +3047,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "ttf-parser",
 ]
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3064,7 +3064,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3080,7 +3080,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3088,12 +3088,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3124,15 +3124,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3154,7 +3154,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3166,12 +3166,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3179,13 +3179,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3193,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3202,14 +3202,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3228,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3254,7 +3254,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3263,18 +3263,18 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "simd-adler32",
 ]
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3290,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3677,7 +3677,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "mime"
@@ -4430,10 +4430,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
- "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
  "unicase 2.9.0",
 ]
 
@@ -5257,12 +5257,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5357,7 +5357,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "sealed"
@@ -5656,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "siphasher"
@@ -5682,7 +5682,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "socket2"
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "tungstenite"
@@ -6515,7 +6515,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-bidi"
@@ -6526,17 +6526,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-ident"
@@ -6547,7 +6547,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-normalization"
@@ -6567,12 +6567,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6583,7 +6583,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "unicode-width"
@@ -6915,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -6937,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -6946,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -6956,7 +6956,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "log",
  "pkg-config",
@@ -7064,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7083,7 +7083,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7116,7 +7116,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7201,7 +7201,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 
 [[package]]
 name = "windows-numerics"
@@ -7245,7 +7245,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#9df7c778f3081381bd6ba9cff991f49a93ac4a8d"
+source = "git+https://github.com/kevinaboos/makepad?branch=runtime_dpi_override#da62750524402e4fadc25a8c15b14f09e4c95cce"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "runtime_dpi_override", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "runtime_dpi_override" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::{
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
     }, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
-    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::AppPreferences, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
+    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
         VerificationModalAction,
         VerificationModalWidgetRefExt,
     }
@@ -218,6 +218,9 @@ impl MatchEvent for App {
         if let Err(e) = persistence::load_window_state(self.ui.window(cx, ids!(main_window)), cx) {
             error!("Failed to load window state: {}", e);
         }
+
+        #[cfg(target_os = "macos")]
+        self.install_macos_menu(cx);
 
         self.update_login_visibility(cx);
 
@@ -659,18 +662,13 @@ impl AppMain for App {
     }
 
     fn handle_event(&mut self, cx: &mut Cx, event: &Event) {
-        // On a file-driven hot-reload (`Event::LiveEdit`), Makepad re-runs
-        // `script_mod!` which reasserts source-defined defaults (e.g.
-        // `mod.widgets.IMG_MSG_FIT = Fit{max: FitBound.Abs(200.0)}`). That
-        // wipes runtime preference overrides we pushed into the heap via
-        // `script_eval!`. Re-broadcast the current preferences so those
-        // overrides are re-established; the `request_script_reapply` inside
-        // `broadcast_all` triggers a follow-up `Event::ScriptReapply` pass
-        // (handled inside the same `run_live_edit_if_needed` tick) so
-        // widgets pick the overrides up. `Event::ScriptReapply` itself must
-        // NOT trigger another broadcast — that would loop.
         if let Event::LiveEdit = event {
             self.app_state.app_prefs.broadcast_all(cx);
+        }
+
+        self.handle_ui_zoom_shortcuts(cx, event);
+        if let Event::MacosMenuCommand(command) = event {
+            self.handle_ui_zoom_menu_command(cx, *command);
         }
 
         // Forward events to the MatchEvent trait implementation.
@@ -683,6 +681,91 @@ impl AppMain for App {
 }
 
 impl App {
+    fn apply_ui_zoom(&mut self, cx: &mut Cx, new_zoom: UiZoom) {
+        if new_zoom != self.app_state.app_prefs.ui_zoom {
+            self.app_state.app_prefs.ui_zoom = new_zoom;
+            self.app_state.app_prefs.on_ui_zoom_changed(cx);
+        }
+    }
+
+    fn handle_ui_zoom_shortcuts(&mut self, cx: &mut Cx, event: &Event) {
+        let Event::KeyDown(e) = event else { return };
+        if !e.modifiers.is_primary() {
+            return;
+        }
+        let current = self.app_state.app_prefs.ui_zoom;
+        let new_zoom = match e.key_code {
+            KeyCode::Equals | KeyCode::NumpadEquals | KeyCode::NumpadAdd => {
+                current.zoom_in_by(UiZoom::STEP)
+            }
+            KeyCode::Minus | KeyCode::NumpadSubtract => current.zoom_out_by(UiZoom::STEP),
+            KeyCode::Key0 | KeyCode::Numpad0 => UiZoom::reset(),
+            _ => return,
+        };
+        self.apply_ui_zoom(cx, new_zoom);
+    }
+
+    /// Set up the menu bar entries, currently macOS-only.
+    #[cfg(target_os = "macos")]
+    fn install_macos_menu(&self, cx: &mut Cx) {
+        cx.update_macos_menu(MacosMenu::Main {
+            items: vec![
+                MacosMenu::Sub {
+                    name: "Robrix".into(),
+                    items: vec![MacosMenu::Item {
+                        name: "Quit Robrix".into(),
+                        command: live_id!(quit),
+                        key: KeyCode::KeyQ,
+                        shift: false,
+                        enabled: true,
+                    }],
+                },
+                MacosMenu::Sub {
+                    name: "View".into(),
+                    items: vec![
+                        MacosMenu::Item {
+                            name: "Zoom In".into(),
+                            command: live_id!(zoom_in),
+                            key: KeyCode::Equals,
+                            shift: true,
+                            enabled: true,
+                        },
+                        MacosMenu::Item {
+                            name: "Zoom Out".into(),
+                            command: live_id!(zoom_out),
+                            key: KeyCode::Minus,
+                            shift: false,
+                            enabled: true,
+                        },
+                        MacosMenu::Line,
+                        MacosMenu::Item {
+                            name: "Reset Zoom".into(),
+                            command: live_id!(reset_zoom),
+                            key: KeyCode::Key0,
+                            shift: false,
+                            enabled: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    /// Connects `MacosMenuCommand`s to the existing zoom shortcut handlers.
+    fn handle_ui_zoom_menu_command(&mut self, cx: &mut Cx, command: LiveId) {
+        let current = self.app_state.app_prefs.ui_zoom;
+        let new_zoom = if command == live_id!(zoom_in) {
+            current.zoom_in_by(UiZoom::STEP)
+        } else if command == live_id!(zoom_out) {
+            current.zoom_out_by(UiZoom::STEP)
+        } else if command == live_id!(reset_zoom) {
+            UiZoom::reset()
+        } else {
+            return;
+        };
+        self.apply_ui_zoom(cx, new_zoom);
+    }
+
     fn handle_lifecycle_event(&mut self, cx: &mut Cx, event: &Event) {
         match event {
             Event::QuitRequested(e) => {

--- a/src/settings/app_preferences.rs
+++ b/src/settings/app_preferences.rs
@@ -4,7 +4,7 @@ use makepad_widgets::*;
 use serde::{Deserialize, Serialize};
 
 /// App-wide user preferences controlled by the App Settings UI.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AppPreferences {
     /// Forces the HomeScreen `AdaptiveView` into a particular layout,
     /// or falls back to the default automatic width-based layout.
@@ -18,6 +18,9 @@ pub struct AppPreferences {
     /// Max height of image thumbnails in the room timeline.
     #[serde(default)]
     pub thumbnail_max_height: ThumbnailMaxHeight,
+    /// UI-wide zoom level, which scaled the entire UI (not just text).
+    #[serde(default)]
+    pub ui_zoom: UiZoom,
 
     // Note: if you add a new preference here, be sure to add a new
     // function `on_<NEW_PREFERENCE>_changed` and update `broadcast_all()`.
@@ -29,6 +32,7 @@ impl Default for AppPreferences {
             view_mode: ViewModeOverride::default(),
             send_on_enter: true,
             thumbnail_max_height: ThumbnailMaxHeight::default(),
+            ui_zoom: UiZoom::default(),
         }
     }
 }
@@ -95,9 +99,24 @@ impl AppPreferences {
         cx.request_script_reapply();
     }
 
+    /// Applies the current `ui_zoom` value by overriding the window's dpi factor.
+    pub fn on_ui_zoom_changed(&self, cx: &mut Cx) {
+        cx.global::<AppPreferencesGlobal>().0.ui_zoom = self.ui_zoom;
+        let window_id = CxWindowPool::id_zero();
+        let dpi_override = if self.ui_zoom.is_default() {
+            None
+        } else {
+            let window = &cx.windows[window_id];
+            let baseline = window.os_dpi_factor.unwrap_or(window.window_geom.dpi_factor);
+            Some(baseline * self.ui_zoom.multiplier())
+        };
+        cx.set_window_dpi_override(window_id, dpi_override);
+        cx.action(AppPreferencesAction::UiZoomChanged(self.ui_zoom));
+    }
+
     /// Broadcasts every preference to listening widgets.
     ///
-    /// Used at app-state restore so every listener picks up the loaded
+    /// Used upon app-state restore so every listener picks up the loaded
     /// values without having to poll `AppState` every draw, and also
     /// after every `Event::LiveEdit` so a hot-reloaded `script_mod!` block
     /// doesn't clobber our runtime heap overrides.
@@ -105,6 +124,7 @@ impl AppPreferences {
         self.on_view_mode_changed(cx);
         self.on_send_on_enter_changed(cx);
         self.on_thumbnail_max_height_changed(cx);
+        self.on_ui_zoom_changed(cx);
     }
 }
 
@@ -181,6 +201,63 @@ impl ThumbnailMaxHeight {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UiZoom(pub f32);
+
+impl UiZoom {
+    pub const MIN: f32 = 0.25;
+    pub const MAX: f32 = 3.00;
+    pub const DEFAULT: f32 = 1.00;
+
+    /// Step size for keyboard shortcuts.
+    pub const STEP: f32 = 0.02;
+    /// Step size for the app settings +/- buttons.
+    pub const BUTTON_STEP: f32 = 0.05;
+
+    /// Create a new zoom value that is properly clamped.
+    pub fn new(value: f32) -> Self {
+        let v = if value.is_finite() { value } else { Self::DEFAULT };
+        Self(v.clamp(Self::MIN, Self::MAX))
+    }
+
+    pub fn multiplier(self) -> f64 {
+        self.0 as f64
+    }
+
+    /// Returns whether this zoom value is within 0.01 of the default 100%.
+    pub fn is_default(self) -> bool {
+        (self.0 - Self::DEFAULT).abs() < 0.01
+    }
+
+    pub fn zoom_in_by(self, delta: f32) -> Self {
+        Self::new(self.0 + delta)
+    }
+
+    pub fn zoom_out_by(self, delta: f32) -> Self {
+        Self::new(self.0 - delta)
+    }
+
+    pub fn reset() -> Self {
+        Self(Self::DEFAULT)
+    }
+
+    pub fn format_percent(self) -> String {
+        let pct = self.0 * 100.0;
+        let rounded = pct.round();
+        if (pct - rounded).abs() < 0.05 {
+            format!("{}%", rounded as i32)
+        } else {
+            format!("{:.1}%", pct)
+        }
+    }
+}
+
+impl Default for UiZoom {
+    fn default() -> Self {
+        Self(Self::DEFAULT)
+    }
+}
+
 /// Actions emitted when an app-wide preference changes so other parts of the
 /// app can react.
 ///
@@ -192,6 +269,7 @@ impl ThumbnailMaxHeight {
 pub enum AppPreferencesAction {
     ViewModeChanged(ViewModeOverride),
     SendOnEnterChanged(bool),
+    UiZoomChanged(UiZoom),
 }
 
 /// A `Cx` global mirror of the current [`AppPreferences`].

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -4,7 +4,7 @@ use makepad_widgets::*;
 
 use crate::{
     app::AppState,
-    settings::app_preferences::{AppPreferences, AppPreferencesGlobal, ThumbnailMaxHeight, ViewModeOverride},
+    settings::app_preferences::{AppPreferences, AppPreferencesAction, AppPreferencesGlobal, ThumbnailMaxHeight, UiZoom, ViewModeOverride},
     shared::popup_list::{enqueue_popup_notification, PopupKind},
 };
 
@@ -14,9 +14,14 @@ const SEND_SHORTCUT_TOGGLE_LABEL: &str = "Send with Cmd⌘ + Enter";
 const SEND_SHORTCUT_TOGGLE_LABEL: &str = "Send with Ctrl + Enter";
 
 #[cfg(target_os = "macos")]
-const SEND_SHORTCUT_DESC_CMD: &str = "Current choice: 'Cmd⌘ + Enter' to send, 'Enter' for a new line";
+const SEND_SHORTCUT_DESC_CMD: &str = "Currently: 'Cmd⌘ + Enter' to send, 'Enter' for a new line";
 #[cfg(not(target_os = "macos"))]
-const SEND_SHORTCUT_DESC_CMD: &str = "Current choice: 'Ctrl + Enter' to send, 'Enter' for a new line";
+const SEND_SHORTCUT_DESC_CMD: &str = "Currently: 'Ctrl + Enter' to send, 'Enter' for a new line";
+
+#[cfg(target_os = "macos")]
+const UI_ZOOM_DESCRIPTION: &str = "Scales the entire UI uniformly.\n'Cmd⌘ + +/-' zooms in or out, 'Cmd⌘ + 0' resets zoom";
+#[cfg(not(target_os = "macos"))]
+const UI_ZOOM_DESCRIPTION: &str = "Scales the entire UI uniformly.\n'Ctrl + +/-' zooms in or out, 'Ctrl + 0' resets zoom.";
 
 
 script_mod! {
@@ -220,6 +225,60 @@ script_mod! {
         }
 
 
+        View {
+            width: Fill, height: Fit
+            flow: Right{wrap: true}
+            align: Align{y: 0.5}
+            spacing: 6
+
+            SubsectionLabel {
+                width: Fit,
+                margin: Inset{top: 4, right: 4}
+                text: "UI Zoom Level:"
+            }
+
+            ui_zoom_controls := View {
+                width: Fit
+                height: Fit
+                flow: Right,
+                margin: Inset {top: 8}
+                align: Align{y: 0.5}
+                spacing: 4
+
+                ui_zoom_minus_button := RobrixNeutralIconButton {
+                    width: 28, height: 28,
+                    padding: 0
+                    align: Align{x: 0.5, y: 0.5}
+                    draw_text +: {
+                        text_style: mod.widgets.SETTINGS_REGULAR_TEXT_STYLE { font_size: 14 },
+                    }
+                    text: "-"
+                }
+
+                ui_zoom_input := RobrixTextInput {
+                    width: 60, height: Fit
+                    align: Align {y: 0.5}
+                    padding: Inset{left: 8, right: 8, top: 5, bottom: 5}
+                    empty_text: "100%"
+                }
+
+                ui_zoom_plus_button := RobrixNeutralIconButton {
+                    width: 28, height: 28,
+                    padding: 0
+                    align: Align{x: 0.5, y: 0.5}
+                    draw_text +: {
+                        text_style: mod.widgets.SETTINGS_REGULAR_TEXT_STYLE { font_size: 14 },
+                    }
+                    text: "+"
+                }
+            }
+        }
+
+        ui_zoom_description := mod.widgets.SettingsSectionDescription {
+            text: "" // see UI_ZOOM_DESCRIPTION
+        }
+
+
         SubsectionLabel {
             text: "Send Message Keyboard Shortcut"
         }
@@ -272,10 +331,7 @@ script_mod! {
                     text: "Custom:"
                 }
 
-                // Starts read-only so it's inert before populate() runs with
-                // the user's actual preference. populate() and the radio
-                // handler then toggle editability based on whether the
-                // "Custom" radio is selected.
+                // Read-only by default, enabled when `thumb_custom_radio` is selected.
                 thumb_custom_input := RobrixTextInput {
                     width: 60, height: Fit
                     padding: Inset{left: 8, right: 8, top: 5, bottom: 5}
@@ -359,6 +415,60 @@ impl AppSettings {
                     PopupKind::Success,
                     Some(3.0),
                 );
+            }
+        }
+
+        let ui_zoom_minus = self.view.button(cx, ids!(ui_zoom_minus_button));
+        let ui_zoom_plus = self.view.button(cx, ids!(ui_zoom_plus_button));
+        let ui_zoom_input = self.view.text_input(cx, ids!(ui_zoom_input));
+
+        if ui_zoom_minus.clicked(actions) {
+            let new_zoom = app_state.app_prefs.ui_zoom.zoom_out_by(UiZoom::BUTTON_STEP);
+            if new_zoom != app_state.app_prefs.ui_zoom {
+                app_state.app_prefs.ui_zoom = new_zoom;
+                app_state.app_prefs.on_ui_zoom_changed(cx);
+            }
+        }
+
+        if ui_zoom_plus.clicked(actions) {
+            let new_zoom = app_state.app_prefs.ui_zoom.zoom_in_by(UiZoom::BUTTON_STEP);
+            if new_zoom != app_state.app_prefs.ui_zoom {
+                app_state.app_prefs.ui_zoom = new_zoom;
+                app_state.app_prefs.on_ui_zoom_changed(cx);
+            }
+        }
+
+        if ui_zoom_input.returned(actions).is_some() || ui_zoom_input.key_focus_lost(actions) {
+            let text = ui_zoom_input.text();
+            match parse_zoom_percent(&text) {
+                Some(multiplier) => {
+                    let new_zoom = UiZoom::new(multiplier);
+                    if new_zoom != app_state.app_prefs.ui_zoom {
+                        app_state.app_prefs.ui_zoom = new_zoom;
+                        app_state.app_prefs.on_ui_zoom_changed(cx);
+                    } else {
+                        ui_zoom_input.set_text(cx, &new_zoom.format_percent());
+                    }
+                }
+                None if !text.trim().is_empty() => {
+                    enqueue_popup_notification(
+                        "UI zoom must be a positive percentage, like 100 or 125%.",
+                        PopupKind::Error,
+                        Some(4.0),
+                    );
+                    ui_zoom_input.set_text(cx, &app_state.app_prefs.ui_zoom.format_percent());
+                }
+                None => { }
+            }
+        }
+
+        for action in actions {
+            if let Some(AppPreferencesAction::UiZoomChanged(new_zoom)) = action.downcast_ref() {
+                let new_zoom = *new_zoom;
+                if new_zoom != app_state.app_prefs.ui_zoom {
+                    app_state.app_prefs.ui_zoom = new_zoom;
+                }
+                ui_zoom_input.set_text(cx, &new_zoom.format_percent());
             }
         }
 
@@ -493,6 +603,11 @@ impl AppSettings {
         view.drop_down(cx, ids!(view_mode_dropdown))
             .set_selected_item(cx, prefs.view_mode.to_index());
 
+        view.text_input(cx, ids!(ui_zoom_input))
+            .set_text(cx, &prefs.ui_zoom.format_percent());
+        view.label(cx, ids!(ui_zoom_description))
+            .set_text(cx, UI_ZOOM_DESCRIPTION);
+
         view.check_box(cx, ids!(send_on_cmd_enter_toggle))
             .set_text(SEND_SHORTCUT_TOGGLE_LABEL);
         Self::update_send_shortcut_description(cx, view, prefs.send_on_enter);
@@ -549,4 +664,17 @@ fn parse_custom_thumb_height(text: &str) -> Option<u32> {
         return None;
     }
     trimmed.parse::<u32>().ok().filter(|v| *v > 0)
+}
+
+fn parse_zoom_percent(text: &str) -> Option<f32> {
+    let trimmed = text.trim().trim_end_matches('%').trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let percent = trimmed.parse::<f32>().ok()?;
+    if percent.is_finite() && percent > 0.0 {
+        Some(percent / 100.0)
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
* Add a UI zoom setting to the app settings screen
* New `UiZoom` preference, valid from 25% - 300%, defaults to 100%, which uses our new runtime-settable Makepad DPI factor override functions in `Cx`