### PR TITLE
Use new Makepad support for more image formats, fix rotation, show SVGs as images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "bytes"
@@ -1954,9 +1954,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2952,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2999,15 +2999,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3015,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "weezl",
 ]
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3052,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "ttf-parser",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3093,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3129,15 +3129,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3159,7 +3159,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3171,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3184,13 +3184,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3207,14 +3207,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3268,13 +3268,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "log",
  "makepad-zune-core",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "log",
 ]
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "simd-adler32",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3702,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "mime"
@@ -4495,10 +4495,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
  "unicase 2.9.0",
 ]
 
@@ -5377,12 +5377,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5477,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "sealed"
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "siphasher"
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "socket2"
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "tungstenite"
@@ -6635,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-bidi"
@@ -6646,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-ident"
@@ -6667,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-normalization"
@@ -6687,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6703,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "unicode-width"
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "log",
  "pkg-config",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "whoami"
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7326,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 
 [[package]]
 name = "windows-numerics"
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "bitmaps"
@@ -728,13 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "byteorder"
@@ -745,13 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "bytes"
@@ -1751,15 +1739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,9 +1954,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
 ]
 
 [[package]]
@@ -2559,21 +2538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck 1.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
 name = "imbl"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,12 +2560,6 @@ checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
 dependencies = [
  "bitmaps",
 ]
-
-[[package]]
-name = "imghdr"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b35f3ad95576ac81603375dfe47a0450b70a368aa34d2b6e5bb0a0d7f02428"
 
 [[package]]
 name = "impartial-ord"
@@ -2986,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2994,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3007,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3015,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3024,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3034,20 +2992,22 @@ dependencies = [
  "makepad-platform",
  "makepad-svg",
  "makepad-webp",
+ "makepad-zune-bmp",
  "makepad-zune-jpeg",
  "makepad-zune-png",
+ "makepad-zune-qoi",
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3055,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "weezl",
 ]
@@ -3078,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3092,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "ttf-parser",
 ]
@@ -3100,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3109,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3117,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3125,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3133,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3147,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3155,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3169,15 +3129,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3199,7 +3159,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3211,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3224,13 +3184,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3238,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3247,14 +3207,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3264,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3273,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3282,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3291,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3299,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3308,26 +3268,38 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+]
+
+[[package]]
+name = "makepad-zune-bmp"
+version = "0.5.2"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+dependencies = [
+ "log",
+ "makepad-zune-core",
 ]
 
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
- "simd-adler32 0.3.9 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3335,10 +3307,18 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
+]
+
+[[package]]
+name = "makepad-zune-qoi"
+version = "0.5.2"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
+dependencies = [
+ "makepad-zune-core",
 ]
 
 [[package]]
@@ -3722,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "mime"
@@ -3759,7 +3739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3771,16 +3750,6 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
 ]
 
 [[package]]
@@ -4384,19 +4353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4539,10 +4495,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
  "unicase 2.9.0",
 ]
 
@@ -4563,12 +4519,6 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quinn"
@@ -5100,9 +5050,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "htmlize",
- "image",
  "imbl",
- "imghdr",
  "indexmap 2.13.0",
  "libc",
  "linkify",
@@ -5429,12 +5377,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
- "bytemuck 1.25.0 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
+ "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=more_image_formats)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5529,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "sealed"
@@ -5828,13 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "siphasher"
@@ -5860,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "socket2"
@@ -6641,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "tungstenite"
@@ -6693,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-bidi"
@@ -6704,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-ident"
@@ -6725,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-normalization"
@@ -6745,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6761,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "unicode-width"
@@ -7093,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7105,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7115,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7124,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7134,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "log",
  "pkg-config",
@@ -7194,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "whoami"
@@ -7247,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7266,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7299,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7320,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7384,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 
 [[package]]
 name = "windows-numerics"
@@ -7428,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7445,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=hardware_keyboard#2dea692ce20f27599a647a7dd79db76dc439f59d"
+source = "git+https://github.com/kevinaboos/makepad?branch=more_image_formats#e4417d78b02d786018d11a31c9bc386ee0588ccf"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8022,18 +7964,3 @@ name = "zmij"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "hardware_keyboard", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "hardware_keyboard" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "more_image_formats", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "more_image_formats" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.
@@ -45,8 +45,6 @@ futures-util = "0.3"
 hashbrown = { version = "0.16", features = ["raw-entry"] }
 htmlize = "1.0.5"
 indexmap = "2.6.0"
-imghdr = "0.7.0"
-image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 libc = "0.2"
 mime = "0.3"
 mime_guess = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "more_image_formats", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "more_image_formats" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "image_coded_hardening_audit", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "image_coded_hardening_audit" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -587,7 +587,7 @@ impl Widget for AddRoomScreen {
                         let res = room_avatar.show_image(
                             cx,
                             None,
-                            |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, image_data),
+                            |cx, img_ref| utils::load_image(&img_ref, cx, image_data),
                         );
                         if res.is_err() {
                             room_avatar.show_text(

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -396,7 +396,7 @@ impl Widget for InviteScreen {
                 drew_avatar = inviter_avatar.show_image(
                     cx,
                     None, // don't make this avatar clickable.
-                    |cx, img| utils::load_png_or_jpg(&img, cx, avatar_bytes),
+                    |cx, img| utils::load_image(&img, cx, avatar_bytes),
                 ).is_ok();
             }
             if !drew_avatar {
@@ -445,7 +445,7 @@ impl Widget for InviteScreen {
                 let _ = room_avatar.show_image(
                     cx,
                     None, // don't make this avatar clickable.
-                    |cx, img| utils::load_png_or_jpg(&img, cx, avatar_bytes),
+                    |cx, img| utils::load_image(&img, cx, avatar_bytes),
                 );
             }
         }

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -421,7 +421,7 @@ impl Widget for ProfileIcon {
             drew_avatar = our_own_avatar.show_image(
                 cx,
                 None, // don't make this avatar clickable; we handle clicks on this ProfileIcon widget directly.
-                |cx, img| utils::load_png_or_jpg(&img, cx, avatar_img_data),
+                |cx, img| utils::load_image(&img, cx, avatar_img_data),
             ).is_ok();
         }
         if !drew_avatar {

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -34,7 +34,7 @@ use crate::{
     shared::{
         attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, media_source_mxc, start_attachment_download}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, file_upload_modal::FileUploadAttemptId, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageStatus, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
     },
-    sliding_sync::{BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, submit_async_request, take_timeline_endpoints}, utils::{self, ImageFormat, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
+    sliding_sync::{BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, submit_async_request, take_timeline_endpoints}, utils::{self, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
 };
 use crate::home::event_reaction_list::ReactionListWidgetRefExt;
 use crate::home::room_read_receipt::AvatarRowWidgetRefExt;
@@ -4199,13 +4199,17 @@ fn populate_image_message_content(
         .map(|info| (info.mimetype.as_deref(), info.width, info.height))
         .unwrap_or_default();
 
-    // If we have a known mimetype and it's not a static image,
-    // then show a message about it being unsupported (e.g., for animated gifs).
+    // If the mimetype is known but isn't an image format makepad can decode,
+    // show a message that it's unsupported.
     if let Some(mime) = mimetype.as_ref() {
-        if ImageFormat::from_mimetype(mime).is_none() {
+        if !utils::is_supported_image_mimetype(mime) {
             text_or_image_ref.show_text(
                 cx,
-                format!("{body}\nUnsupported type {mime:?}"),
+                format!("{}{}Unsupported type {:?}",
+                    body,
+                    if body.trim().is_empty() { "" } else { "\n" },
+                    mime,
+                ),
             );
             return true; // consider this as fully drawn
         }
@@ -4217,7 +4221,7 @@ fn populate_image_message_content(
         match media_cache.try_get_media_or_fetch(&media_source, MEDIA_THUMBNAIL_FORMAT.into()) {
             (MediaCacheEntry::Loaded(data), _media_format) => {
                 let show_image_result = text_or_image_ref.show_image(cx, Some(media_source), |cx, img| {
-                    utils::load_png_or_jpg(&img, cx, &data)
+                    utils::load_image(&img, cx, &data)
                         .map(|()| img.size_in_pixels(cx).unwrap_or_default())
                 });
                 if let Err(e) = show_image_result {

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -392,7 +392,7 @@ impl RoomsListEntryContent {
                 let _ = self.view.avatar(cx, ids!(avatar)).show_image(
                     cx,
                     None, // Avatars in a RoomsListEntry shouldn't be clickable.
-                    |cx, img| utils::load_png_or_jpg(&img, cx, img_bytes),
+                    |cx, img| utils::load_image(&img, cx, img_bytes),
                 );
             }
         }
@@ -419,7 +419,7 @@ impl RoomsListEntryContent {
                 let _ = self.view.avatar(cx, ids!(avatar)).show_image(
                     cx,
                     None, // Avatars in a RoomsListEntry shouldn't be clickable.
-                    |cx, img| utils::load_png_or_jpg(&img, cx, img_bytes),
+                    |cx, img| utils::load_image(&img, cx, img_bytes),
                 );
             }
         }

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -1152,7 +1152,7 @@ impl Widget for SpaceLobbyScreen {
             parent_avatar_ref.show_image(
                 cx,
                 None,
-                |cx, img| utils::load_png_or_jpg(&img, cx, data),
+                |cx, img| utils::load_image(&img, cx, data),
             ).is_err()
         }) {
             let first_char = self.space_name_id.as_ref().and_then(|sni| sni.name_for_avatar())
@@ -1263,7 +1263,7 @@ impl Widget for SpaceLobbyScreen {
                                     drew_avatar = avatar_ref.show_image(
                                         cx,
                                         None,
-                                        |cx, img| utils::load_png_or_jpg(&img, cx, data),
+                                        |cx, img| utils::load_image(&img, cx, data),
                                     ).is_ok();
                                 }
                                 AvatarState::Known(Some(uri)) => {
@@ -1272,7 +1272,7 @@ impl Widget for SpaceLobbyScreen {
                                             drew_avatar = avatar_ref.show_image(
                                                 cx,
                                                 None,
-                                                |cx, img| utils::load_png_or_jpg(&img, cx, &data),
+                                                |cx, img| utils::load_image(&img, cx, &data),
                                             ).is_ok();
                                             info.avatar = AvatarState::Loaded(data);
                                         }

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -479,7 +479,7 @@ impl Widget for SpacesBar {
                                 let res = avatar_ref.show_image(
                                     cx,
                                     None,
-                                    |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, image_data),
+                                    |cx, img_ref| utils::load_image(&img_ref, cx, image_data),
                                 );
                                 if res.is_err() {
                                     avatar_ref.show_text(

--- a/src/home/tombstone_footer.rs
+++ b/src/home/tombstone_footer.rs
@@ -182,7 +182,7 @@ impl TombstoneFooter {
                         let res = successor_room_avatar.show_image(
                             cx,
                             None,
-                            |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, image_data),
+                            |cx, img_ref| utils::load_image(&img_ref, cx, image_data),
                         );
                         if res.is_err() {
                             successor_room_avatar.show_text(

--- a/src/image_utils.rs
+++ b/src/image_utils.rs
@@ -1,13 +1,36 @@
-//! Image processing utilities for thumbnail generation and image manipulation.
+//! Image processing utilities.
 
-/// Returns true if the given MIME type represents an image format that can be displayed.
+use std::io::Read;
+use std::path::Path;
+
+use makepad_widgets::image_cache::image_size_by_data;
+
+/// Returns true if the given MIME type is an image format that robrix can display.
 ///
-/// Note: Only JPEG and PNG are supported because those are the only formats
-/// enabled in the `image` crate features. Other formats (gif, webp, bmp) would
-/// fail to decode.
+/// Delegates to [`crate::utils::is_supported_image_mimetype`] so display and
+/// upload-preview gating share a single source of truth.
 pub fn is_displayable_image(mime_type: &str) -> bool {
-    matches!(
-        mime_type,
-        "image/png" | "image/jpeg" | "image/jpg"
-    )
+    crate::utils::is_supported_image_mimetype(mime_type)
+}
+
+/// Reads an image's pixel `(width, height)` from the file at `path`.
+///
+/// Tries a bounded header read first (cheap for large photos), and falls back to
+/// the full file only if the prefix wasn't enough — e.g. an animated GIF/ICO, or
+/// a JPEG with a large EXIF/ICC block before its SOF marker. Because of that
+/// fallback, it never fails to parse dimensions that a full read would have found.
+pub fn read_image_dimensions(path: &Path) -> Option<(usize, usize)> {
+    // Generous prefix: covers every format's header plus typical EXIF/ICC blocks.
+    const HEADER_PREFIX_LEN: u64 = 256 * 1024;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut buf = Vec::new();
+    file.by_ref().take(HEADER_PREFIX_LEN).read_to_end(&mut buf).ok()?;
+    if let Ok(dims) = image_size_by_data(&buf, path) {
+        return Some(dims);
+    }
+    // The prefix wasn't enough; pull in the rest of the file and try once more.
+    if file.read_to_end(&mut buf).ok()? > 0 {
+        return image_size_by_data(&buf, path).ok();
+    }
+    None
 }

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -535,7 +535,7 @@ impl Widget for UserProfileSlidingPane {
         let avatar_ref = self.avatar(cx, ids!(avatar));
         info.avatar_state
             .data()
-            .and_then(|data| avatar_ref.show_image(cx, None, |cx, img| utils::load_png_or_jpg(&img, cx, data)).ok())
+            .and_then(|data| avatar_ref.show_image(cx, None, |cx, img| utils::load_image(&img, cx, data)).ok())
             .unwrap_or_else(|| avatar_ref.show_text(cx, None, None, info.displayable_name()));
 
         // Set the membership status and role in the room.

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -609,7 +609,7 @@ impl AccountSettings {
             drew_avatar = our_own_avatar.show_image(
                 cx,
                 None, // don't make this avatar clickable; we handle clicks on this ProfileIcon widget directly.
-                |cx, img| utils::load_png_or_jpg(&img, cx, avatar_img_data),
+                |cx, img| utils::load_image(&img, cx, avatar_img_data),
             ).is_ok();
         }
         if !drew_avatar {

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -328,7 +328,7 @@ impl Avatar {
                         timeline_kind.room_id().to_owned(),
                         data.clone()
                     ))),
-                    |cx, img| utils::load_png_or_jpg(&img, cx, &data),
+                    |cx, img| utils::load_image(&img, cx, &data),
                 )
                 .ok()
             })

--- a/src/shared/file_upload_modal.rs
+++ b/src/shared/file_upload_modal.rs
@@ -360,7 +360,7 @@ impl FileUploadModal {
 
             // Load image data into the preview
             if let Some(preview_data) = &file_data.preview_data {
-                if let Err(e) = crate::utils::load_png_or_jpg(&image_preview, cx, preview_data) {
+                if let Err(e) = crate::utils::load_image(&image_preview, cx, preview_data) {
                     makepad_widgets::error!("Failed to load image preview: {:?}", e);
                     // Fall back to file icon
                     image_preview_container.set_visible(cx, false);

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -503,7 +503,7 @@ impl MatrixLinkPill {
             let res = avatar_ref.show_image(
                 cx,
                 None, // Don't make this avatar clickable
-                |cx, img_ref| utils::load_png_or_jpg(&img_ref, cx, &data),
+                |cx, img_ref| utils::load_image(&img_ref, cx, &data),
             );
             if res.is_ok() {
                 return;

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -7,7 +7,7 @@ use std::sync::{mpsc::Receiver, Arc};
 use chrono::{DateTime, Local};
 use makepad_widgets::{
     event::TouchUpdateEvent,
-    image_cache::{ImageBuffer, ImageError},
+    image_cache::{decode_image_from_data, looks_like_svg, ImageBuffer, ImageError},
     *,
 };
 use matrix_sdk_ui::timeline::EventTimelineItem;
@@ -22,24 +22,15 @@ use crate::{
 /// The timeout for hiding the UI overlays after no user mouse/tap activity.
 const SHOW_UI_DURATION: f64 = 3.0;
 
-/// Loads the given image `data` into an `ImageBuffer` as either a PNG or JPEG, using the `imghdr` library to determine which format it is.
+/// Duration of one 90° rotation spin, in seconds (matches the DSL const).
+const ROTATION_ANIMATION_DURATION_SECS: f64 = 0.2;
+
+/// Decodes the given image `data` into an `ImageBuffer`, auto-detecting any
+/// image format that makepad supports.
 ///
-/// Returns an error if either load fails or if the image format is unknown.
-pub fn get_png_or_jpg_image_buffer(data: Vec<u8>) -> Result<ImageBuffer, ImageError> {
-    match imghdr::from_bytes(&data) {
-        Some(imghdr::Type::Png) => {
-            ImageBuffer::from_png(&data)
-        },
-        Some(imghdr::Type::Jpeg) => {
-            ImageBuffer::from_jpg(&data)
-        },
-        Some(_unsupported) => {
-            Err(ImageError::UnsupportedFormat)
-        }
-        None => {
-            Err(ImageError::UnsupportedFormat)
-        }
-    }
+/// Returns an error if the format is unsupported or decoding fails.
+pub fn get_image_buffer(data: Vec<u8>) -> Result<ImageBuffer, ImageError> {
+    decode_image_from_data(&data)
 }
 
 /// Configuration for zoom and pan settings in the image viewer.
@@ -112,8 +103,6 @@ script_mod! {
 
     mod.widgets.UI_ANIMATION_DURATION_SECS = 0.4
 
-    mod.widgets.ROTATION_ANIMATION_DURATION_SECS = 0.2
-
     mod.widgets.ImageViewerButton = RobrixNeutralIconButton {
 
         width: 44, height: 44
@@ -153,7 +142,10 @@ script_mod! {
                 align: Align{x: 0.5, y: 0.5}
                 rotated_image := Image {
                     width: Fill, height: Fill,
-                    fit: ImageFit.Smallest
+                    // The viewer computes the exact frame size itself (and the
+                    // shader handles fit + rotation), so don't let the widget
+                    // re-fit the texture's own aspect over our rotated frame.
+                    fit: ImageFit.Stretch
                 }
             }
 
@@ -345,63 +337,6 @@ script_mod! {
         }
 
         animator: Animator{
-            mode: {
-                default: @upright
-                degree_neg90: AnimatorState{
-                    redraw: false,
-                    from: {all: Forward {duration: (mod.widgets.ROTATION_ANIMATION_DURATION_SECS)}}
-                    apply: {
-                        image_layer: { rotated_image_container: { rotated_image: {
-                            draw_bg: {rotation: -90.0}
-                        }}}
-                    }
-                }
-                upright: AnimatorState{
-                    redraw: false,
-                    from: {all: Forward {duration: (mod.widgets.ROTATION_ANIMATION_DURATION_SECS)}}
-                    apply: {
-                        image_layer: { rotated_image_container: { rotated_image: {
-                            draw_bg: {rotation: 0.0}
-                        }}}
-                    }
-                }
-                degree_90: AnimatorState{
-                    redraw: false,
-                    from: {all: Forward {duration: (mod.widgets.ROTATION_ANIMATION_DURATION_SECS)}}
-                    apply: {
-                        image_layer: { rotated_image_container: { rotated_image: {
-                            draw_bg: {rotation: 90.0}
-                        }}}
-                    }
-                }
-                degree_180: AnimatorState{
-                    redraw: false,
-                    from: {all: Forward {duration: (mod.widgets.ROTATION_ANIMATION_DURATION_SECS)}}
-                    apply: {
-                        image_layer: { rotated_image_container: { rotated_image: {
-                            draw_bg: {rotation: 180.0}
-                        }}}
-                    }
-                }
-                degree_270: AnimatorState{
-                    redraw: false,
-                    from: {all: Forward {duration: (mod.widgets.ROTATION_ANIMATION_DURATION_SECS)}}
-                    apply: {
-                        image_layer: { rotated_image_container: { rotated_image: {
-                            draw_bg: {rotation: 270.0}
-                        }}}
-                    }
-                }
-                degree_360: AnimatorState{
-                    redraw: false,
-                    from: {all: Forward {duration: 0.0}}
-                    apply: {
-                        image_layer: { rotated_image_container: { rotated_image: {
-                            draw_bg: {rotation: 360.0}
-                        }}}
-                    }
-                }
-            }
             hover: {
                 default: @off
                 off: AnimatorState{
@@ -493,6 +428,19 @@ struct ImageViewer {
     /// from the continuous `FingerHoverOver` events that fire every frame.
     #[rust] last_mouse_pos: DVec2,
     #[rust] capped_dimension: DVec2,
+    /// The image's intrinsic (unrotated) pixel size, kept so we can re-fit the
+    /// rotated bounding box at every angle of the spin.
+    #[rust] natural_dimension: DVec2,
+    /// The currently-displayed rotation angle in degrees (continuous during the
+    /// animated spin; settles on a multiple of 90°).
+    #[rust] current_angle: f64,
+    /// Animation endpoints for the in-progress rigid rotation.
+    #[rust] rotation_anim_from: f64,
+    #[rust] rotation_target_angle: f64,
+    /// Wall-clock start of the rotation animation (set on its first frame).
+    #[rust] rotation_anim_start_time: Option<f64>,
+    /// Drives the per-frame rotation animation.
+    #[rust] rotation_next_frame: NextFrame,
     /// Info about how to download the image being shown.
     #[rust] downloadable: Option<DownloadableAttachment>,
     /// A reference to the image being shown so we can easily save it to storage.
@@ -504,41 +452,12 @@ impl Widget for ImageViewer {
         self.view.handle_event(cx, event, scope);
         self.match_event(cx, event);
 
-        // Handle the app window being resized.
+        // Handle the app window being resized: re-fit for the new container.
+        // `display_current_image` re-lays out at the current angle and zoom; the
+        // pan margin persists on the widget, so zoom/pan are retained.
         if matches!(event, Event::WindowGeomChange(_)) {
-            let image_container_rect = self.view.area().rect(cx);
-            self.image_container_size = image_container_rect.size;
-
-            // Save current drag state to retain zoom and pan
-            let saved_zoom_level = self.drag_state.zoom_level;
-            let saved_pan_offset = self.drag_state.pan_offset;
-
-            // Recalculate base dimensions for new container size
-            self.display_using_texture(cx);
-
-            // Restore drag state
-            self.drag_state.zoom_level = saved_zoom_level;
-            self.drag_state.pan_offset = saved_pan_offset;
-
-            // Reapply zoom and pan if they differ from defaults
-            if saved_zoom_level != 1.0 || saved_pan_offset.is_some() {
-                let mut rotated_image = self.view.image(cx, ids!(rotated_image));
-                let width = self.capped_dimension.x * saved_zoom_level;
-                let height = self.capped_dimension.y * saved_zoom_level;
-
-                if let Some(offset) = saved_pan_offset {
-                    script_apply_eval!(cx, rotated_image, {
-                        margin +: { top: #(offset.y), left: #(offset.x) },
-                        width: #(width),
-                        height: #(height),
-                    });
-                } else {
-                    script_apply_eval!(cx, rotated_image, {
-                        width: #(width),
-                        height: #(height),
-                    });
-                }
-            }
+            self.image_container_size = self.view.area().rect(cx).size;
+            self.display_current_image(cx);
         }
 
         // Handle hover events for UI overlay elements.
@@ -686,9 +605,12 @@ impl Widget for ImageViewer {
                 }
                 Ok(Err(error)) => {
                     let error = match error {
-                        ImageError::JpgDecode(_) | ImageError::PngDecode(_) => {
-                            ImageViewerError::UnsupportedFormat
-                        }
+                        ImageError::JpgDecode(_)
+                        | ImageError::PngDecode(_)
+                        | ImageError::GifDecode(_)
+                        | ImageError::WebpDecode(_)
+                        | ImageError::BmpDecode(_)
+                        | ImageError::QoiDecode(_) => ImageViewerError::UnsupportedFormat,
                         ImageError::EmptyData => ImageViewerError::BadData,
                         ImageError::PathNotFound(_) => ImageViewerError::NotFound,
                         ImageError::UnsupportedFormat => ImageViewerError::UnsupportedFormat,
@@ -718,19 +640,10 @@ impl Widget for ImageViewer {
         }
 
         if self.next_frame.is_event(event).is_some() {
-            self.display_using_texture(cx);
+            self.display_current_image(cx);
         }
-        else if let Event::NextFrame(_) = event {
-            let animation_id = match self.rotation_step {
-                0 => ids!(mode.upright),    // 0°
-                1 => ids!(mode.degree_90),  // 90°
-                2 => ids!(mode.degree_180), // 180°
-                3 => ids!(mode.degree_270), // 270°
-                _ => ids!(mode.upright),
-            };
-            if self.animator.in_state(cx, animation_id) {
-                self.is_animating_rotation = matches!(animator_action, AnimatorAction::Animating { .. });
-            }
+        if let Some(ne) = self.rotation_next_frame.is_event(event) {
+            self.advance_rotation(cx, ne.time);
         }
 
         if event.back_pressed()
@@ -811,27 +724,12 @@ impl MatchEvent for ImageViewer {
 
         if self.view.button(cx, ids!(rotate_cw_button)).clicked(actions) {
             was_overlay_button_clicked = true;
-            if !self.is_animating_rotation {
-                self.is_animating_rotation = true;
-                if self.rotation_step == 3 {
-                    self.animator_cut(cx, ids!(mode.degree_neg90));
-                }
-                self.rotation_step = (self.rotation_step + 1) % 4; // Rotate 90 degrees clockwise
-                self.update_rotation_animation(cx);
-            }
+            self.start_rotation(cx, 90.0);
         }
 
         if self.view.button(cx, ids!(rotate_ccw_button)).clicked(actions) {
             was_overlay_button_clicked = true;
-            if !self.is_animating_rotation {
-                self.is_animating_rotation = true;
-                if self.rotation_step == 0 {
-                    self.rotation_step = 4;
-                    self.animator_cut(cx, ids!(mode.degree_360));
-                }
-                self.rotation_step = (self.rotation_step - 1) % 4; // Rotate 90 degrees clockwise
-                self.update_rotation_animation(cx);
-            }
+            self.start_rotation(cx, -90.0);
         }
 
         if self.view.button(cx, ids!(download_button)).clicked(actions)
@@ -910,6 +808,9 @@ impl ImageViewer {
     /// Reset state.
     pub fn reset(&mut self, cx: &mut Cx) {
         self.rotation_step = 0; // Reset to upright (0°)
+        self.current_angle = 0.0;
+        self.rotation_target_angle = 0.0;
+        self.rotation_anim_start_time = None;
         self.is_animating_rotation = false; // Reset animation state
         self.previous_pinch_distance = None; // Reset pinch tracking
         self.mouse_cursor_hover_over_image = false; // Reset hover state
@@ -928,7 +829,6 @@ impl ImageViewer {
         // Snap to fully visible (no animation on reset).
         self.animator_cut(cx, ids!(ui_animator.show));
         self.reset_drag_state(cx);
-        self.animator_cut(cx, ids!(mode.upright));
         let rotated_image_ref = self
             .view
             .image(cx, ids!(rotated_image_container.rotated_image));
@@ -937,32 +837,6 @@ impl ImageViewer {
 
     /// Updates the shader uniforms of the rotated image widget with the current rotation,
     /// and requests a redraw.
-    fn update_rotation_animation(&mut self, cx: &mut Cx) {
-        // Map rotation step to animation state
-        let animation_id = match self.rotation_step {
-            0 => ids!(mode.upright),    // 0°
-            1 => ids!(mode.degree_90),  // 90°
-            2 => ids!(mode.degree_180), // 180°
-            3 => ids!(mode.degree_270), // 270°
-            _ => ids!(mode.upright),
-        };
-        self.animator_play(cx, animation_id);
-
-        // Also directly set the rotation value on the image's draw_bg shader,
-        // in case the animator apply paths don't work for deeply nested children.
-        let rotation_deg = match self.rotation_step {
-            0 => 0.0_f64,
-            1 => 90.0,
-            2 => 180.0,
-            3 => 270.0,
-            _ => 0.0,
-        };
-        let mut rotated_image = self.view.image(cx, ids!(rotated_image));
-        script_apply_eval!(cx, rotated_image, {
-            draw_bg +: { rotation: #(rotation_deg) }
-        });
-    }
-
     /// Resets the drag state of the modal to its initial state.
     ///
     /// This function can be used to reset drag state when the magnifying glass is toggled off.
@@ -976,7 +850,7 @@ impl ImageViewer {
         });
         rotated_image_container.redraw(cx);
 
-        self.update_rotation_animation(cx);
+        self.apply_rotation_frame(cx);
     }
 
     /// Displays an image in the image viewer widget.
@@ -986,6 +860,23 @@ impl ImageViewer {
         if self.receiver.is_some() {
             return;
         }
+        // SVG is a vector format: load it straight into the image widget (which
+        // renders it natively and stays crisp at any zoom) instead of decoding to
+        // a raster texture on a worker thread.
+        if looks_like_svg(image_bytes) {
+            let rotated_image = self.image(cx, ids!(rotated_image));
+            let load_state = match rotated_image.load_image_from_data(cx, image_bytes) {
+                Ok(()) => {
+                    self.texture = None;
+                    self.next_frame = cx.new_next_frame();
+                    LoadState::FinishedBackgroundDecoding
+                }
+                Err(_) => LoadState::Error(ImageViewerError::BadData),
+            };
+            cx.action(ImageViewerAction::Show(load_state));
+            self.show_overlay_ui(cx, true);
+            return;
+        }
         if let Some(new_value) = self.background_task_id.checked_add(1) {
             self.background_task_id = new_value;
         }
@@ -993,7 +884,7 @@ impl ImageViewer {
         self.receiver = Some((self.background_task_id, receiver));
         let image_bytes_clone = image_bytes.to_vec();
         cx.spawn_thread(move || {
-            let _ = sender.send(get_png_or_jpg_image_buffer(image_bytes_clone));
+            let _ = sender.send(get_image_buffer(image_bytes_clone));
             SignalToUI::set_ui_signal();
         });
         self.show_overlay_ui(cx, true);
@@ -1002,59 +893,107 @@ impl ImageViewer {
     /// Displays an image in the image viewer widget using the provided texture.
     /// 
     /// `Texture` is an optional `Texture` that can be set to display an image. If `None`, the image is cleared.
-    pub fn display_using_texture(&mut self, cx: &mut Cx) {
+    pub fn display_current_image(&mut self, cx: &mut Cx) {
         if self.image_container_size.length() == 0.0 {
             return;
         }
-        let texture = self.texture.clone();
         let mut rotated_image = self.image(cx, ids!(rotated_image));
-        let (texture_width, texture_height) = texture
-            .as_ref()
-            .and_then(|texture| texture.get_format(cx).vec_width_height())
-            .unwrap_or_default();
-        
-        // Calculate scaling factors for both dimensions
-        let scale_x = self.image_container_size.x / texture_width as f64;
-        let scale_y = self.image_container_size.y / texture_height as f64;
-        
-        // Use the smaller scale factor to ensure image fits within container
-        let scale = scale_x.min(scale_y);
-        
-        let capped_width = (texture_width as f64 * scale).floor();
-        let capped_height = (texture_height as f64 * scale).floor();
-        self.capped_dimension = DVec2{
-            x: capped_width,
-            y: capped_height
+        // Natural (unrotated) size: the texture's dimensions for raster images,
+        // or the intrinsic SVG size when an SVG has been loaded into the widget.
+        let natural = if self.texture.is_some() {
+            let texture = self.texture.clone();
+            rotated_image.set_texture(cx, texture);
+            self.texture
+                .as_ref()
+                .and_then(|t| t.get_format(cx).vec_width_height())
+                .map(|(w, h)| DVec2 { x: w as f64, y: h as f64 })
+                .unwrap_or_default()
+        } else {
+            rotated_image
+                .size_in_pixels(cx)
+                .map(|(w, h)| DVec2 { x: w as f64, y: h as f64 })
+                .unwrap_or_default()
         };
-        
-        rotated_image.set_texture(cx, texture);
+        if natural.x == 0.0 || natural.y == 0.0 {
+            return;
+        }
+        self.natural_dimension = natural;
+        if !self.is_animating_rotation {
+            self.current_angle = f64::from(self.rotation_step) * 90.0;
+        }
+        self.apply_rotation_frame(cx);
+    }
+
+    /// Lays the image out for the current rotation angle: the on-screen frame is
+    /// the rotated bounding box (fit to the viewport and the current zoom), and
+    /// the shader is told the image's own pixel size so it rotates *rigidly* —
+    /// a non-square image keeps its correct aspect ratio at every angle.
+    fn apply_rotation_frame(&mut self, cx: &mut Cx) {
+        let (w, h) = (self.natural_dimension.x, self.natural_dimension.y);
+        if w <= 0.0 || h <= 0.0 || self.image_container_size.length() == 0.0 {
+            return;
+        }
+        let rad = self.current_angle.to_radians();
+        let (ca, sa) = (rad.cos().abs(), rad.sin().abs());
+        let bbox_w = w * ca + h * sa;
+        let bbox_h = w * sa + h * ca;
+        let fit = (self.image_container_size.x / bbox_w)
+            .min(self.image_container_size.y / bbox_h);
+        self.capped_dimension = DVec2 { x: bbox_w * fit, y: bbox_h * fit };
+        let zoom = self.drag_state.zoom_level;
+        let frame_w = self.capped_dimension.x * zoom;
+        let frame_h = self.capped_dimension.y * zoom;
+        let image_w = w * fit * zoom;
+        let image_h = h * fit * zoom;
+        let angle = self.current_angle;
+        let mut rotated_image = self.view.image(cx, ids!(rotated_image));
         script_apply_eval!(cx, rotated_image, {
-            width: #(capped_width),
-            height: #(capped_height),
+            width: #(frame_w),
+            height: #(frame_h),
+            draw_bg +: {
+                rotation: #(angle),
+                image_dim_w: #(image_w),
+                image_dim_h: #(image_h),
+            }
         });
+    }
+
+    /// Starts an animated rigid rotation by `delta_deg` (±90°), unless one is
+    /// already running. The spin itself is driven per frame in `handle_event`.
+    fn start_rotation(&mut self, cx: &mut Cx, delta_deg: f64) {
+        if self.is_animating_rotation || self.natural_dimension.x <= 0.0 {
+            return;
+        }
+        self.is_animating_rotation = true;
+        self.rotation_anim_from = self.current_angle;
+        self.rotation_target_angle = self.current_angle + delta_deg;
+        self.rotation_anim_start_time = None;
+        self.rotation_next_frame = cx.new_next_frame();
+    }
+
+    /// Advances the rigid rotation animation by one frame. Returns true while the
+    /// animation is still running.
+    fn advance_rotation(&mut self, cx: &mut Cx, now: f64) {
+        let start = *self.rotation_anim_start_time.get_or_insert(now);
+        let t = ((now - start) / ROTATION_ANIMATION_DURATION_SECS).clamp(0.0, 1.0);
+        let eased = t * t * (3.0 - 2.0 * t); // smoothstep
+        self.current_angle =
+            self.rotation_anim_from + (self.rotation_target_angle - self.rotation_anim_from) * eased;
+        if t >= 1.0 {
+            self.current_angle = self.rotation_target_angle;
+            self.is_animating_rotation = false;
+            self.rotation_step = self.rotation_target_angle.div_euclid(90.0).rem_euclid(4.0) as i8;
+        } else {
+            self.rotation_next_frame = cx.new_next_frame();
+        }
+        self.apply_rotation_frame(cx);
     }
 
     /// Adjust the zoom level of the image viewer based on the provided zoom factor.
     fn adjust_zoom(&mut self, cx: &mut Cx, zoom_factor: f64) {
-        let mut rotated_image = self.view.image(cx, ids!(rotated_image));
-        let size = rotated_image.area().rect(cx).size;
-        let capped_dimension = self.capped_dimension;
-        let target_zoom = self.drag_state.zoom_level * zoom_factor;
-        let (width, height) = if target_zoom < self.config.min_zoom {
-            (capped_dimension.x * self.config.min_zoom, capped_dimension.y * self.config.min_zoom)
-        } else {
-            let actual_zoom_factor = target_zoom / self.drag_state.zoom_level;
-            self.drag_state.zoom_level = target_zoom;
-            self.drag_state.zoom_level = (self.drag_state.zoom_level * 1000.0).round() / 1000.0;
-            let width = (size.x * actual_zoom_factor * 1000.0).round() / 1000.0;
-            let height = (size.y * actual_zoom_factor * 1000.0).round() / 1000.0;
-            (width, height)
-        };
-
-        script_apply_eval!(cx, rotated_image, {
-            width: #(width),
-            height: #(height),
-        });
+        let target_zoom = (self.drag_state.zoom_level * zoom_factor).max(self.config.min_zoom);
+        self.drag_state.zoom_level = (target_zoom * 1000.0).round() / 1000.0;
+        self.apply_rotation_frame(cx);
     }
 
     /// Handle touch update events, specifically the pinch gesture to zoom in/out.

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -897,7 +897,7 @@ impl ImageViewer {
         if self.image_container_size.length() == 0.0 {
             return;
         }
-        let mut rotated_image = self.image(cx, ids!(rotated_image));
+        let rotated_image = self.image(cx, ids!(rotated_image));
         // Natural (unrotated) size: the texture's dimensions for raster images,
         // or the intrinsic SVG size when an SVG has been loaded into the widget.
         let natural = if self.texture.is_some() {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1883,11 +1883,9 @@ async fn matrix_worker_task(
                         let content_type: Mime = file_data.mime_type.parse()
                             .unwrap_or(mime::APPLICATION_OCTET_STREAM);
 
-                        let image_dimensions = if content_type.type_() == mime::IMAGE {
-                            image::ImageReader::open(file_data.path())
-                                .ok()
-                                .and_then(|reader| reader.with_guessed_format().ok())
-                                .and_then(|reader| reader.into_dimensions().ok())
+                        let image_dimensions: Option<(u32, u32)> = if content_type.type_() == mime::IMAGE {
+                            crate::image_utils::read_image_dimensions(file_data.path())
+                                .map(|(w, h)| (w as u32, h as u32))
                         } else {
                             None
                         };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use url::Url;
 
 use unicode_segmentation::UnicodeSegmentation;
 use chrono::{DateTime, Duration, Local, TimeZone};
-use makepad_widgets::{Cx, Event, ImageRef, error, image_cache::ImageError};
+use makepad_widgets::{Cx, Event, ImageRef, image_cache::ImageError};
 use matrix_sdk::{media::{MediaFormat, MediaThumbnailSettings}, ruma::{api::client::media::get_content_thumbnail::v3::Method, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId}, RoomDisplayName};
 use matrix_sdk_ui::timeline::{EventTimelineItem, PaginationError, TimelineDetails};
 
@@ -77,71 +77,32 @@ pub fn is_interactive_hit_event(event: &Event) -> bool {
     )
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ImageFormat {
-    Png,
-    Jpeg,
-    XIcon,
+/// Returns true if the given MIME type is an image format that makepad can display.
+pub fn is_supported_image_mimetype(mimetype: &str) -> bool {
+    matches!(
+        mimetype,
+        "image/png"
+            | "image/jpeg"
+            | "image/jpg"
+            | "image/gif"
+            | "image/webp"
+            | "image/bmp"
+            | "image/x-bmp"
+            | "image/x-ms-bmp"
+            | "image/x-icon"
+            | "image/vnd.microsoft.icon"
+            | "image/qoi"
+            | "image/x-qoi"
+            | "image/svg+xml"
+    )
 }
 
-impl ImageFormat {
-    pub fn from_mimetype(mimetype: &str) -> Option<Self> {
-        match mimetype {
-            "image/png" => Some(Self::Png),
-            "image/jpeg" => Some(Self::Jpeg),
-            "image/x-icon" => Some(Self::XIcon),
-            _ => None,
-        }
-    }
-}
-
-/// Loads the given image `data` into the given `ImageRef` as either a
-/// PNG or JPEG, using the `imghdr` library to determine which format it is.
+/// Loads the given image `data` into the given `ImageRef`, auto-detecting any
+/// image format that makepad supports (PNG, JPEG, GIF, WebP, BMP, ICO, QOI).
 ///
-/// Returns an error if either load fails or if the image format is unknown.
-pub fn load_png_or_jpg(img: &ImageRef, cx: &mut Cx, data: &[u8]) -> Result<(), ImageError> {
-
-    fn attempt_both(img: &ImageRef, cx: &mut Cx, data: &[u8]) -> Result<(), ImageError> {
-        img.load_png_from_data(cx, data)
-            .or_else(|_| img.load_jpg_from_data(cx, data))
-    }
-
-    let res = match imghdr::from_bytes(data) {
-        Some(imghdr::Type::Png) => img.load_png_from_data(cx, data),
-        Some(imghdr::Type::Jpeg) => img.load_jpg_from_data(cx, data),
-        Some(unsupported) => {
-            // Attempt to load it as a PNG or JPEG anyway, since imghdr isn't perfect.
-            attempt_both(img, cx, data).map_err(|_| {
-                error!("load_png_or_jpg(): The {unsupported:?} image format is unsupported");
-                ImageError::UnsupportedFormat
-            })
-        }
-        None => {
-            // Attempt to load it as a PNG or JPEG anyway, since imghdr isn't perfect.
-            attempt_both(img, cx, data).map_err(|_| {
-                error!("load_png_or_jpg(): Unknown image format");
-                ImageError::UnsupportedFormat
-            })
-        }
-    };
-    // Disabled: dumping invalid user-selected image bytes can duplicate private or large files.
-    // if let Err(err) = res.as_ref() {
-    //     // debugging: dump out the bad image to disk
-    //     let mut path = crate::temp_storage::get_temp_dir_path().clone();
-    //     let filename = format!(
-    //         "img_{}",
-    //         std::time::SystemTime::now()
-    //             .duration_since(std::time::SystemTime::UNIX_EPOCH)
-    //             .map(|d| d.as_millis())
-    //             .unwrap_or_else(|_| rand::random::<u128>()),
-    //     );
-    //     path.push(filename);
-    //     path.set_extension("unknown");
-    //     error!("Failed to load PNG/JPG: {err}. Dumping bad image: {:?}", path);
-    //     let _ = std::fs::write(path, data)
-    //         .inspect_err(|e| error!("Failed to write bad image to disk: {e}"));
-    // }
-    res
+/// Returns an error if the format is unsupported or decoding fails.
+pub fn load_image(img: &ImageRef, cx: &mut Cx, data: &[u8]) -> Result<(), ImageError> {
+    img.load_image_from_data(cx, data)
 }
 
 


### PR DESCRIPTION
We can now display png, jpg, gif, webp, bmp, ico, qoi, svg, which covers the vast majority of image formats encountered in the wild in Matrix rooms. Note that we already had SVG support,ngs like icons, it just wasn't included in the main `Image` widget.

My changes to makepad make it easy to auto-detect and load any image format, so there's no need for complex PNG- or JPG-specific code with fallbacks. All of that's been moved into makepad's Image widget.

Fix the ImageViewer to support SVGs, and fix its image rotation for images that don't have a square aspec ratio, with a neat little animation.

Plus, now we don't need the dependency on the big `image` crate.