### PR TITLE
Better hardware keyboard support and IME pre-edit fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "bytes"
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2952,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3015,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "weezl",
 ]
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3052,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "ttf-parser",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3093,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3129,12 +3129,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -3171,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3207,12 +3207,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "makepad-error-log",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "log",
  "makepad-zune-core",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "log",
 ]
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "simd-adler32",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3702,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "mime"
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -5377,7 +5377,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "bytemuck",
@@ -5477,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "sealed"
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "siphasher"
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "socket2"
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "tungstenite"
@@ -6635,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-bidi"
@@ -6646,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-ident"
@@ -6667,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-normalization"
@@ -6687,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6703,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "unicode-width"
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "log",
  "pkg-config",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "whoami"
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7326,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 
 [[package]]
 name = "windows-numerics"
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#873593b6b2bbedfda0bc6ea444b78f0579c0264b"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "bytes"
@@ -1954,9 +1954,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2952,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -2999,15 +2999,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3015,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "weezl",
 ]
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3052,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "ttf-parser",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3093,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3129,15 +3129,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3159,7 +3159,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3171,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3184,13 +3184,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3207,14 +3207,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3268,13 +3268,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "log",
  "makepad-zune-core",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "log",
 ]
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "simd-adler32",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3702,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "mime"
@@ -4495,10 +4495,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "unicase 2.9.0",
 ]
 
@@ -5377,12 +5377,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=modal_fixes)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5477,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "sealed"
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "siphasher"
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "socket2"
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "tungstenite"
@@ -6635,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-bidi"
@@ -6646,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-ident"
@@ -6667,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-normalization"
@@ -6687,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6703,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "unicode-width"
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "log",
  "pkg-config",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "whoami"
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7326,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 
 [[package]]
 name = "windows-numerics"
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=modal_fixes#8ab4476223f6efcd2976a50ed85783738cc48604"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "bytes"
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2952,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3015,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "weezl",
 ]
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3052,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "ttf-parser",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3093,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3129,12 +3129,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -3171,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3207,12 +3207,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "makepad-error-log",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "log",
  "makepad-zune-core",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "log",
 ]
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "simd-adler32",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3702,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "mime"
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -5377,7 +5377,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "bytemuck",
@@ -5477,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "sealed"
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "siphasher"
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "socket2"
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "tungstenite"
@@ -6635,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-bidi"
@@ -6646,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-ident"
@@ -6667,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-normalization"
@@ -6687,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6703,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "unicode-width"
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "log",
  "pkg-config",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "whoami"
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7326,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 
 [[package]]
 name = "windows-numerics"
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#41c71ebe52d97bc0c066d149c542b2dbbaa523cd"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "bytes"
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2952,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3015,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "weezl",
 ]
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3052,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "ttf-parser",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3093,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3129,12 +3129,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -3171,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3207,12 +3207,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "makepad-error-log",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "log",
  "makepad-zune-core",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "log",
 ]
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "simd-adler32",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3702,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "mime"
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -5377,7 +5377,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "bytemuck",
@@ -5477,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "sealed"
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "siphasher"
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "socket2"
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "tungstenite"
@@ -6635,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-bidi"
@@ -6646,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-ident"
@@ -6667,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-normalization"
@@ -6687,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6703,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "unicode-width"
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "log",
  "pkg-config",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "whoami"
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7326,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 
 [[package]]
 name = "windows-numerics"
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#544ac23440cfaa1c25f2b0fa04ebb2a564f4e2e6"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "accessory"
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "bitmaps"
@@ -728,7 +728,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "byteorder"
@@ -739,7 +739,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "bytes"
@@ -1954,7 +1954,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
 ]
@@ -2797,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2952,12 +2952,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3007,7 +3007,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3015,22 +3015,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "weezl",
 ]
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3052,7 +3052,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "ttf-parser",
 ]
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3069,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3093,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3129,12 +3129,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -3171,12 +3171,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3190,7 +3190,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3207,12 +3207,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "makepad-error-log",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3233,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3251,7 +3251,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "log",
  "makepad-zune-core",
@@ -3283,7 +3283,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "log",
 ]
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "simd-adler32",
 ]
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3307,7 +3307,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3702,7 +3702,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "mime"
@@ -4495,7 +4495,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
@@ -5377,7 +5377,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview)",
  "bytemuck",
@@ -5477,7 +5477,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "sealed"
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "siphasher"
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "socket2"
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "tungstenite"
@@ -6635,7 +6635,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-bidi"
@@ -6646,17 +6646,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-ident"
@@ -6667,7 +6667,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-normalization"
@@ -6687,12 +6687,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6703,7 +6703,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "unicode-width"
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7047,7 +7047,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7057,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7066,7 +7066,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "log",
  "pkg-config",
@@ -7136,7 +7136,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "whoami"
@@ -7189,7 +7189,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7241,7 +7241,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7262,7 +7262,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7326,7 +7326,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 
 [[package]]
 name = "windows-numerics"
@@ -7370,7 +7370,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#e72447c6ce0673bde8ae4254ffee37a5e54b4b3a"
+source = "git+https://github.com/kevinaboos/makepad?branch=ime_composition_preview#6ecfdae90b0ca97d82cfd7000a73d2b4946f71ab"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "modal_fixes", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "modal_fixes" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "ime_composition_preview", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "ime_composition_preview" }
 
 
 ## Including this crate automatically configures all `robius-*` crates to work with Makepad.

--- a/src/home/add_room.rs
+++ b/src/home/add_room.rs
@@ -65,6 +65,8 @@ script_mod! {
                 width: Fill { max: 400 } // same width as the above `help_info`
                 height: 40
                 empty_text: "Enter alias, ID, or Matrix link..."
+                autocapitalize: None,
+                autocorrect: Disabled,
             }
 
             search_for_room_button := RobrixIconButton {

--- a/src/home/invite_modal.rs
+++ b/src/home/invite_modal.rs
@@ -24,6 +24,8 @@ script_mod! {
                 color: #000
             }
             empty_text: "@user:example.org",
+            autocapitalize: None,
+            autocorrect: Disabled,
         }
 
         buttons_view := ModalButtonsRow {

--- a/src/login/login_screen.rs
+++ b/src/login/login_screen.rs
@@ -112,6 +112,9 @@ script_mod! {
                         flow: Right, // do not wrap
                         padding: 10,
                         empty_text: "User ID"
+                        autocapitalize: None,
+                        autocorrect: Disabled,
+                        content_type: Username,
                     }
 
                     View {
@@ -125,6 +128,9 @@ script_mod! {
                             padding: Inset{top: 10, bottom: 10, left: 10, right: 38}
                             empty_text: "Password"
                             is_password: true,
+                            autocapitalize: None,
+                            autocorrect: Disabled,
+                            content_type: Password,
                         }
 
                         View {
@@ -177,6 +183,10 @@ script_mod! {
                             flow: Right, // do not wrap
                             padding: Inset{top: 5, bottom: 5, left: 10, right: 10}
                             empty_text: "matrix.org"
+                            autocapitalize: None,
+                            autocorrect: Disabled,
+                            content_type: Url,
+                            input_mode: Url,
                             draw_text +: {
                                 text_style: TITLE_TEXT {font_size: 10.0}
                             }

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -390,9 +390,10 @@ impl ScriptHook for AppSettings {
         if !apply.is_script_reapply() {
             return;
         }
-        let cx = vm.cx_mut();
-        let prefs = cx.global::<AppPreferencesGlobal>().0.clone();
-        Self::populate_safe(cx, &self.view, &prefs);
+        vm.with_cx_mut(|cx| {
+            let prefs = cx.global::<AppPreferencesGlobal>().0.clone();
+            Self::populate_safe(cx, &self.view, &prefs);
+        });
     }
 }
 

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -260,6 +260,8 @@ script_mod! {
                     align: Align {y: 0.5}
                     padding: Inset{left: 8, right: 8, top: 5, bottom: 5}
                     empty_text: "100%"
+                    autocapitalize: None,
+                    autocorrect: Disabled,
                 }
 
                 ui_zoom_plus_button := RobrixNeutralIconButton {
@@ -341,6 +343,8 @@ script_mod! {
                     width: 60, height: Fit
                     padding: Inset{left: 8, right: 8, top: 5, bottom: 5}
                     empty_text: "300"
+                    autocapitalize: None,
+                    autocorrect: Disabled,
                     is_read_only: true
                 }
 

--- a/src/shared/room_filter_input_bar.rs
+++ b/src/shared/room_filter_input_bar.rs
@@ -42,6 +42,7 @@ script_mod! {
             padding: 5
             
             empty_text: "Filter rooms & spaces..."
+            autocapitalize: None,
             
             draw_bg.border_size: 0.0
             draw_text +: {

--- a/src/tsp/create_did_modal.rs
+++ b/src/tsp/create_did_modal.rs
@@ -43,6 +43,8 @@ script_mod! {
                     color: #000
                 }
                 empty_text: "Identity Username",
+                autocapitalize: None,
+                autocorrect: Disabled,
             }
 
             alias_input := RobrixTextInput {
@@ -85,6 +87,9 @@ script_mod! {
                     flow: Right, // do not wrap
                     padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
                     empty_text: "p.teaspoon.world",
+                    autocapitalize: None,
+                    autocorrect: Disabled,
+                    content_type: Url,
                     draw_text +: {
                         text_style: REGULAR_TEXT {font_size: 10.0}
                     }
@@ -127,6 +132,9 @@ script_mod! {
                     flow: Right, // do not wrap
                     padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
                     empty_text: "did.teaspoon.world",
+                    autocapitalize: None,
+                    autocorrect: Disabled,
+                    content_type: Url,
                     draw_text +: {
                         text_style: REGULAR_TEXT {font_size: 10.0}
                     }

--- a/src/tsp/create_wallet_modal.rs
+++ b/src/tsp/create_wallet_modal.rs
@@ -51,8 +51,10 @@ script_mod! {
                     text_style: REGULAR_TEXT {font_size: 12},
                     color: #000
                 }
-                is_password: true,
                 empty_text: "Wallet Password",
+                autocapitalize: None,
+                autocorrect: Disabled,
+                content_type: NewPassword,
             }
 
             confirm_password_input := RobrixTextInput {
@@ -63,8 +65,10 @@ script_mod! {
                     text_style: REGULAR_TEXT {font_size: 12},
                     color: #000
                 }
-                is_password: true,
                 empty_text: "Confirm Wallet Password",
+                autocapitalize: None,
+                autocorrect: Disabled,
+                content_type: NewPassword,
             }
 
             View {
@@ -76,6 +80,8 @@ script_mod! {
                     flow: Right, // do not wrap
                     padding: Inset { left: 10, right: 10, top: 5, bottom: 5 }
                     empty_text: "my_wallet_file",
+                    autocapitalize: None,
+                    autocorrect: Disabled,
                     draw_text +: {
                         text_style: REGULAR_TEXT {font_size: 10.0}
                     }

--- a/src/tsp/verify_user.rs
+++ b/src/tsp/verify_user.rs
@@ -88,6 +88,9 @@ script_mod! {
 
                 tsp_did_input := RobrixTextInput {
                     empty_text: "Enter their TSP DID..."
+                    autocapitalize: None,
+                    autocorrect: Disabled,
+                    content_type: Url,
                 }
 
                 verify_user_button := RobrixPositiveIconButton {


### PR DESCRIPTION
Grab our major changes to iOS hardware kbd/IME support.

IME pre-edits weren't being shown on desktop (makepad issue). See https://github.com/makepad/makepad/pull/1109

Tested fully working on all platforms, and phew was that difficult!