### PR TITLE
Refactor all modals to unify them into one shared `SmallModal` widget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "bytes"
@@ -1954,9 +1954,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
 ]
 
 [[package]]
@@ -2185,9 +2185,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hilog-sys"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b1d492766a538e49020f97af3e91e0acb718b3b008ed4ab6d39374f42b3e83"
+checksum = "f715f263b6e73aa2322b59057134b4daf56a765cbebc2f6b35e640ffded3361b"
 
 [[package]]
 name = "hkdf"
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2952,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2999,15 +2999,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3015,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "weezl",
 ]
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3052,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "ttf-parser",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3093,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3129,15 +3129,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3159,7 +3159,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3171,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3184,13 +3184,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3207,14 +3207,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3268,13 +3268,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "log",
  "makepad-zune-core",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "log",
 ]
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "simd-adler32",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3702,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "mime"
@@ -3868,9 +3868,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if",
@@ -4495,10 +4495,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
  "unicase 2.9.0",
 ]
 
@@ -5377,12 +5377,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5477,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "sealed"
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "siphasher"
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "socket2"
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "tungstenite"
@@ -6635,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-bidi"
@@ -6646,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-ident"
@@ -6667,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-normalization"
@@ -6687,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6703,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "unicode-width"
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "log",
  "pkg-config",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "whoami"
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7326,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 
 [[package]]
 name = "windows-numerics"
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=image_coded_hardening_audit#993560d3887f4a5fa902b0ea92816688f8e4eed9"
+source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "image_coded_hardening_audit", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "image_coded_hardening_audit" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "modal_fixes", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "modal_fixes" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,9 +66,7 @@ script_mod! {
                             home_screen := HomeScreen {}
                         }
                         join_leave_modal := Modal {
-                            content +: {
-                                join_leave_modal_inner := JoinLeaveRoomModal {}
-                            }
+                            content := JoinLeaveRoomModal {}
                         }
                         login_screen_view := View {
                             visible: true
@@ -76,10 +74,7 @@ script_mod! {
                         }
 
                         image_viewer_modal := Modal {
-                            content +: {
-                                width: Fill, height: Fill,
-                                image_viewer_modal_inner := ImageViewer {}
-                            }
+                            content := ImageViewer {}
                         }
                         
                         // Context menus should be shown in front of other UI elements,
@@ -89,75 +84,51 @@ script_mod! {
 
                         // A modal to confirm sending out an invite to a room.
                         invite_confirmation_modal := Modal {
-                            content +: {
-                                invite_confirmation_modal_inner := PositiveConfirmationModal {
-                                    wrapper +: { buttons_view +: { accept_button +: {
-                                        draw_icon +: { svg: (ICON_INVITE) }
-                                        icon_walk: Walk{width: 28, height: Fit, margin: Inset{left: -10, right: 2} }
-                                    } } }
-                                }
+                            content := PositiveConfirmationModal {
+                                buttons_view +: { accept_button +: {
+                                    draw_icon +: { svg: (ICON_INVITE) }
+                                    icon_walk: Walk{width: 28, height: Fit, margin: Inset{left: -10, right: 2} }
+                                } }
                             }
                         }
 
                         // A modal to invite a user to a room.
                         invite_modal := Modal {
-                            content +: {
-                                invite_modal_inner := InviteModal {}
-                            }
+                            content := InviteModal {}
                         }
 
                         // Show the logout confirmation modal.
                         logout_confirm_modal := Modal {
-                            content +: {
-                                logout_confirm_modal_inner := LogoutConfirmModal {}
-                            }
+                            content := LogoutConfirmModal {}
                         }
 
                         // Show the event source modal (View Source for messages).
                         event_source_modal := Modal {
-                            content +: {
-                                height: Fill,
-                                width: Fill,
-                                align: Align{x: 0.5, y: 0.5},
-                                event_source_modal_inner := EventSourceModal {}
-                            }
+                            content := EventSourceModal {}
                         }
 
                         // Show incoming verification requests in front of the aforementioned UI elements.
                         verification_modal := Modal {
                             can_dismiss: false,
-                            content +: {
-                                verification_modal_inner := VerificationModal {}
-                            }
+                            content := VerificationModal {}
                         }
                         tsp_verification_modal := Modal {
-                            content +: {
-                                tsp_verification_modal_inner := TspVerificationModal {}
-                            }
+                            content := TspVerificationModal {}
                         }
 
                         // A generic modal to confirm any positive action.
                         positive_confirmation_modal := Modal {
-                            content +: {
-                                positive_confirmation_modal_inner := PositiveConfirmationModal { }
-                            }
+                            content := PositiveConfirmationModal {}
                         }
 
                         // A modal to confirm any deletion/removal action.
                         delete_confirmation_modal := Modal {
-                            content +: {
-                                delete_confirmation_modal_inner := NegativeConfirmationModal { }
-                            }
+                            content := NegativeConfirmationModal {}
                         }
 
                         // A modal to preview and confirm file uploads.
                         file_upload_modal := Modal {
-                            content +: {
-                                height: Fill,
-                                width: Fill,
-                                align: Align{x: 0.5, y: 0.5},
-                                file_upload_modal_inner := FileUploadModal {}
-                            }
+                            content := FileUploadModal {}
                         }
 
                         PopupList {}
@@ -255,25 +226,25 @@ impl MatchEvent for App {
     }
 
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions) {
-        let invite_confirmation_modal_inner = self.ui.confirmation_modal(cx, ids!(invite_confirmation_modal_inner));
-        if let Some(_accepted) = invite_confirmation_modal_inner.closed(actions) {
+        let invite_confirmation_modal_content = self.ui.confirmation_modal(cx, ids!(invite_confirmation_modal.content));
+        if let Some(_accepted) = invite_confirmation_modal_content.closed(actions) {
             self.ui.modal(cx, ids!(invite_confirmation_modal)).close(cx);
         }
 
-        let delete_confirmation_modal_inner = self.ui.confirmation_modal(cx, ids!(delete_confirmation_modal_inner));
-        if let Some(_accepted) = delete_confirmation_modal_inner.closed(actions) {
+        let delete_confirmation_modal_content = self.ui.confirmation_modal(cx, ids!(delete_confirmation_modal.content));
+        if let Some(_accepted) = delete_confirmation_modal_content.closed(actions) {
             self.ui.modal(cx, ids!(delete_confirmation_modal)).close(cx);
         }
 
-        let positive_confirmation_modal_inner = self.ui.confirmation_modal(cx, ids!(positive_confirmation_modal_inner));
-        if let Some(_accepted) = positive_confirmation_modal_inner.closed(actions) {
+        let positive_confirmation_modal_content = self.ui.confirmation_modal(cx, ids!(positive_confirmation_modal.content));
+        if let Some(_accepted) = positive_confirmation_modal_content.closed(actions) {
             self.ui.modal(cx, ids!(positive_confirmation_modal)).close(cx);
         }
 
         for action in actions {
             match action.downcast_ref() {
                 Some(LogoutConfirmModalAction::Open) => {
-                    self.ui.logout_confirm_modal(cx, ids!(logout_confirm_modal_inner)).reset_state(cx);
+                    self.ui.logout_confirm_modal(cx, ids!(logout_confirm_modal.content)).reset_state(cx);
                     self.ui.modal(cx, ids!(logout_confirm_modal)).open(cx);
                     continue;
                 },
@@ -330,7 +301,7 @@ impl MatchEvent for App {
             // Handle file upload modal actions
             match action.downcast_ref() {
                 Some(FilePreviewerAction::Show { upload }) => {
-                    self.ui.file_upload_modal(cx, ids!(file_upload_modal_inner))
+                    self.ui.file_upload_modal(cx, ids!(file_upload_modal.content))
                         .set_upload(cx, upload.clone());
                     self.ui.modal(cx, ids!(file_upload_modal)).open(cx);
                     continue;
@@ -447,7 +418,7 @@ impl MatchEvent for App {
             match action.downcast_ref() {
                 Some(JoinLeaveRoomModalAction::Open { kind, show_tip }) => {
                     self.ui
-                        .join_leave_room_modal(cx, ids!(join_leave_modal_inner))
+                        .join_leave_room_modal(cx, ids!(join_leave_modal.content))
                         .set_kind(cx, kind.clone(), *show_tip);
                     self.ui.modal(cx, ids!(join_leave_modal)).open(cx);
                     continue;
@@ -466,7 +437,7 @@ impl MatchEvent for App {
             //
             // Note: other verification actions are handled by the verification modal itself.
             if let Some(VerificationAction::RequestReceived(state)) = action.downcast_ref() {
-                self.ui.verification_modal(cx, ids!(verification_modal_inner))
+                self.ui.verification_modal(cx, ids!(verification_modal.content))
                     .initialize_with_data(cx, state.clone());
                 self.ui.modal(cx, ids!(verification_modal)).open(cx);
                 continue;
@@ -492,7 +463,7 @@ impl MatchEvent for App {
                 use crate::tsp::{tsp_verification_modal::{TspVerificationModalAction, TspVerificationModalWidgetRefExt}, TspIdentityAction};
 
                 if let Some(TspIdentityAction::ReceivedDidAssociationRequest { details, wallet_db }) = action.downcast_ref() {
-                    self.ui.tsp_verification_modal(cx, ids!(tsp_verification_modal_inner))
+                    self.ui.tsp_verification_modal(cx, ids!(tsp_verification_modal.content))
                         .initialize_with_details(cx, details.clone(), wallet_db.deref().clone());
                     self.ui.modal(cx, ids!(tsp_verification_modal)).open(cx);
                     continue;
@@ -506,7 +477,7 @@ impl MatchEvent for App {
             // Handle a request to show the invite confirmation modal.
             if let Some(InviteAction::ShowInviteConfirmationModal(content_opt)) = action.downcast_ref() {
                 if let Some(content) = content_opt.borrow_mut().take() {
-                    invite_confirmation_modal_inner.show(cx, content);
+                    invite_confirmation_modal_content.show(cx, content);
                     self.ui.modal(cx, ids!(invite_confirmation_modal)).open(cx);
                 }
                 continue;
@@ -515,7 +486,7 @@ impl MatchEvent for App {
             // Handle a request to show the generic positive confirmation modal.
             if let Some(PositiveConfirmationModalAction::Show(content_opt)) = action.downcast_ref() {
                 if let Some(content) = content_opt.borrow_mut().take() {
-                    positive_confirmation_modal_inner.show(cx, content);
+                    positive_confirmation_modal_content.show(cx, content);
                     self.ui.modal(cx, ids!(positive_confirmation_modal)).open(cx);
                 }
                 continue;
@@ -524,7 +495,7 @@ impl MatchEvent for App {
             // Handle a request to show the delete confirmation modal.
             if let Some(ConfirmDeleteAction::Show(content_opt)) = action.downcast_ref() {
                 if let Some(content) = content_opt.borrow_mut().take() {
-                    self.ui.confirmation_modal(cx, ids!(delete_confirmation_modal_inner)).show(cx, content);
+                    self.ui.confirmation_modal(cx, ids!(delete_confirmation_modal.content)).show(cx, content);
                     self.ui.modal(cx, ids!(delete_confirmation_modal)).open(cx);
                 }
                 continue;
@@ -533,7 +504,7 @@ impl MatchEvent for App {
             // Handle InviteModalAction to open/close the invite modal.
             match action.downcast_ref() {
                 Some(InviteModalAction::Open(room_name_id)) => {
-                    self.ui.invite_modal(cx, ids!(invite_modal_inner)).show(cx, room_name_id.clone());
+                    self.ui.invite_modal(cx, ids!(invite_modal.content)).show(cx, room_name_id.clone());
                     self.ui.modal(cx, ids!(invite_modal)).open(cx); 
                     continue;
                 }
@@ -547,7 +518,7 @@ impl MatchEvent for App {
             // Handle EventSourceModalAction to open/close the event source modal.
             match action.downcast_ref() {
                 Some(EventSourceModalAction::Open { room_id, event_id, latest_json }) => {
-                    self.ui.event_source_modal(cx, ids!(event_source_modal_inner))
+                    self.ui.event_source_modal(cx, ids!(event_source_modal.content))
                         .show(cx, room_id.clone(), event_id.clone(), latest_json.clone());
                     self.ui.modal(cx, ids!(event_source_modal)).open(cx);
                     continue;
@@ -579,7 +550,7 @@ impl MatchEvent for App {
                             user_profile.user_id,
                         ),
                     };
-                    positive_confirmation_modal_inner.show(
+                    positive_confirmation_modal_content.show(
                         cx,
                         ConfirmationModalContent {
                             title_text: "Create New Direct Message".into(),

--- a/src/home/event_source_modal.rs
+++ b/src/home/event_source_modal.rs
@@ -34,10 +34,8 @@ script_mod! {
         ..mod.widgets.RoundedView
 
         width: Fill { max: 1000 }
-        // TODO: i'd like for this height to be Fit with a max of Rel { base: Full, factor: 0.90 },
-        //       but Makepad doesn't allow Fit views with a max to be scrolled.
-        height: Fill // { max: 1400 }
-        margin: 40,
+        height: Fit { max: FitBound.Rel{base: Base.Full, factor: 1.0} }
+        margin: 30,
         align: Align{x: 0.5, y: 0}
         flow: Down
         padding: Inset{top: 20, right: 25, bottom: 20, left: 25}

--- a/src/home/invite_modal.rs
+++ b/src/home/invite_modal.rs
@@ -13,104 +13,66 @@ script_mod! {
     use mod.widgets.*
 
 
-    mod.widgets.InviteModal = #(InviteModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.InviteModal = set_type_default() do #(InviteModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
 
-        RoundedView {
-            width: 400
-            height: Fit
-            align: Align{x: 0.5}
-            flow: Down
-            padding: Inset{top: 30, right: 25, bottom: 20, left: 25}
+        title := ModalTitle {}
 
-            show_bg: true
-            draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 4.0
+        user_id_input := RobrixTextInput {
+            draw_text +: {
+                text_style: REGULAR_TEXT {font_size: 11},
+                color: #000
+            }
+            empty_text: "@user:example.org",
+        }
+
+        buttons_view := ModalButtonsRow {
+            cancel_button := RobrixNeutralIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 12,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Cancel"
             }
 
-            title_view := View {
+            confirm_button := RobrixPositiveIconButton {
+                width: 120
+                align: Align{x: 0.5, y: 0.5}
+                padding: 12,
+                draw_icon.svg: (ICON_ADD_USER)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Invite"
+            }
+
+            okay_button := RobrixIconButton {
+                visible: false
+                width: 120
+                align: Align{x: 0.5, y: 0.5}
+                padding: 12,
+                draw_icon.svg: (ICON_CHECKMARK)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Okay"
+            }
+        }
+
+        status_label_view := View {
+            visible: false
+            width: Fill,
+            height: Fit,
+            align: Align{x: 0.5, y: 0.0}
+
+            status_label := Label {
                 width: Fill,
                 height: Fit,
-                padding: Inset{top: 0, bottom: 25}
+                flow: Flow.Right{wrap: true},
                 align: Align{x: 0.5, y: 0.0}
-
-                title := Label {
-                    width: Fill
-                    height: Fit
-                    align: Align{x: 0.5}
-                    flow: Flow.Right{wrap: true},
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                    text: "Invite to Room"
-                }
-            }
-
-            user_id_input := RobrixTextInput {
+                margin: Inset{top: 10}
                 draw_text +: {
                     text_style: REGULAR_TEXT {font_size: 11},
                     color: #000
                 }
-                empty_text: "@user:example.org",
-            }
-
-            View {
-                width: Fill, height: Fit
-                flow: Right,
-                padding: Inset{top: 20, bottom: 10}
-                align: Align{x: 1.0, y: 0.5}
-                spacing: 20
-
-                cancel_button := RobrixNeutralIconButton {
-                    width: 120,
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 12,
-                    draw_icon.svg: (ICON_FORBIDDEN)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Cancel"
-                }
-
-                confirm_button := RobrixPositiveIconButton {
-                    width: 120
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 12,
-                    draw_icon.svg: (ICON_ADD_USER)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Invite"
-                }
-
-                okay_button := RobrixIconButton {
-                    visible: false
-                    width: 120
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 12,
-                    draw_icon.svg: (ICON_CHECKMARK)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Okay"
-                }
-            }
-
-            status_label_view := View {
-                visible: false
-                width: Fill,
-                height: Fit,
-                align: Align{x: 0.5, y: 0.0}
-
-                status_label := Label {
-                    width: Fill,
-                    height: Fit,
-                    flow: Flow.Right{wrap: true},
-                    align: Align{x: 0.5, y: 0.0}
-                    margin: Inset{top: 10}
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {font_size: 11},
-                        color: #000
-                    }
-                    text: ""
-                }
+                text: ""
             }
         }
     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2751,6 +2751,9 @@ impl RoomScreen {
         self.hide_timeline();
         // Reset the the state of the inner loading pane.
         self.loading_pane(cx, ids!(loading_pane)).take_state();
+        // Reset the user profile sliding pane so a previous room's open profile
+        // pane doesn't remain shown when this RoomScreen is reused for a new room.
+        self.user_profile_sliding_pane(cx, ids!(user_profile_sliding_pane)).reset(cx);
 
         self.room_name_id = Some(room_name_id.clone());
         self.timeline_kind = Some(timeline_kind.clone());

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -15,98 +15,52 @@ script_mod! {
     use mod.widgets.*
 
 
-    mod.widgets.JoinLeaveRoomModal = #(JoinLeaveRoomModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.JoinLeaveRoomModal = set_type_default() do #(JoinLeaveRoomModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
 
-        RoundedView {
-            flow: Down
-            width: 400
-            height: Fit
-            padding: Inset{top: 30, right: 40, bottom: 20, left: 40}
+        title := ModalTitle {}
 
-            show_bg: true
-            draw_bg.color: (COLOR_PRIMARY)
-            draw_bg.border_radius: 4.0
+        body := ModalBody {}
 
-            title_view := View {
-                width: Fill,
-                height: Fit,
-                padding: Inset{top: 0, bottom: 25}
-                align: Align{x: 0.5, y: 0.0}
-
-                title := Label {
-                    flow: Flow.Right{wrap: true},
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                }
+        buttons_view := ModalButtonsRow {
+            cancel_button := RobrixNegativeIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Cancel"
             }
 
-            body := View {
+            accept_button := RobrixPositiveIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_CHECKMARK)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Yes"
+            }
+        }
+
+        tip_view := View {
+            width: Fill,
+            height: Fit,
+            align: Align{x: 0.5, y: 0.0}
+
+            tip := Label {
+                padding: 0,
+                margin: 0,
                 width: Fill,
                 height: Fit,
-                flow: Down,
-
-                description := Label {
-                    width: Fill
-                    flow: Flow.Right{wrap: true}
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {
-                            font_size: 11.5,
-                        },
-                        color: #000
-                    }
+                flow: Flow.Right{wrap: true},
+                align: Align{x: 0.5}
+                draw_text +: {
+                    text_style: REGULAR_TEXT {
+                        font_size: 9,
+                    },
+                    color: #A,
                 }
-
-                View {
-                    width: Fill, height: Fit
-                    flow: Right,
-                    padding: Inset{top: 20, bottom: 20}
-                    align: Align{x: 1.0, y: 0.5}
-                    spacing: 20
-
-                    cancel_button := RobrixNegativeIconButton {
-                        width: 120,
-                        align: Align{x: 0.5, y: 0.5}
-                        padding: 15,
-                        draw_icon.svg: (ICON_FORBIDDEN)
-                        icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                        text: "Cancel"
-                    }
-
-                    accept_button := RobrixPositiveIconButton {
-                        width: 120,
-                        align: Align{x: 0.5, y: 0.5}
-                        padding: 15,
-                        draw_icon.svg: (ICON_CHECKMARK)
-                        icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                        text: "Yes"
-                    }
-                }
-
-                tip_view := View {
-                    width: Fill,
-                    height: Fit,
-                    align: Align{x: 0.5, y: 0.0}
-
-                    tip := Label {
-                        padding: 0,
-                        margin: 0,
-                        width: Fill,
-                        height: Fit,
-                        flow: Flow.Right{wrap: true},
-                        align: Align{x: 0.5}
-                        draw_text +: {
-                            text_style: REGULAR_TEXT {
-                                font_size: 9,
-                            },
-                            color: #A,
-                        }
-                        text: "Tip: hold Shift when clicking a button to bypass this prompt."
-                    }
-                }
+                text: "Tip: hold Shift when clicking a button to bypass this prompt."
             }
         }
     }
@@ -312,7 +266,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                 }
 
                 self.view.label(cx, ids!(title)).set_text(cx, &title);
-                self.view.label(cx, ids!(description)).set_text(cx, &description);
+                self.view.label(cx, ids!(body)).set_text(cx, &description);
                 self.view.view(cx, ids!(tip_view)).set_visible(cx, false);
                 accept_button.set_text(cx, accept_button_text);
                 accept_button.set_enabled(cx, false);
@@ -330,7 +284,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                         Some(3.0),
                     );
                     self.view.label(cx, ids!(title)).set_text(cx, "Joined room!");
-                    self.view.label(cx, ids!(description)).set_text(cx, &format!(
+                    self.view.label(cx, ids!(body)).set_text(cx, &format!(
                         "Successfully joined \"{}\".",
                         kind.room_name(),
                     ));
@@ -340,7 +294,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                     self.view.label(cx, ids!(title)).set_text(cx, "Error joining room!");
                     let was_invite = matches!(kind, JoinLeaveModalKind::AcceptInvite(_) | JoinLeaveModalKind::RejectInvite(_));
                     let msg = utils::stringify_join_leave_error(error, kind.room_name(), true, was_invite);
-                    self.view.label(cx, ids!(description)).set_text(cx, &msg);
+                    self.view.label(cx, ids!(body)).set_text(cx, &msg);
                     enqueue_popup_notification(
                         msg,
                         PopupKind::Error,
@@ -372,7 +326,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                         popup_msg = "Successfully left room.".into();
                     }
                     self.view.label(cx, ids!(title)).set_text(cx, title);
-                    self.view.label(cx, ids!(description)).set_text(cx, &description);
+                    self.view.label(cx, ids!(body)).set_text(cx, &description);
                     enqueue_popup_notification(popup_msg, PopupKind::Success, Some(5.0));
                     new_final_success = Some(true);
                 }
@@ -391,7 +345,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                     }
 
                     self.view.label(cx, ids!(title)).set_text(cx, title);
-                    self.view.label(cx, ids!(description)).set_text(cx, &description);
+                    self.view.label(cx, ids!(body)).set_text(cx, &description);
                     enqueue_popup_notification(popup_msg, PopupKind::Error, None);
                     new_final_success = Some(false);
                 }
@@ -415,7 +369,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                         }
                     }
                     self.view.label(cx, ids!(title)).set_text(cx, title);
-                    self.view.label(cx, ids!(description)).set_text(cx, &description);
+                    self.view.label(cx, ids!(body)).set_text(cx, &description);
                 }
             }
         }
@@ -509,7 +463,7 @@ impl JoinLeaveRoomModal {
         }
 
         self.view.label(cx, ids!(title)).set_text(cx, title);
-        self.view.label(cx, ids!(description)).set_text(cx, &description);
+        self.view.label(cx, ids!(body)).set_text(cx, &description);
         if show_tip {
             self.view.view(cx, ids!(tip_view)).set_visible(cx, true);
             self.view.label(cx, ids!(tip)).set_text(cx, &format!(

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -304,9 +304,7 @@ script_mod! {
                 // such as when the user is logging in or when there is an error.
                 login_status_modal := Modal {
                     can_dismiss: false,
-                    content +: {
-                        login_status_modal_inner := mod.widgets.LoginStatusModal {}
-                    }
+                    content := mod.widgets.LoginStatusModal {}
                 }
             }
         }
@@ -348,7 +346,7 @@ impl MatchEvent for LoginScreen {
         let homeserver_input = self.view.text_input(cx, ids!(homeserver_input));
 
         let login_status_modal = self.view.modal(cx, ids!(login_status_modal));
-        let login_status_modal_inner = self.view.login_status_modal(cx, ids!(login_status_modal_inner));
+        let login_status_modal_content = self.view.login_status_modal(cx, ids!(login_status_modal.content));
 
         // Handle toggling password visibility
         let show_pw_button = self.view.button(cx, ids!(show_password_button));
@@ -376,17 +374,17 @@ impl MatchEvent for LoginScreen {
             let password = password_input.text();
             let homeserver = homeserver_input.text();
             if user_id.is_empty() {
-                login_status_modal_inner.set_title(cx, "Missing User ID");
-                login_status_modal_inner.set_status(cx, "Please enter a valid User ID.");
-                login_status_modal_inner.button_ref(cx).set_text(cx, "Okay");
+                login_status_modal_content.set_title(cx, "Missing User ID");
+                login_status_modal_content.set_status(cx, "Please enter a valid User ID.");
+                login_status_modal_content.button_ref(cx).set_text(cx, "Okay");
             } else if password.is_empty() {
-                login_status_modal_inner.set_title(cx, "Missing Password");
-                login_status_modal_inner.set_status(cx, "Please enter a valid password.");
-                login_status_modal_inner.button_ref(cx).set_text(cx, "Okay");
+                login_status_modal_content.set_title(cx, "Missing Password");
+                login_status_modal_content.set_status(cx, "Please enter a valid password.");
+                login_status_modal_content.button_ref(cx).set_text(cx, "Okay");
             } else {
-                login_status_modal_inner.set_title(cx, "Logging in...");
-                login_status_modal_inner.set_status(cx, "Waiting for a login response...");
-                login_status_modal_inner.button_ref(cx).set_text(cx, "Cancel");
+                login_status_modal_content.set_title(cx, "Logging in...");
+                login_status_modal_content.set_status(cx, "Waiting for a login response...");
+                login_status_modal_content.button_ref(cx).set_text(cx, "Cancel");
                 submit_async_request(MatrixRequest::Login(LoginRequest::LoginByPassword(LoginByPassword {
                     user_id,
                     password,
@@ -417,20 +415,20 @@ impl MatchEvent for LoginScreen {
                     user_id_input.set_text(cx, user_id);
                     password_input.set_text(cx, "");
                     homeserver_input.set_text(cx, homeserver.as_deref().unwrap_or_default());
-                    login_status_modal_inner.set_title(cx, "Logging in via CLI...");
-                    login_status_modal_inner.set_status(
+                    login_status_modal_content.set_title(cx, "Logging in via CLI...");
+                    login_status_modal_content.set_status(
                         cx,
                         &format!("Auto-logging in as user {user_id}...")
                     );
-                    let login_status_modal_button = login_status_modal_inner.button_ref(cx);
+                    let login_status_modal_button = login_status_modal_content.button_ref(cx);
                     login_status_modal_button.set_text(cx, "Cancel");
                     login_status_modal_button.set_enabled(cx, false); // Login cancel not yet supported
                     login_status_modal.open(cx);
                 }
                 Some(LoginAction::Status { title, status }) => {
-                    login_status_modal_inner.set_title(cx, title);
-                    login_status_modal_inner.set_status(cx, status);
-                    let login_status_modal_button = login_status_modal_inner.button_ref(cx);
+                    login_status_modal_content.set_title(cx, title);
+                    login_status_modal_content.set_status(cx, status);
+                    let login_status_modal_button = login_status_modal_content.button_ref(cx);
                     login_status_modal_button.set_text(cx, "Cancel");
                     login_status_modal_button.set_enabled(cx, true);
                     login_status_modal.open(cx);
@@ -446,9 +444,9 @@ impl MatchEvent for LoginScreen {
                     self.redraw(cx);
                 }
                 Some(LoginAction::LoginFailure(error)) => {
-                    login_status_modal_inner.set_title(cx, "Login Failed.");
-                    login_status_modal_inner.set_status(cx, error);
-                    let login_status_modal_button = login_status_modal_inner.button_ref(cx);
+                    login_status_modal_content.set_title(cx, "Login Failed.");
+                    login_status_modal_content.set_status(cx, error);
+                    let login_status_modal_button = login_status_modal_content.button_ref(cx);
                     login_status_modal_button.set_text(cx, "Okay");
                     login_status_modal_button.set_enabled(cx, true);
                     login_status_modal.open(cx);
@@ -477,7 +475,7 @@ impl MatchEvent for LoginScreen {
 
         // If the Login SSO screen's "cancel" button was clicked, send a http request to gracefully shutdown the SSO server
         if let Some(sso_redirect_url) = &self.sso_redirect_url {
-            let login_status_modal_button = login_status_modal_inner.button_ref(cx);
+            let login_status_modal_button = login_status_modal_content.button_ref(cx);
             if login_status_modal_button.clicked(actions) {
                 let request_id = id!(SSO_CANCEL_BUTTON);
                 let request = HttpRequest::new(format!("{}/?login_token=",sso_redirect_url), HttpMethod::GET);
@@ -491,7 +489,7 @@ impl MatchEvent for LoginScreen {
         // SSO failure path, which resets state for the next attempt.
         #[cfg(target_os = "ios")]
         if self.sso_pending {
-            let login_status_modal_button = login_status_modal_inner.button_ref(cx);
+            let login_status_modal_button = login_status_modal_content.button_ref(cx);
             if login_status_modal_button.clicked(actions) {
                 crate::sliding_sync::cancel_active_sso_auth_session();
             }

--- a/src/login/login_status_modal.rs
+++ b/src/login/login_status_modal.rs
@@ -6,67 +6,22 @@ script_mod! {
 
 
     // A modal dialog that displays the status of a login attempt.
-    mod.widgets.LoginStatusModal = #(LoginStatusModal::register_widget(vm)) {
-        width: Fit,
-        height: Fit
-        align: Align{x: 0.5}
+    mod.widgets.LoginStatusModal = set_type_default() do #(LoginStatusModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
 
-        RoundedView {
-            width: 350
-            height: Fit,
-            flow: Down,
+        title := ModalTitle { text: "Login Status" }
+
+        body := ModalBody {
             align: Align{x: 0.5}
-            padding: 25,
-            spacing: 10,
+            margin: Inset{top: 5, bottom: 5}
+        }
 
-            show_bg: true
-            draw_bg +: {
-                color: #CCC
-                border_radius: 4.0
-            }
-
-            View {
-                width: Fill,
-                height: Fit,
-                flow: Right
-                padding: Inset{top: 0, bottom: 10}
-                align: Align{x: 0.5, y: 0.0}
-
-                title := Label {
-                    text: "Login Status"
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                }
-            }
-
-            status := Label {
-                width: Fill
-                margin: Inset{top: 5, bottom: 5}
-                align: Align{x: 0.5, y: 0.0}
-                flow: Flow.Right{wrap: true}
-                draw_text +: {
-                    text_style: REGULAR_TEXT {
-                        font_size: 11.5,
-                    },
-                    color: #000
-                }
-            }
-
-            View {
-                width: Fill,
-                height: Fit,
-                flow: Right
-                align: Align{x: 1.0}
-                margin: Inset{top: 10}
-
-                button := RobrixIconButton {
-                    align: Align{x: 0.5, y: 0.5}
-                    width: Fit, height: Fit
-                    padding: 12
-                    text: "Cancel"
-                }
+        buttons_view := ModalButtonsRow {
+            button := RobrixIconButton {
+                align: Align{x: 0.5, y: 0.5}
+                width: Fit, height: Fit
+                padding: 12
+                text: "Cancel"
             }
         }
     }
@@ -127,7 +82,7 @@ impl LoginStatusModal {
 
     /// Sets the status text displayed in the body of the modal.
     fn set_status(&mut self, cx: &mut Cx, status: &str) {
-        self.label(cx, ids!(status)).set_text(cx, status);
+        self.label(cx, ids!(body)).set_text(cx, status);
     }
 
     /// Returns a reference to the modal's button, enabling you to set its properties.

--- a/src/logout/logout_confirm_modal.rs
+++ b/src/logout/logout_confirm_modal.rs
@@ -12,77 +12,34 @@ script_mod! {
 
 
     // A modal dialog that displays logout confirmation
-    mod.widgets.LogoutConfirmModal = #(LogoutConfirmModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.LogoutConfirmModal = set_type_default() do #(LogoutConfirmModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
 
-        RoundedView {
-            width: 400
-            height: Fit
-            align: Align{x: 0.5}
-            flow: Down
-            padding: Inset{top: 30, right: 25, bottom: 20, left: 25}
+        title := ModalTitle {
+            text: "Confirm Logout"
+        }
 
-            show_bg: true
-            draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 4.0
+        body := ModalBody {
+            text: "Are you sure you want to logout?"
+        }
+
+        buttons_view := ModalButtonsRow {
+            cancel_button := RobrixNeutralIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 12,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Cancel"
             }
 
-            title_view := View {
-                width: Fill,
-                height: Fit,
-                padding: Inset{top: 0, bottom: 25}
-                align: Align{x: 0.5, y: 0.0}
-
-                title := Label {
-                    width: Fill
-                    height: Fit
-                    align: Align{x: 0.5}
-                    flow: Flow.Right{wrap: true},
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                    text: "Confirm Logout"
-                }
-            }
-
-            message := Label {
-                width: Fill
-                height: Fit
-                flow: Flow.Right{wrap: true},
-                draw_text +: {
-                    text_style: REGULAR_TEXT {font_size: 11},
-                    color: #000
-                },
-                text: "Are you sure you want to logout?"
-            }
-
-            View {
-                width: Fill, height: Fit
-                flow: Right,
-                padding: Inset{top: 20, bottom: 10}
-                align: Align{x: 1.0, y: 0.5}
-                spacing: 20
-
-                cancel_button := RobrixNeutralIconButton {
-                    width: 120,
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 12,
-                    draw_icon.svg: (ICON_FORBIDDEN)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Cancel"
-                }
-
-                confirm_button := RobrixNegativeIconButton {
-                    width: 120
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 12,
-                    draw_icon.svg: (ICON_LOGOUT)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Logout Now"
-                }
+            confirm_button := RobrixNegativeIconButton {
+                width: 120
+                align: Align{x: 0.5, y: 0.5}
+                padding: 12,
+                draw_icon.svg: (ICON_LOGOUT)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Logout Now"
             }
         }
     }
@@ -301,7 +258,7 @@ impl WidgetMatchEvent for LogoutConfirmModal {
 impl LogoutConfirmModal {
     /// Sets the message text displayed in the body of the modal.
     pub fn set_message(&mut self, cx: &mut Cx, message: &str) {
-        self.label(cx, ids!(message)).set_text(cx, message);
+        self.label(cx, ids!(body)).set_text(cx, message);
     }
 
     fn reset_state(&mut self, cx: &mut Cx) {

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -664,9 +664,6 @@ impl UserProfileSlidingPaneRef {
     }
 
     /// Hides the pane immediately and clears its state without animating it out.
-    ///
-    /// Used when a RoomScreen is reused for a different room, so a previous
-    /// room's open profile pane doesn't remain shown in the new room.
     pub fn reset(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.visible = false;
@@ -674,10 +671,6 @@ impl UserProfileSlidingPaneRef {
         inner.is_animating_out = false;
         inner.info = None;
         inner.view(cx, ids!(bg_view)).set_visible(cx, false);
-        // If the pane currently holds key focus, release it so the now-hidden pane
-        // can't swallow keyboard input after the RoomScreen is reused. Guarded so we
-        // never steal focus from another widget (e.g. the message input) when the
-        // pane wasn't focused, matching the animated-hide cleanup path above.
         if cx.has_key_focus(inner.view.area()) {
             cx.revert_key_focus();
         }

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -662,4 +662,25 @@ impl UserProfileSlidingPaneRef {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.show(cx);
     }
+
+    /// Hides the pane immediately and clears its state without animating it out.
+    ///
+    /// Used when a RoomScreen is reused for a different room, so a previous
+    /// room's open profile pane doesn't remain shown in the new room.
+    pub fn reset(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.visible = false;
+        inner.animator_cut(cx, ids!(panel.hide));
+        inner.is_animating_out = false;
+        inner.info = None;
+        inner.view(cx, ids!(bg_view)).set_visible(cx, false);
+        // If the pane currently holds key focus, release it so the now-hidden pane
+        // can't swallow keyboard input after the RoomScreen is reused. Guarded so we
+        // never steal focus from another widget (e.g. the message input) when the
+        // pane wasn't focused, matching the animated-hide cleanup path above.
+        if cx.has_key_focus(inner.view.area()) {
+            cx.revert_key_focus();
+        }
+        inner.redraw(cx);
+    }
 }

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -78,15 +78,11 @@ script_mod! {
 
         // We want all modals to appear in front of the settings screen.
         create_wallet_modal := Modal {
-            content +: {
-                create_wallet_modal_inner := CreateWalletModal {}
-            }
+            content := CreateWalletModal {}
         }
 
         create_did_modal := Modal {
-            content +: {
-                create_did_modal_inner := CreateDidModal {}
-            }
+            content := CreateDidModal {}
         }
     }
 }
@@ -149,7 +145,7 @@ impl Widget for SettingsScreen {
                 match action.downcast_ref() {
                     Some(CreateWalletModalAction::Open) => {
                         use crate::tsp::create_wallet_modal::CreateWalletModalWidgetExt;
-                        self.view.create_wallet_modal(cx, ids!(create_wallet_modal_inner)).show(cx);
+                        self.view.create_wallet_modal(cx, ids!(create_wallet_modal.content)).show(cx);
                         self.view.modal(cx, ids!(create_wallet_modal)).open(cx);
                     }
                     Some(CreateWalletModalAction::Close) => {
@@ -162,7 +158,7 @@ impl Widget for SettingsScreen {
                 match action.downcast_ref() {
                     Some(CreateDidModalAction::Open) => {
                         use crate::tsp::create_did_modal::CreateDidModalWidgetExt;
-                        self.view.create_did_modal(cx, ids!(create_did_modal_inner)).show(cx);
+                        self.view.create_did_modal(cx, ids!(create_did_modal.content)).show(cx);
                         self.view.modal(cx, ids!(create_did_modal)).open(cx);
                     }
                     Some(CreateDidModalAction::Close) => {

--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -12,75 +12,27 @@ script_mod! {
 
     // A confirmation modal with no icons in the buttons.
     // The accept button is blue and the cancel button is gray.
-    mod.widgets.ConfirmationModal = #(ConfirmationModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.ConfirmationModal = set_type_default() do #(ConfirmationModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
 
-        wrapper := RoundedView {
-            width: 400
-            height: Fit
-            align: Align{x: 0.5}
-            flow: Down
-            padding: Inset{top: 30, right: 40, bottom: 20, left: 40}
+        title := ModalTitle {}
+        body := ModalBody {}
 
-            show_bg: true
-            draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 4.0
+        buttons_view := ModalButtonsRow {
+            cancel_button := RobrixNeutralIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                icon_walk: Walk{width: 0, height: 0, margin: 0}
+                text: "Cancel"
             }
 
-            title_view := View {
-                width: Fill,
-                height: Fit,
-                padding: Inset{top: 0, bottom: 25}
-                align: Align{x: 0.5, y: 0.0}
-
-                title := Label {
-                    flow: Flow.Right{wrap: true},
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                }
-            }
-
-            body_view := View {
-                width: Fill, height: Fit
-                align: Align{x: 0.5, y: 0.0}
-
-                body := Label {
-                    width: Fill, height: Fit
-                    flow: Flow.Right{wrap: true},
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {font_size: 11.5},
-                        color: #000
-                    }
-                }
-            }
-
-            buttons_view := View {
-                width: Fill, height: Fit
-                flow: Right,
-                padding: Inset{top: 20, bottom: 20}
-                margin: Inset{right: -15}
-                align: Align{x: 1.0, y: 0.5}
-                spacing: 20
-
-                cancel_button := RobrixNeutralIconButton {
-                    width: 120,
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    icon_walk: Walk{width: 0, height: 0, margin: 0}
-                    text: "Cancel"
-                }
-
-                accept_button := RobrixPositiveIconButton {
-                    width: 120
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    icon_walk: Walk{width: 0, height: 0, margin: 0}
-                    text: "Confirm"
-                }
+            accept_button := RobrixPositiveIconButton {
+                width: 120
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                icon_walk: Walk{width: 0, height: 0, margin: 0}
+                text: "Confirm"
             }
         }
     }
@@ -88,16 +40,14 @@ script_mod! {
     // A confirmation modal for a positive action.
     // The accept button is green with a checkmark icon.
     mod.widgets.PositiveConfirmationModal = mod.widgets.ConfirmationModal {
-        wrapper +: {
-            buttons_view +: {
-                cancel_button +: {
-                    draw_icon +: { svg: (ICON_FORBIDDEN) }
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
-                }
-                accept_button +: {
-                    draw_icon +: { svg: (ICON_CHECKMARK) }
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
-                }
+        buttons_view +: {
+            cancel_button +: {
+                draw_icon +: { svg: (ICON_FORBIDDEN) }
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
+            }
+            accept_button +: {
+                draw_icon +: { svg: (ICON_CHECKMARK) }
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
             }
         }
     }
@@ -105,22 +55,20 @@ script_mod! {
     // A confirmation modal for a negative action.
     // The accept button is red with a forbidden icon.
     mod.widgets.NegativeConfirmationModal = mod.widgets.ConfirmationModal {
-        wrapper +: {
-            buttons_view +: {
-                cancel_button := RobrixNeutralIconButton {
-                    width: 120,
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    draw_icon +: { svg: (ICON_FORBIDDEN) }
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
-                }
-                accept_button := RobrixNegativeIconButton {
-                    width: 120,
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    draw_icon +: { svg: (ICON_CLOSE) }
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
-                }
+        buttons_view +: {
+            cancel_button := RobrixNeutralIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon +: { svg: (ICON_FORBIDDEN) }
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
+            }
+            accept_button := RobrixNegativeIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon +: { svg: (ICON_CLOSE) }
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
             }
         }
     }

--- a/src/shared/file_upload_modal.rs
+++ b/src/shared/file_upload_modal.rs
@@ -36,7 +36,7 @@ script_mod! {
 
         width: Fill { max: 1000 }
         height: Fill
-        margin: 40,
+        margin: 30,
         align: Align{x: 0.5, y: 0}
         flow: Down
         padding: Inset{top: 20, right: 25, bottom: 20, left: 25}
@@ -69,59 +69,6 @@ script_mod! {
                     color: (COLOR_TEXT)
                 }
                 text: "Upload File"
-            }
-        }
-
-        // Preview area - fills available space with image/icon centered
-        preview_container := View {
-            width: Fill,
-            height: Fill,
-            flow: Overlay,
-            align: Align{x: 0.5, y: 0.5},
-
-            show_bg: true,
-            draw_bg.color: (COLOR_SECONDARY)
-
-            // Image preview container (visible when file is an image)
-            image_preview_container := View {
-                visible: false,
-                width: Fill,
-                height: Fill,
-                image_preview := Image {
-                    width: Fill,
-                    height: Fill,
-                    fit: ImageFit.Smallest,
-                }
-            }
-
-            // File icon (visible when file is not an image)
-            file_icon_container := View {
-                visible: false,
-                width: Fill,
-                height: Fill,
-                align: Align{x: 0.5, y: 0.5},
-                flow: Down,
-                spacing: 10,
-
-                Icon {
-                    width: Fit, height: Fit,
-                    draw_icon +: {
-                        svg: (ICON_FILE)
-                        color: (COLOR_TEXT)
-                    }
-                    icon_walk: Walk{width: 64, height: 64}
-                }
-
-                file_type_label := Label {
-                    width: Fit,
-                    padding: 0,
-                    margin: 0
-                    draw_text +: {
-                        text_style: REGULAR_TEXT { font_size: 10 },
-                        color: (SMALL_STATE_TEXT_COLOR)
-                    }
-                    text: ""
-                }
             }
         }
 
@@ -180,6 +127,59 @@ script_mod! {
                     color: (COLOR_TEXT_WARNING_NOT_FOUND)
                 }
                 text: "This file is empty (0 bytes). Are you sure you want to upload it?"
+            }
+        }
+
+        // Preview area - fills available space with image/icon centered
+        preview_container := View {
+            width: Fill,
+            height: Fill,
+            flow: Overlay,
+            align: Align{x: 0.5, y: 0.5},
+
+            show_bg: true,
+            draw_bg.color: (COLOR_SECONDARY)
+
+            // Image preview container (visible when file is an image)
+            image_preview_container := View {
+                visible: false,
+                width: Fill,
+                height: Fill,
+                image_preview := Image {
+                    width: Fill,
+                    height: Fill,
+                    fit: ImageFit.Smallest,
+                }
+            }
+
+            // File icon (visible when file is not an image)
+            file_icon_container := View {
+                visible: false,
+                width: Fill,
+                height: Fill,
+                align: Align{x: 0.5, y: 0.5},
+                flow: Down,
+                spacing: 10,
+
+                Icon {
+                    width: Fit, height: Fit,
+                    draw_icon +: {
+                        svg: (ICON_FILE)
+                        color: (COLOR_TEXT)
+                    }
+                    icon_walk: Walk{width: 64, height: 64}
+                }
+
+                file_type_label := Label {
+                    width: Fit,
+                    padding: 0,
+                    margin: 0
+                    draw_text +: {
+                        text_style: REGULAR_TEXT { font_size: 10 },
+                        color: (SMALL_STATE_TEXT_COLOR)
+                    }
+                    text: ""
+                }
             }
         }
 

--- a/src/shared/helpers.rs
+++ b/src/shared/helpers.rs
@@ -41,21 +41,16 @@ script_mod! {
     mod.widgets.FillerX = View { width: Fill, height: Fit }
     mod.widgets.FillerY = View { width: Fit,  height: Fill }
 
-    // Shared base for all small (non-full-screen) modal dialogs: fills width up to 400
-    // with a 20px left/right gutter so it stays off the edges on narrow screens, caps its
-    // height at 90% of the viewport, and scrolls vertically when content is taller.
-    // Defines the standard padding all modals share; modals add only their content.
+
+    // The base widget definition used for all "small" modals in Robrix.
     mod.widgets.SmallModal = RoundedView {
         width: Fill { max: 400 }
-        height: Fit { max: FitBound.Rel{base: Base.Full, factor: 0.9} }
-        // Only a horizontal gutter; the vertical gap comes from the Modal centering
-        // the (capped) box, so a tall/scrollable modal can't overflow off the bottom.
-        margin: Inset{left: 20, right: 20}
+        height: Fit { max: FitBound.Rel{base: Base.Full, factor: 1.0} }
+        margin: 20
         padding: Inset{top: 30, right: 25, bottom: 20, left: 25}
         flow: Down
 
-        // Scroll the content when it's taller than the max height, so the
-        // buttons stay reachable on short windows.
+        // Make the modal scrollable for cases when it's too tall for the app window.
         scroll_bars: ScrollBars {
             show_scroll_x: false
             show_scroll_y: true
@@ -69,11 +64,6 @@ script_mod! {
         }
     }
 
-    // Shared dialog pieces for SmallModal-based modals. Declared inline in each modal
-    // (Makepad can't inherit child widgets from a plain base), but they centralize the
-    // styling and the wrapping behavior so modals don't repeat it.
-
-    // A modal title: fills the width and wraps, centered.
     mod.widgets.ModalTitle = Label {
         width: Fill, height: Fit
         flow: Flow.Right{wrap: true}
@@ -85,7 +75,7 @@ script_mod! {
         }
     }
 
-    // A modal body/description label: fills the width and wraps.
+    // A modal body or description label, which fills the width and wraps.
     mod.widgets.ModalBody = Label {
         width: Fill, height: Fit
         flow: Flow.Right{wrap: true}
@@ -95,13 +85,13 @@ script_mod! {
         }
     }
 
-    // A modal buttons row: fills the width, right-aligned, and wraps to the next line
-    // on narrow screens. Each modal adds its own buttons inside.
+    // A modal buttons row that fills the width, is right-aligned,
+    // and wraps to the next line.
     mod.widgets.ModalButtonsRow = View {
         width: Fill, height: Fit
         flow: Flow.Right{wrap: true}
         align: Align{x: 1.0, y: 0.5}
-        spacing: 20
+        spacing: 15
         padding: Inset{top: 20, bottom: 20}
     }
 }

--- a/src/shared/helpers.rs
+++ b/src/shared/helpers.rs
@@ -40,4 +40,68 @@ script_mod! {
 
     mod.widgets.FillerX = View { width: Fill, height: Fit }
     mod.widgets.FillerY = View { width: Fit,  height: Fill }
+
+    // Shared base for all small (non-full-screen) modal dialogs: fills width up to 400
+    // with a 20px left/right gutter so it stays off the edges on narrow screens, caps its
+    // height at 90% of the viewport, and scrolls vertically when content is taller.
+    // Defines the standard padding all modals share; modals add only their content.
+    mod.widgets.SmallModal = RoundedView {
+        width: Fill { max: 400 }
+        height: Fit { max: FitBound.Rel{base: Base.Full, factor: 0.9} }
+        // Only a horizontal gutter; the vertical gap comes from the Modal centering
+        // the (capped) box, so a tall/scrollable modal can't overflow off the bottom.
+        margin: Inset{left: 20, right: 20}
+        padding: Inset{top: 30, right: 25, bottom: 20, left: 25}
+        flow: Down
+
+        // Scroll the content when it's taller than the max height, so the
+        // buttons stay reachable on short windows.
+        scroll_bars: ScrollBars {
+            show_scroll_x: false
+            show_scroll_y: true
+            scroll_bar_y.drag_scrolling: true
+        }
+
+        show_bg: true
+        draw_bg +: {
+            color: (COLOR_PRIMARY)
+            border_radius: 4.0
+        }
+    }
+
+    // Shared dialog pieces for SmallModal-based modals. Declared inline in each modal
+    // (Makepad can't inherit child widgets from a plain base), but they centralize the
+    // styling and the wrapping behavior so modals don't repeat it.
+
+    // A modal title: fills the width and wraps, centered.
+    mod.widgets.ModalTitle = Label {
+        width: Fill, height: Fit
+        flow: Flow.Right{wrap: true}
+        align: Align{x: 0.5}
+        margin: Inset{bottom: 25}
+        draw_text +: {
+            text_style: TITLE_TEXT {font_size: 13},
+            color: #000
+        }
+    }
+
+    // A modal body/description label: fills the width and wraps.
+    mod.widgets.ModalBody = Label {
+        width: Fill, height: Fit
+        flow: Flow.Right{wrap: true}
+        draw_text +: {
+            text_style: REGULAR_TEXT {font_size: 11.5},
+            color: #000
+        }
+    }
+
+    // A modal buttons row: fills the width, right-aligned, and wraps to the next line
+    // on narrow screens. Each modal adds its own buttons inside.
+    mod.widgets.ModalButtonsRow = View {
+        width: Fill, height: Fit
+        flow: Flow.Right{wrap: true}
+        align: Align{x: 1.0, y: 0.5}
+        spacing: 20
+        padding: Inset{top: 20, bottom: 20}
+    }
 }

--- a/src/tsp/create_did_modal.rs
+++ b/src/tsp/create_did_modal.rs
@@ -12,219 +12,183 @@ script_mod! {
     use mod.widgets.*
 
 
-    mod.widgets.CreateDidModal = #(CreateDidModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.CreateDidModal = set_type_default() do #(CreateDidModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
+        align: Align{x: 0.5}
+
+        title := ModalTitle {
+            text: "Create New Identity (DID)"
+        }
 
         RoundedView {
-            width: 400
-            height: Fit
+            width: Fill { max: 350 },
+            height: Fit,
+            spacing: 15,
+            padding: 15,
             align: Align{x: 0.5}
-            flow: Down
-            padding: Inset{top: 30, right: 25, bottom: 20, left: 25}
+            flow: Down,
 
             show_bg: true
             draw_bg +: {
-                color: (COLOR_PRIMARY)
+                color: (COLOR_SECONDARY)
                 border_radius: 4.0
             }
 
-            title_view := View {
+            username_input := RobrixTextInput {
                 width: Fill,
                 height: Fit,
-                padding: Inset{top: 0, bottom: 25}
-                align: Align{x: 0.5, y: 0.0}
+                padding: 10,
+                draw_text +: {
+                    text_style: REGULAR_TEXT {font_size: 12},
+                    color: #000
+                }
+                empty_text: "Identity Username",
+            }
 
-                title := Label {
-                    flow: Flow.Right{wrap: true},
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                    text: "Create New Identity (DID)"
+            alias_input := RobrixTextInput {
+                width: Fill,
+                height: Fit,
+                padding: 10,
+                draw_text +: {
+                    text_style: REGULAR_TEXT {font_size: 12},
+                    color: #000
+                }
+                empty_text: "Enter an alias (optional)",
+            }
+
+            did_type_radio_buttons := View {
+                spacing: 20,
+                width: Fit, height: Fit,
+                did_web := RadioButtonFlat {
+                    text: "Web"
+                    draw_text +: { color: (COLOR_TEXT) }
+                    animator: { active: { default: on } }
+                }
+                did_webvh := RadioButtonFlat {
+                    text: "WebVH"
+                    draw_text +: { color: (COLOR_TEXT) }
+                    animator: { disabled: { default: on } }
+                }
+                did_peer := RadioButtonFlat {
+                    text: "Peer",
+                    draw_text +: { color: (COLOR_TEXT) }
+                    animator: { disabled: { default: on } }
                 }
             }
 
-            RoundedView {
-                width: 350,
-                height: Fit,
-                spacing: 15,
-                padding: 15,
-                align: Align{x: 0.5}
-                flow: Down,
+            View {
+                width: Fill, height: Fit
+                flow: Down
 
-                show_bg: true
-                draw_bg +: {
-                    color: (COLOR_SECONDARY)
-                    border_radius: 4.0
-                }
-
-                username_input := RobrixTextInput {
-                    width: Fill,
-                    height: Fit,
-                    padding: 10,
+                server_input := RobrixTextInput {
+                    width: Fill, height: Fit,
+                    flow: Right, // do not wrap
+                    padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
+                    empty_text: "p.teaspoon.world",
                     draw_text +: {
-                        text_style: REGULAR_TEXT {font_size: 12},
-                        color: #000
-                    }
-                    empty_text: "Identity Username",
-                }
-
-                alias_input := RobrixTextInput {
-                    width: Fill,
-                    height: Fit,
-                    padding: 10,
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {font_size: 12},
-                        color: #000
-                    }
-                    empty_text: "Enter an alias (optional)",
-                }
-
-                did_type_radio_buttons := View {
-                    spacing: 20,
-                    width: Fit, height: Fit,
-                    did_web := RadioButtonFlat {
-                        text: "Web"
-                        draw_text +: { color: (COLOR_TEXT) }
-                        animator: { active: { default: on } }
-                    }
-                    did_webvh := RadioButtonFlat {
-                        text: "WebVH"
-                        draw_text +: { color: (COLOR_TEXT) }
-                        animator: { disabled: { default: on } }
-                    }
-                    did_peer := RadioButtonFlat {
-                        text: "Peer",
-                        draw_text +: { color: (COLOR_TEXT) }
-                        animator: { disabled: { default: on } }
+                        text_style: REGULAR_TEXT {font_size: 10.0}
                     }
                 }
 
                 View {
-                    width: Fill, height: Fit
-                    flow: Down
+                    width: Fill,
+                    height: Fit,
+                    flow: Right,
+                    padding: Inset{top: 5, left: 2, right: 2, bottom: 2}
+                    spacing: 0.0,
+                    align: Align{x: 0.5, y: 0.5} // center horizontally and vertically
 
-                    server_input := RobrixTextInput {
-                        width: Fill, height: Fit,
-                        flow: Right, // do not wrap
-                        padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
-                        empty_text: "p.teaspoon.world",
+                    left_line := LineH {
+                        draw_bg.color: #C8C8C8
+                    }
+
+                    Label {
+                        width: Fit, height: Fit
+                        padding:  0
                         draw_text +: {
-                            text_style: REGULAR_TEXT {font_size: 10.0}
+                            color: #777777
+                            text_style: REGULAR_TEXT {font_size: 9}
                         }
+                        text: "Intermediary server domain"
                     }
 
-                    View {
-                        width: Fill,
-                        height: Fit,
-                        flow: Right,
-                        padding: Inset{top: 5, left: 2, right: 2, bottom: 2}
-                        spacing: 0.0,
-                        align: Align{x: 0.5, y: 0.5} // center horizontally and vertically
-
-                        left_line := LineH {
-                            draw_bg.color: #C8C8C8
-                        }
-
-                        Label {
-                            width: Fit, height: Fit
-                            padding:  0
-                            draw_text +: {
-                                color: #777777
-                                text_style: REGULAR_TEXT {font_size: 9}
-                            }
-                            text: "Intermediary server domain"
-                        }
-
-                        right_line := LineH {
-                            draw_bg.color: #C8C8C8
-                        }
-                    }
-                }
-
-                View {
-                    width: Fill, height: Fit
-                    flow: Down
-
-                    did_server_input := RobrixTextInput {
-                        width: Fill, height: Fit,
-                        flow: Right, // do not wrap
-                        padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
-                        empty_text: "did.teaspoon.world",
-                        draw_text +: {
-                            text_style: REGULAR_TEXT {font_size: 10.0}
-                        }
-                    }
-
-                    View {
-                        width: Fill,
-                        height: Fit,
-                        flow: Right,
-                        padding: Inset{top: 5, left: 2, right: 2, bottom: 2}
-                        spacing: 0.0,
-                        align: Align{x: 0.5, y: 0.5} // center horizontally and vertically
-
-                        left_line := LineH {
-                            draw_bg.color: #C8C8C8
-                        }
-
-                        Label {
-                            width: Fit, height: Fit
-                            padding: 0
-                            draw_text +: {
-                                color: #777777
-                                text_style: REGULAR_TEXT {font_size: 9}
-                            }
-                            text: "DID server domain"
-                        }
-
-                        right_line := LineH {
-                            draw_bg.color: #C8C8C8
-                        }
+                    right_line := LineH {
+                        draw_bg.color: #C8C8C8
                     }
                 }
             }
 
             View {
                 width: Fill, height: Fit
-                flow: Right,
-                padding: Inset{top: 20, bottom: 20}
-                align: Align{x: 1.0, y: 0.5}
-                spacing: 20
+                flow: Down
 
-                cancel_button := RobrixNegativeIconButton {
-                    width: 100,
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    draw_icon.svg: (ICON_FORBIDDEN)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Cancel"
+                did_server_input := RobrixTextInput {
+                    width: Fill, height: Fit,
+                    flow: Right, // do not wrap
+                    padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
+                    empty_text: "did.teaspoon.world",
+                    draw_text +: {
+                        text_style: REGULAR_TEXT {font_size: 10.0}
+                    }
                 }
 
-                accept_button := RobrixPositiveIconButton {
-                    width: 140
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    draw_icon.svg: (ICON_CHECKMARK)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Create DID"
+                View {
+                    width: Fill,
+                    height: Fit,
+                    flow: Right,
+                    padding: Inset{top: 5, left: 2, right: 2, bottom: 2}
+                    spacing: 0.0,
+                    align: Align{x: 0.5, y: 0.5} // center horizontally and vertically
+
+                    left_line := LineH {
+                        draw_bg.color: #C8C8C8
+                    }
+
+                    Label {
+                        width: Fit, height: Fit
+                        padding: 0
+                        draw_text +: {
+                            color: #777777
+                            text_style: REGULAR_TEXT {font_size: 9}
+                        }
+                        text: "DID server domain"
+                    }
+
+                    right_line := LineH {
+                        draw_bg.color: #C8C8C8
+                    }
                 }
             }
+        }
 
-            status_label := Label {
-                width: Fill,
-                height: Fit,
-                padding: 0,
-                margin: 0,
-                flow: Flow.Right{wrap: true},
-                align: Align{x: 0.5, y: 0.0}
-                draw_text +: {
-                    text_style: REGULAR_TEXT {font_size: 11},
-                    color: #000
-                }
-                text: "status label"
+        buttons_view := ModalButtonsRow {
+            cancel_button := RobrixNegativeIconButton {
+                width: 100,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Cancel"
             }
+
+            accept_button := RobrixPositiveIconButton {
+                width: 140
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_CHECKMARK)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Create DID"
+            }
+        }
+
+        status_label := ModalBody {
+            padding: 0,
+            margin: 0,
+            align: Align{x: 0.5, y: 0.0}
+            draw_text +: {
+                text_style: REGULAR_TEXT {font_size: 11}
+            }
+            text: "status label"
         }
     }
 }

--- a/src/tsp/create_wallet_modal.rs
+++ b/src/tsp/create_wallet_modal.rs
@@ -12,168 +12,130 @@ script_mod! {
     use mod.widgets.*
 
 
-    mod.widgets.CreateWalletModal = #(CreateWalletModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.CreateWalletModal = set_type_default() do #(CreateWalletModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
+        align: Align{x: 0.5}
+
+        title := ModalTitle { text: "Create New TSP Wallet" }
 
         RoundedView {
-            width: 400
-            height: Fit
+            width: Fill { max: 350 },
+            height: Fit,
+            spacing: 15,
+            padding: 15,
             align: Align{x: 0.5}
-            flow: Down
-            padding: Inset{top: 30, right: 25, bottom: 20, left: 25}
+            flow: Down,
 
             show_bg: true
             draw_bg +: {
-                color: (COLOR_PRIMARY)
+                color: (COLOR_SECONDARY)
                 border_radius: 4.0
             }
 
-            title_view := View {
+            wallet_name_input := RobrixTextInput {
                 width: Fill,
                 height: Fit,
-                padding: Inset{top: 0, bottom: 25}
-                align: Align{x: 0.5, y: 0.0}
-
-                title := Label {
-                    flow: Flow.Right{wrap: true},
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                    text: "Create New TSP Wallet"
+                padding: 10,
+                draw_text +: {
+                    text_style: REGULAR_TEXT {font_size: 12},
+                    color: #000
                 }
+                empty_text: "Wallet Name",
             }
 
-            RoundedView {
-                width: 350,
+            password_input := RobrixTextInput {
+                width: Fill,
                 height: Fit,
-                spacing: 15,
-                padding: 15,
-                align: Align{x: 0.5}
-                flow: Down,
-
-                show_bg: true
-                draw_bg +: {
-                    color: (COLOR_SECONDARY)
-                    border_radius: 4.0
+                padding: 10,
+                draw_text +: {
+                    text_style: REGULAR_TEXT {font_size: 12},
+                    color: #000
                 }
+                is_password: true,
+                empty_text: "Wallet Password",
+            }
 
-                wallet_name_input := RobrixTextInput {
-                    width: Fill,
-                    height: Fit,
-                    padding: 10,
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {font_size: 12},
-                        color: #000
-                    }
-                    empty_text: "Wallet Name",
+            confirm_password_input := RobrixTextInput {
+                width: Fill,
+                height: Fit,
+                padding: 10,
+                draw_text +: {
+                    text_style: REGULAR_TEXT {font_size: 12},
+                    color: #000
                 }
-
-                password_input := RobrixTextInput {
-                    width: Fill,
-                    height: Fit,
-                    padding: 10,
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {font_size: 12},
-                        color: #000
-                    }
-                    is_password: true,
-                    empty_text: "Wallet Password",
-                }
-
-                confirm_password_input := RobrixTextInput {
-                    width: Fill,
-                    height: Fit,
-                    padding: 10,
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {font_size: 12},
-                        color: #000
-                    }
-                    is_password: true,
-                    empty_text: "Confirm Wallet Password",
-                }
-
-                View {
-                    width: Fill, height: Fit
-                    flow: Down
-
-                    wallet_file_name_input := RobrixTextInput {
-                        width: Fill, height: Fit,
-                        flow: Right, // do not wrap
-                        padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
-                        empty_text: "my_wallet_file",
-                        draw_text +: {
-                            text_style: REGULAR_TEXT {font_size: 10.0}
-                        }
-                    }
-
-                    View {
-                        width: Fill,
-                        height: Fit,
-                        flow: Right,
-                        padding: Inset{top: 5, left: 2, right: 2, bottom: 2}
-                        spacing: 0.0,
-                        align: Align{x: 0.5, y: 0.5} // center horizontally and vertically
-
-                        left_line := LineH {
-                            draw_bg.color: #C8C8C8
-                        }
-
-                        Label {
-                            width: Fit, height: Fit
-                            padding: 0
-                            draw_text +: {
-                                color: #777777
-                                text_style: REGULAR_TEXT {font_size: 9}
-                            }
-                            text: "Wallet File Name (optional)"
-                        }
-
-                        right_line := LineH {
-                            draw_bg.color: #C8C8C8
-                        }
-                    }
-                }
+                is_password: true,
+                empty_text: "Confirm Wallet Password",
             }
 
             View {
                 width: Fill, height: Fit
-                flow: Right,
-                padding: Inset{top: 20, bottom: 20}
-                align: Align{x: 1.0, y: 0.5}
-                spacing: 20
+                flow: Down
 
-                cancel_button := RobrixNegativeIconButton {
-                    width: 100,
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    draw_icon.svg: (ICON_FORBIDDEN)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Cancel"
+                wallet_file_name_input := RobrixTextInput {
+                    width: Fill, height: Fit,
+                    flow: Right, // do not wrap
+                    padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
+                    empty_text: "my_wallet_file",
+                    draw_text +: {
+                        text_style: REGULAR_TEXT {font_size: 10.0}
+                    }
                 }
 
-                accept_button := RobrixPositiveIconButton {
-                    width: 140
-                    align: Align{x: 0.5, y: 0.5}
-                    padding: 15,
-                    draw_icon.svg: (ICON_CHECKMARK)
-                    icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                    text: "Create Wallet"
+                View {
+                    width: Fill,
+                    height: Fit,
+                    flow: Right,
+                    padding: Inset{top: 5, left: 2, right: 2, bottom: 2}
+                    spacing: 0.0,
+                    align: Align{x: 0.5, y: 0.5} // center horizontally and vertically
+
+                    left_line := LineH {
+                        draw_bg.color: #C8C8C8
+                    }
+
+                    Label {
+                        width: Fit, height: Fit
+                        padding: 0
+                        draw_text +: {
+                            color: #777777
+                            text_style: REGULAR_TEXT {font_size: 9}
+                        }
+                        text: "Wallet File Name (optional)"
+                    }
+
+                    right_line := LineH {
+                        draw_bg.color: #C8C8C8
+                    }
                 }
             }
+        }
 
-            status_label := Label {
-                width: Fill,
-                height: Fit,
-                flow: Flow.Right{wrap: true},
-                align: Align{x: 0.5, y: 0.0}
-                draw_text +: {
-                    text_style: REGULAR_TEXT {font_size: 11},
-                    color: #000
-                }
-                text: "status label"
+        buttons_view := ModalButtonsRow {
+            cancel_button := RobrixNegativeIconButton {
+                width: 100,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Cancel"
             }
+
+            accept_button := RobrixPositiveIconButton {
+                width: 140
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_CHECKMARK)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Create Wallet"
+            }
+        }
+
+        status_label := ModalBody {
+            align: Align{x: 0.5, y: 0.0}
+            draw_text +: {
+                text_style: REGULAR_TEXT {font_size: 11}
+            }
+            text: "status label"
         }
     }
 }

--- a/src/tsp/tsp_settings_screen.rs
+++ b/src/tsp/tsp_settings_screen.rs
@@ -107,13 +107,14 @@ script_mod! {
             width: Fill, height: Fit
             flow: Flow.Right{wrap: true},
             align: Align{y: 0.5},
-            spacing: 10
+            spacing: 10,
+            wrap_spacing: 2
 
             create_did_button := RobrixPositiveIconButton {
                 width: Fit,
                 height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
                 padding: 10,
-                margin: Inset{left: 5},
+                margin: Inset{left: 5, top: 5, bottom: 5},
                 draw_icon.svg: (ICON_ADD_USER)
                 icon_walk: Walk{width: 19, height: Fit, margin: 0}
                 text: "Create New Identity (DID)"
@@ -123,7 +124,7 @@ script_mod! {
                 width: Fit,
                 height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
                 padding: 10,
-                margin: Inset{left: 5},
+                margin: Inset{left: 5, top: 5, bottom: 5},
                 draw_icon.svg: (ICON_ADD_WALLET)
                 icon_walk: Walk{width: 21, height: Fit, margin: 0}
                 text: "Create New Wallet"
@@ -133,7 +134,7 @@ script_mod! {
                 width: Fit,
                 height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
                 padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
-                margin: Inset{left: 5}
+                margin: Inset{left: 5, top: 5, bottom: 5}
                 text: "Import Existing Wallet"
                 draw_icon +: {
                     svg: (ICON_IMPORT)

--- a/src/tsp/tsp_verification_modal.rs
+++ b/src/tsp/tsp_verification_modal.rs
@@ -11,78 +11,32 @@ script_mod! {
     use mod.widgets.*
 
 
-    mod.widgets.TspVerificationModal = #(TspVerificationModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.TspVerificationModal = set_type_default() do #(TspVerificationModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
 
-        RoundedView {
-            flow: Down
-            width: 400
-            height: Fit
-            padding: Inset{top: 25, right: 30 bottom: 30 left: 45}
-            spacing: 10
+        title := ModalTitle {
+            text: "TSP Verification Request"
+        }
 
-            show_bg: true
-            draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 3.0
+        body := ModalBody {}
+
+        buttons_view := ModalButtonsRow {
+            margin: Inset{top: 30}
+
+            cancel_button := RobrixNegativeIconButton {
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Ignore Request"
             }
 
-            title := View {
-                width: Fill,
-                height: Fit,
-                flow: Right
-                padding: Inset{top: 0, bottom: 40}
-                align: Align{x: 0.5, y: 0.0}
-
-                Label {
-                    text: "TSP Verification Request"
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                }
-            }
-
-            body := View {
-                width: Fill,
-                height: Fit,
-                flow: Down,
-                spacing: 40,
-
-                prompt := Label {
-                    width: Fill
-                    flow: Flow.Right{wrap: true}
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {
-                            font_size: 11.5,
-                        },
-                        color: #000
-                    }
-                }
-
-                View {
-                    width: Fill, height: Fit
-                    flow: Right,
-                    align: Align{x: 1.0, y: 0.5}
-                    spacing: 20
-
-                    cancel_button := RobrixNegativeIconButton {
-                        align: Align{x: 0.5, y: 0.5}
-                        padding: 15,
-                        draw_icon.svg: (ICON_FORBIDDEN)
-                        icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                        text: "Ignore Request"
-                    }
-
-                    accept_button := RobrixPositiveIconButton {
-                        align: Align{x: 0.5, y: 0.5}
-                        padding: 15,
-                        draw_icon.svg: (ICON_CHECKMARK)
-                        icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                        text: "Accept Request"
-                    }
-                }
+            accept_button := RobrixPositiveIconButton {
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_CHECKMARK)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Accept Request"
             }
         }
     }
@@ -175,7 +129,7 @@ impl WidgetMatchEvent for TspVerificationModal {
             return;
         }
 
-        let prompt_label = self.view.label(cx, ids!(prompt));
+        let prompt_label = self.view.label(cx, ids!(body));
         if accept_button.clicked(actions) {
             let current_state = std::mem::take(&mut self.state);
             let new_state: TspVerificationModalState;
@@ -268,11 +222,11 @@ impl WidgetMatchEvent for TspVerificationModal {
                 {
                     match result {
                         Ok(()) => {
-                            self.label(cx, ids!(prompt)).set_text(cx, "The TSP verification process has completed successfully.\n\nYou may now close this.");
+                            self.label(cx, ids!(body)).set_text(cx, "The TSP verification process has completed successfully.\n\nYou may now close this.");
                             self.state = TspVerificationModalState::RequestVerified;
                         }
                         Err(e) => {
-                            self.label(cx, ids!(prompt)).set_text(cx, &format!("Error: failed to complete the TSP verification process:\n\n{e}"));
+                            self.label(cx, ids!(body)).set_text(cx, &format!("Error: failed to complete the TSP verification process:\n\n{e}"));
                             self.state = TspVerificationModalState::RequestDeclined;
                         }
                     }
@@ -315,7 +269,7 @@ impl TspVerificationModal {
             details.responding_vid,
             details.responding_user_id,
         );
-        self.label(cx, ids!(prompt)).set_text(cx, &prompt_text);
+        self.label(cx, ids!(body)).set_text(cx, &prompt_text);
 
         let accept_button = self.button(cx, ids!(accept_button));
         let cancel_button = self.button(cx, ids!(cancel_button));

--- a/src/verification_modal.rs
+++ b/src/verification_modal.rs
@@ -10,78 +10,32 @@ script_mod! {
     use mod.widgets.*
 
 
-    mod.widgets.VerificationModal = #(VerificationModal::register_widget(vm)) {
-        width: Fit
-        height: Fit
+    mod.widgets.VerificationModal = set_type_default() do #(VerificationModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
 
-        RoundedView {
-            flow: Down
-            width: 400
-            height: Fit
-            padding: Inset{top: 25, right: 30 bottom: 30 left: 45}
-            spacing: 10
+        title := ModalTitle {
+            text: "Verification Request"
+        }
 
-            show_bg: true
-            draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 3.0
+        body := ModalBody {}
+
+        buttons_view := ModalButtonsRow {
+            margin: Inset{top: 30}
+
+            cancel_button := RobrixNegativeIconButton {
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Cancel"
             }
 
-            title := View {
-                width: Fill,
-                height: Fit,
-                flow: Right
-                padding: Inset{top: 0, bottom: 40}
-                align: Align{x: 0.5, y: 0.0}
-
-                Label {
-                    text: "Verification Request"
-                    draw_text +: {
-                        text_style: TITLE_TEXT {font_size: 13},
-                        color: #000
-                    }
-                }
-            }
-
-            body := View {
-                width: Fill,
-                height: Fit,
-                flow: Down,
-                spacing: 40,
-
-                prompt := Label {
-                    width: Fill
-                    flow: Flow.Right{wrap: true}
-                    draw_text +: {
-                        text_style: REGULAR_TEXT {
-                            font_size: 11.5,
-                        },
-                        color: #000
-                    }
-                }
-
-                View {
-                    width: Fill, height: Fit
-                    flow: Right,
-                    align: Align{x: 1.0, y: 0.5}
-                    spacing: 20
-
-                    cancel_button := RobrixNegativeIconButton {
-                        align: Align{x: 0.5, y: 0.5}
-                        padding: 15,
-                        draw_icon.svg: (ICON_FORBIDDEN)
-                        icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                        text: "Cancel"
-                    }
-
-                    accept_button := RobrixPositiveIconButton {
-                        align: Align{x: 0.5, y: 0.5}
-                        padding: 15,
-                        draw_icon.svg: (ICON_CHECKMARK)
-                        icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                        text: "Yes"
-                    }
-                }
+            accept_button := RobrixPositiveIconButton {
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_CHECKMARK)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Yes"
             }
         }
     }
@@ -156,7 +110,7 @@ impl WidgetMatchEvent for VerificationModal {
             if let Some(verification_action) = action.downcast_ref::<VerificationAction>() {
                 match verification_action {
                     VerificationAction::RequestCancelled(cancel_info) => {
-                        self.label(cx, ids!(prompt)).set_text(
+                        self.label(cx, ids!(body)).set_text(
                             cx,
                             &format!("Verification request was cancelled: {}", cancel_info.reason())
                         );
@@ -167,7 +121,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::RequestAccepted => {
-                        self.label(cx, ids!(prompt)).set_text(
+                        self.label(cx, ids!(body)).set_text(
                             cx,
                             "You successfully accepted the verification request.\n\n\
                             Waiting for the other device to agree on verification methods..."
@@ -180,7 +134,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::RequestAcceptError(error) => {
-                        self.label(cx, ids!(prompt)).set_text(cx, 
+                        self.label(cx, ids!(body)).set_text(cx, 
                             &format!(
                                 "Error accepting verification request: {}\n\n\
                                 Please try the verification process again.",
@@ -194,7 +148,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::RequestCancelError(error) => {
-                        self.label(cx, ids!(prompt)).set_text(
+                        self.label(cx, ids!(body)).set_text(
                             cx,
                             &format!("Error cancelling verification request: {}.", error)
                         );
@@ -205,7 +159,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::RequestTransitionedToUnsupportedMethod(method) => {
-                        self.label(cx, ids!(prompt)).set_text(
+                        self.label(cx, ids!(body)).set_text(
                             cx,
                             &format!(
                                 "Verification request transitioned to unsupported method: {}\n\nPlease try the verification process again.",
@@ -223,7 +177,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::SasAccepted(_accepted_protocols) => {
-                        self.label(cx, ids!(prompt)).set_text(
+                        self.label(cx, ids!(body)).set_text(
                             cx,
                             "Both sides have accepted the same verification method(s).\n\n\
                             Waiting for both devices to exchange keys..."
@@ -255,7 +209,7 @@ impl WidgetMatchEvent for VerificationModal {
                                 decimals.0, decimals.1, decimals.2,
                             )
                         };
-                        self.label(cx, ids!(prompt)).set_text(cx, &text);
+                        self.label(cx, ids!(body)).set_text(cx, &text);
                         accept_button.set_enabled(cx, true);
                         accept_button.set_text(cx, "Yes");
                         cancel_button.set_text(cx, "No");
@@ -264,7 +218,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::SasConfirmed => {
-                        self.label(cx, ids!(prompt)).set_text(
+                        self.label(cx, ids!(body)).set_text(
                             cx,
                             "You successfully confirmed the Short Auth String keys.\n\n\
                             Waiting for the other device to confirm..."
@@ -277,7 +231,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::SasConfirmationError(error) => {
-                        self.label(cx, ids!(prompt)).set_text(
+                        self.label(cx, ids!(body)).set_text(
                             cx,
                             &format!("Error confirming keys: {}\n\nPlease retry the verification process.", error)
                         );
@@ -288,7 +242,7 @@ impl WidgetMatchEvent for VerificationModal {
                     }
 
                     VerificationAction::RequestCompleted => {
-                        self.label(cx, ids!(prompt)).set_text(cx, "Verification completed successfully!");
+                        self.label(cx, ids!(body)).set_text(cx, "Verification completed successfully!");
                         accept_button.set_text(cx, "Ok");
                         accept_button.set_enabled(cx, true);
                         cancel_button.set_visible(cx, false);
@@ -334,7 +288,7 @@ impl VerificationModal {
                 ).into()
             }
         };
-        self.label(cx, ids!(prompt)).set_text(cx, &prompt_text);
+        self.label(cx, ids!(body)).set_text(cx, &prompt_text);
 
         let accept_button = self.button(cx, ids!(accept_button));
         let cancel_button = self.button(cx, ids!(cancel_button));


### PR DESCRIPTION
Closes #911

This basically ensures that we have a consistent modal display size and layout for all modals in Robrix. WIthout this, they looked a bit unprofessional due to their inconsistencies.
Now every smaller modal (which excludes the full-screen modals for event source and file uploads) looks the same, and offers a title, body, and buttons row.
This also makes the modals easier to define, and ensures that their content is never cut off by app window or screen size limitations, both vertically and horizontally, and that scrolling always works as expected.

As part of this, we've fixed modal-related bugs on the Makepad side as well, such as scrolling piercing thru a modal to the underlying view, and scrolling within a modal (or any other view) that has a Fit-max bound, and drag scrolling using your finger.
See: <https://github.com/makepad/makepad/pull/1117>

Thanks to those makepad fixes, the bottom margins of all modals are now respected when the app window is too short for the modal to fit.

Other fixes:
* Reset the user profile sliding pane when a room is shown.
* Fix vertical spacing of buttons in the TSP settings screen.