### PR TITLE
Update Makepad to get our fixes to TextInput keyboard nav

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "bitmaps"
@@ -734,7 +734,7 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "byteorder"
@@ -745,7 +745,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "byteorder-lite"
@@ -1756,7 +1756,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
- "simd-adler32 0.3.9",
+ "simd-adler32 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1975,9 +1975,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
 ]
 
 [[package]]
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2994,12 +2994,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3039,15 +3039,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3055,22 +3055,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "weezl",
 ]
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3092,7 +3092,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "ttf-parser",
 ]
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3117,7 +3117,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3133,12 +3133,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3169,15 +3169,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3199,7 +3199,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3211,12 +3211,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3224,13 +3224,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3247,14 +3247,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3308,34 +3308,34 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "makepad-zune-inflate"
-version = "0.2.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+version = "0.2.54"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
- "simd-adler32 0.3.8",
+ "simd-adler32 0.3.9 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
 ]
 
 [[package]]
 name = "makepad-zune-jpeg"
-version = "0.5.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+version = "0.5.15"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-zune-core",
 ]
 
 [[package]]
 name = "makepad-zune-png"
-version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+version = "0.5.2"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3722,7 +3722,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "mime"
@@ -3759,7 +3759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32 0.3.9",
+ "simd-adler32 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4539,10 +4539,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
- "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
  "unicase 2.9.0",
 ]
 
@@ -5429,12 +5429,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
- "bytemuck 1.25.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
+ "bytemuck 1.25.0 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5529,7 +5529,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "sealed"
@@ -5827,14 +5827,14 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "siphasher"
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "socket2"
@@ -6641,7 +6641,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "tungstenite"
@@ -6693,7 +6693,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-bidi"
@@ -6704,17 +6704,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-ident"
@@ -6725,7 +6725,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-normalization"
@@ -6745,12 +6745,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6761,7 +6761,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "unicode-width"
@@ -7093,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7124,7 +7124,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "log",
  "pkg-config",
@@ -7194,7 +7194,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "whoami"
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7299,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7384,7 +7384,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 
 [[package]]
 name = "windows-numerics"
@@ -7428,7 +7428,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#46ee22634c9848eafa010e9a80a093521688c88b"
+source = "git+https://github.com/kevinaboos/makepad?branch=text_input_kbd_nav#04953c4d8cea0986bf6dcd83d8fbcb413b4dcc4f"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ version = "1.0.0-alpha.1"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "text_input_kbd_nav", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "text_input_kbd_nav" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/settings/about_settings.rs
+++ b/src/settings/about_settings.rs
@@ -3,13 +3,12 @@
 //! Shows the app version and a set of external links (e.g., privacy policy).
 
 use makepad_widgets::*;
-
 use crate::shared::popup_list::{enqueue_popup_notification, PopupKind};
 
-const PRIVACY_POLICY_URL: &str = "https://robrix.app/privacy/";
 const HOMEPAGE_URL: &str = "https://robrix.app";
+const PRIVACY_POLICY_URL: &str = "https://robrix.app/privacy/";
 const SOURCE_URL: &str = "https://github.com/project-robius/robrix";
-const ISSUES_URL: &str = "https://github.com/project-robius/robrix/issues";
+const NEW_ISSUE_URL: &str = "https://github.com/project-robius/robrix/issues/new";
 
 const ROBRIX_VERSION: &str = env!("CARGO_PKG_VERSION");
 const ROBRIX_GIT_COMMIT_HASH: &str = env!("ROBRIX_GIT_COMMIT_HASH");
@@ -220,7 +219,7 @@ impl AboutSettings {
             open_url(SOURCE_URL);
         }
         if self.view.button(cx, ids!(issues_button)).clicked(actions) {
-            open_url(ISSUES_URL);
+            open_url(NEW_ISSUE_URL);
         }
     }
 


### PR DESCRIPTION
now it supports all the Home/End and keyboard modifier combos you'd expect. See <https://github.com/makepad/makepad/pull/1101> for more.

Closes #892