### PR TITLE
🎨 Palette: Added tooltips to RoomInputBar buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-12 - Adding Tooltips to Icon-only Makepad Buttons
+**Learning:** Tooltips for icon-only buttons like `RobrixIconButton` variants can be added by manually intercepting `Hit::FingerHoverIn` and `Hit::FingerHoverOut` in the parent view's `handle_event`, and dispatching `TooltipAction::HoverIn` / `HoverOut` actions to the UI context.
+**Action:** When creating or modifying standalone icon buttons that lack built-in tooltip props, handle their hover area bounds manually using `cx.widget_action` with `CalloutTooltipOptions` to ensure accessibility.

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -215,6 +215,46 @@ impl Widget for RoomInputBar {
             _ => {}
         }
 
+        match event.hits(cx, self.view.button(cx, ids!(location_button)).area()) {
+            Hit::FingerHoverIn(_) => {
+                cx.widget_action(
+                    self.widget_uid(),
+                    TooltipAction::HoverIn {
+                        widget_rect: self.view.button(cx, ids!(location_button)).area().rect(cx),
+                        text: "Share location".to_string(),
+                        options: CalloutTooltipOptions {
+                            position: TooltipPosition::Top,
+                            ..Default::default()
+                        },
+                    },
+                );
+            }
+            Hit::FingerHoverOut(_) => {
+                cx.widget_action(self.widget_uid(), TooltipAction::HoverOut);
+            }
+            _ => {}
+        }
+
+        match event.hits(cx, self.view.button(cx, ids!(send_message_button)).area()) {
+            Hit::FingerHoverIn(_) => {
+                cx.widget_action(
+                    self.widget_uid(),
+                    TooltipAction::HoverIn {
+                        widget_rect: self.view.button(cx, ids!(send_message_button)).area().rect(cx),
+                        text: "Send message".to_string(),
+                        options: CalloutTooltipOptions {
+                            position: TooltipPosition::Top,
+                            ..Default::default()
+                        },
+                    },
+                );
+            }
+            Hit::FingerHoverOut(_) => {
+                cx.widget_action(self.widget_uid(), TooltipAction::HoverOut);
+            }
+            _ => {}
+        }
+
         if let Event::Actions(actions) = event {
             // Handle changes to the `send_on_enter` preference.
             for action in actions {


### PR DESCRIPTION
💡 What: Added tooltips to the "Share location" and "Send message" buttons in the room input bar.
🎯 Why: These are icon-only buttons (`RobrixPositiveIconButton` and `RobrixIconButton`), so adding a tooltip makes it clearer what they do, improving the interface's usability.
♿ Accessibility: Provides a text label when hovering over icon-only actions.

---
*PR created automatically by Jules for task [2632404869697377733](https://jules.google.com/task/2632404869697377733) started by @kevinaboos*