### PR TITLE
Auto-enable `hide_windows_console` for packaged builds only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,12 +114,13 @@ robius-web-auth-session = { git = "https://github.com/project-robius/robius" }
 
 
 [features]
-default = ["hide_windows_console"]
+default = []
 ## Enables experimental support for using TSP wallets.
 tsp = ["dep:tsp_sdk", "dep:quinn", "dep:aws-lc-rs", "dep:percent-encoding", "dep:reqwest"]
 
-## Hides the command prompt console on Windows. Enabled by default;
-## disable with `--no-default-features` if you need a console for a detached launch.
+## Hides the command prompt console/log window on Windows.
+## This is enabled automatically for packaged builds via cargo-packager
+## (see `build.rs`), but you can also enable it manually if desired.
 hide_windows_console = []
 
 ## Logs all diffs received by the Matrix RoomListService.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ cargo install --locked --git https://github.com/project-robius/robius-packaging-
 ```sh
 cargo packager --release ## --verbose is optional
 ```
-  * On Windows, the cmd prompt console is hidden by default via the `hide_windows_console` Cargo feature. If you need to keep the console visible (e.g., to debug a detached launch), build with `--no-default-features`.
+  * On Windows, the cmd prompt console is hidden automatically for packaged builds only. See the `hide_windows_console` cargo feature in our Cargo.toml.
 
 
 ### Platform-specific considerations

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,11 @@
 fn main() {
+    // Detect `cargo packager` builds using the `CARGO_PACKAGER_FORMAT` env var.
+    println!("cargo::rustc-check-cfg=cfg(packaging_build)");
+    println!("cargo:rerun-if-env-changed=CARGO_PACKAGER_FORMAT");
+    if std::env::var_os("CARGO_PACKAGER_FORMAT").is_some() {
+        println!("cargo:rustc-cfg=packaging_build");
+    }
+
     // Note: `#[cfg(windows)]` checks the *host* OS, not the *target*.
     // We must check the target env at runtime to avoid running this
     // when cross-compiling (e.g., building for Android on a Windows CI runner).

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,12 @@
 // as dll (mobile / wasm) and some require to be built as executable
 // unfortunately cargo doesn't facilitate this without a main.rs stub
 
-// This cfg option hides the command prompt console window on Windows.
+// Hide the command prompt console window on Windows, if desired.
 // TODO: move this into Makepad itself as an addition to the `MAKEPAD` env var.
-#![cfg_attr(all(feature = "hide_windows_console", target_os = "windows"), windows_subsystem = "windows")]
+#![cfg_attr(
+    all(any(feature = "hide_windows_console", packaging_build), target_os = "windows"),
+    windows_subsystem = "windows",
+)]
 
 fn main() {
     robrix::app::app_main()


### PR DESCRIPTION
We accidentally made this the default on all windows builds, which means that didn't get a console/terminal log even when running `cargo run`. Oops.