### PR TITLE
Support hardware keyboards, improve virtual kbd behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "bitmaps"
@@ -734,7 +734,7 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "byteorder"
@@ -745,7 +745,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "byteorder-lite"
@@ -1975,9 +1975,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
 ]
 
 [[package]]
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2994,12 +2994,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3039,15 +3039,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3055,22 +3055,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "weezl",
 ]
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3092,7 +3092,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "ttf-parser",
 ]
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3117,7 +3117,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3125,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3133,12 +3133,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3169,15 +3169,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3199,7 +3199,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3211,12 +3211,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3224,13 +3224,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3247,14 +3247,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3264,7 +3264,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3308,26 +3308,26 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
- "simd-adler32 0.3.9 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "simd-adler32 0.3.9 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
 ]
 
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3722,7 +3722,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "mime"
@@ -4539,10 +4539,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
  "unicase 2.9.0",
 ]
 
@@ -5429,12 +5429,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
- "bytemuck 1.25.0 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "bytemuck 1.25.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5529,7 +5529,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "sealed"
@@ -5834,7 +5834,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "siphasher"
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "socket2"
@@ -6641,7 +6641,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "tungstenite"
@@ -6693,7 +6693,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-bidi"
@@ -6704,17 +6704,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-ident"
@@ -6725,7 +6725,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-normalization"
@@ -6745,12 +6745,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6761,7 +6761,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "unicode-width"
@@ -7093,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7124,7 +7124,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7134,7 +7134,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "log",
  "pkg-config",
@@ -7194,7 +7194,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "whoami"
@@ -7247,7 +7247,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7299,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7384,7 +7384,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 
 [[package]]
 name = "windows-numerics"
@@ -7428,7 +7428,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=iamge_fit_improvements#81385eaf6b377291af93a36be3cf29f2d734fb6f"
+source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "iamge_fit_improvements", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "iamge_fit_improvements" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "hardware_keyboard", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "hardware_keyboard" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/settings/app_preferences.rs
+++ b/src/settings/app_preferences.rs
@@ -11,8 +11,9 @@ pub struct AppPreferences {
     #[serde(default)]
     pub view_mode: ViewModeOverride,
     /// * If `true` (default), plain Enter sends the message (Shift+Enter inserts a newline).
-    /// * If `false`, Cmd+Enter (macOS) / Ctrl+Enter (other platforms) sends the
+    /// * If `false`, Cmd+Enter (Apple platforms) / Ctrl+Enter (other platforms) sends the
     ///   message and plain Enter inserts a newline.
+    /// Only applies with a physical keyboard; on a soft keyboard Enter always inserts a newline.
     #[serde(default)]
     pub send_on_enter: bool,
     /// Max height of image thumbnails in the room timeline.

--- a/src/settings/app_preferences.rs
+++ b/src/settings/app_preferences.rs
@@ -12,8 +12,8 @@ pub struct AppPreferences {
     pub view_mode: ViewModeOverride,
     /// * If `true` (default), plain Enter sends the message (Shift+Enter inserts a newline).
     /// * If `false`, Cmd+Enter (Apple platforms) / Ctrl+Enter (other platforms) sends the
-    ///   message and plain Enter inserts a newline.
-    /// Only applies with a physical keyboard; on a soft keyboard Enter always inserts a newline.
+    ///   message and plain Enter inserts a newline. This is only relevant for physical keyboards;
+    ///   virtual/soft keyboards always insert a newline upon Enter.
     #[serde(default)]
     pub send_on_enter: bool,
     /// Max height of image thumbnails in the room timeline.

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -8,19 +8,19 @@ use crate::{
     shared::popup_list::{enqueue_popup_notification, PopupKind},
 };
 
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 const SEND_SHORTCUT_TOGGLE_LABEL: &str = "Send with Cmd⌘ + Enter";
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(target_vendor = "apple"))]
 const SEND_SHORTCUT_TOGGLE_LABEL: &str = "Send with Ctrl + Enter";
 
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 const SEND_SHORTCUT_DESC_CMD: &str = "Currently: 'Cmd⌘ + Enter' to send, 'Enter' for a new line";
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(target_vendor = "apple"))]
 const SEND_SHORTCUT_DESC_CMD: &str = "Currently: 'Ctrl + Enter' to send, 'Enter' for a new line";
 
-#[cfg(target_os = "macos")]
+#[cfg(target_vendor = "apple")]
 const UI_ZOOM_DESCRIPTION: &str = "Scales the entire UI uniformly.\n'Cmd⌘ + +/-' zooms in or out, 'Cmd⌘ + 0' resets zoom";
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(target_vendor = "apple"))]
 const UI_ZOOM_DESCRIPTION: &str = "Scales the entire UI uniformly.\n'Ctrl + +/-' zooms in or out, 'Ctrl + 0' resets zoom.";
 
 
@@ -280,11 +280,11 @@ script_mod! {
 
 
         SubsectionLabel {
-            text: "Send Message Keyboard Shortcut"
+            text: "Keyboard Shortcut to Send Message"
         }
 
         send_on_cmd_enter_toggle := ToggleFlat {
-            margin: Inset{left: 6.5, top: 5, bottom: 5}
+            margin: Inset{left: 6.5, top: 5, bottom: 6}
             padding: Inset { left: 15}
             active: false,
             draw_bg +: { size: 21 }
@@ -298,6 +298,11 @@ script_mod! {
             text: "Current setting: \"Enter\" to send, \"Shift + Enter\" for a new line"
         }
 
+        send_shortcut_soft_keyboard_warning := mod.widgets.SettingsSectionDescription {
+            visible: false // shown only on iOS/Android, see `populate_safe()``
+            draw_text +: { color: (COLOR_TEXT_WARNING_NOT_FOUND) }
+            text: "Note: this only applies to physical (hardware) keyboards."
+        }
 
         SubsectionLabel {
             text: "Maximum Height of Thumbnails"
@@ -595,10 +600,9 @@ impl AppSettings {
         self.view.text_input(cx, ids!(thumb_custom_input)).set_text(cx, &custom_text);
     }
 
-    /// Restores the code-set fields the apply walk just reset to DSL defaults:
-    /// toggle label, description, dropdown index, custom-input read-only flag.
-    /// None of these go through `cx.with_vm`, so it's safe to call from
-    /// `on_after_apply`. Doing it inline is what prevents the one-frame flicker.
+    /// Re-populated fields set by code, for use after an apply action reset things to DSL defaults.
+    ///
+    /// This is safe to call from `on_after_apply` since it doesn't use `cx.with_vm`.
     fn populate_safe(cx: &mut Cx, view: &View, prefs: &AppPreferences) {
         view.drop_down(cx, ids!(view_mode_dropdown))
             .set_selected_item(cx, prefs.view_mode.to_index());
@@ -611,6 +615,11 @@ impl AppSettings {
         view.check_box(cx, ids!(send_on_cmd_enter_toggle))
             .set_text(SEND_SHORTCUT_TOGGLE_LABEL);
         Self::update_send_shortcut_description(cx, view, prefs.send_on_enter);
+
+        // The send shortcut only applies to a physical keyboard, so the
+        // soft-keyboard caveat is only relevant on iOS/Android.
+        view.widget(cx, ids!(send_shortcut_soft_keyboard_warning))
+            .set_visible(cx, cfg!(any(target_os = "ios", target_os = "android")));
 
         let custom_active = matches!(prefs.thumbnail_max_height, ThumbnailMaxHeight::Custom(_));
         Self::set_thumb_custom_input_read_only(cx, view, custom_active);


### PR DESCRIPTION
Major changes to improve keyboard behavior, primarily on iOS but also on Android, with special Makepad-level handling of real/physical hardware keyboards.

Keyboard shortcuts work for kbd nav on iOS & Android too, now.