### PR TITLE
Minor fixes: retain focus when pressing show/hide password button

### DIFF
--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -358,6 +358,7 @@ impl MatchEvent for LoginScreen {
             password_input.toggle_is_password(cx);
             show_pw_button.set_visible(cx, !self.password_visible);
             hide_pw_button.set_visible(cx, self.password_visible);
+            password_input.set_key_focus(cx);
             self.redraw(cx);
         }
 

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2639,14 +2639,6 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
                                 log!("matrix worker task ended with error due to logout: {e:?}");
                             } else {
                                 error!("Error: matrix worker task ended:\n\t{e:?}");
-                                rooms_list::enqueue_rooms_list_update(RoomsListUpdate::Status {
-                                    status: e.to_string(),
-                                });
-                                enqueue_popup_notification(
-                                    format!("Rooms list update error: {e}"),
-                                    PopupKind::Error,
-                                    None,
-                                );
                             }
                         },
                         Err(e) => {


### PR DESCRIPTION
in the login screen, that is.

Also, don't surface background task errors (in the matrix worker task, for example) to the user, since they're meaningless to a non-technical user and also occur frequently during the app lifecycle process of being paused/killed/resumed by the system.