### PR TITLE
After closing a tab, navigate back to the *previous* room

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1003,8 +1003,8 @@ pub struct SavedDockState {
     pub dock_items: HashMap<LiveId, DockItem>,
     /// The rooms that are currently open, keyed by their room or space ID.
     pub open_rooms: HashMap<LiveId, SelectedRoom>,
-    /// The order in which the rooms were opened, in chronological order
-    /// from first opened (at the beginning) to last opened (at the end).
+    /// The order in which room/thread tabs were last viewed,
+    /// from oldest at the front to most recent at the end.
     pub room_order: Vec<SelectedRoom>,
     /// The selected room tab in this dock when the dock state was saved.
     pub selected_room: Option<SelectedRoom>,

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -584,12 +584,8 @@ impl Widget for HomeScreen {
                 // Handle room selections. Desktop owns tab creation in MainDesktopUI,
                 // while mobile owns StackNavigation screen pushes here.
                 match action.as_widget_action().cast() {
-                    RoomsListAction::Selected(selected_room) => {
-                        if effective_is_desktop(cx) {
-                            app_state.selected_room = Some(selected_room);
-                        } else {
-                            self.push_selected_screen_view(cx, app_state, selected_room);
-                        }
+                    RoomsListAction::Selected(selected_room) if !effective_is_desktop(cx) => {
+                        self.push_selected_screen_view(cx, app_state, selected_room);
                     }
                     RoomsListAction::InviteAccepted { room_name_id } => {
                         cx.action(AppStateAction::UpgradedInviteToJoinedRoom(

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -79,10 +79,6 @@ pub struct MainDesktopUI {
     #[rust]
     open_rooms: HashMap<LiveId, SelectedRoom>,
 
-    /// The tab that should be closed in the next draw event
-    #[rust]
-    tab_to_close: Option<LiveId>,
-
     /// The order in which room/thread tabs were last viewed,
     /// from oldest at the front to most recent at the end.
     #[rust]
@@ -153,6 +149,23 @@ impl MainDesktopUI {
         self.room_order.push(room.clone());
     }
 
+    /// Selects the tab for the given `room`, or the home tab if `None`.
+    ///
+    /// Updates the room order, current selection, and app state.
+    fn select_room(&mut self, cx: &mut Cx, room: Option<SelectedRoom>) {
+        let dock = self.view.dock(cx, ids!(dock));
+        if let Some(room) = room {
+            dock.select_tab(cx, room.tab_id());
+            self.mark_room_as_recent(&room);
+            cx.action(AppStateAction::RoomFocused(room.clone()));
+            self.most_recently_selected_room = Some(room);
+        } else {
+            dock.select_tab(cx, id!(home_tab));
+            cx.action(AppStateAction::FocusNone);
+            self.most_recently_selected_room = None;
+        }
+    }
+
     /// Focuses on a room if it is already open, otherwise creates a new tab for the room.
     fn focus_or_create_tab(&mut self, cx: &mut Cx, room: SelectedRoom) {
         // Do nothing if the room to select is already created and focused.
@@ -165,11 +178,10 @@ impl MainDesktopUI {
         // If the room is already open, select (jump to) its existing tab
         let room_tab_id = room.tab_id();
         if self.open_rooms.contains_key(&room_tab_id) {
-            dock.select_tab(cx, room_tab_id);
+            self.select_room(cx, Some(room));
             // Lazily initialize the tab's widget if it was deferred during dock restoration.
             self.init_tab_if_needed(cx, room_tab_id);
-            self.mark_room_as_recent(&room);
-            self.most_recently_selected_room = Some(room);
+            cx.action(MainDesktopUiAction::SaveDockIntoAppState);
             return;
         }
 
@@ -192,9 +204,8 @@ impl MainDesktopUI {
             Some(insert_after),
         );
 
-        // if the tab was created, set the room screen and add the room to the room order
+        // if the tab was created, set the room screen
         if let Some(new_widget) = new_tab_widget {
-            self.room_order.push(room.clone());
             match &room {
                 SelectedRoom::JoinedRoom { room_name_id }  => {
                     new_widget.as_room_screen().set_displayed_room(
@@ -224,12 +235,11 @@ impl MainDesktopUI {
                 }
             }
             cx.action(MainDesktopUiAction::SaveDockIntoAppState);
+            self.open_rooms.insert(room_tab_id, room.clone());
+            self.select_room(cx, Some(room));
         } else {
             error!("BUG: failed to create tab for {room:?}");
         }
-
-        self.open_rooms.insert(room_tab_id, room.clone());
-        self.most_recently_selected_room = Some(room);
     }
 
     /// Closes a tab in the dock and selects the next most recently viewed tab.
@@ -238,7 +248,6 @@ impl MainDesktopUI {
 
         let Some(room_being_closed) = self.open_rooms.get(&tab_id).cloned() else {
             dock.close_tab(cx, tab_id);
-            self.tab_to_close = None;
             self.init_all_visible_tabs(cx);
             return;
         };
@@ -252,21 +261,10 @@ impl MainDesktopUI {
         };
 
         dock.close_tab(cx, tab_id);
-        self.tab_to_close = None;
         self.open_rooms.remove(&tab_id);
 
         // Makepad's dock chooses an adjacent tab by itself, so we have to override that.
-        if let Some(rts) = room_to_select {
-            dock.select_tab(cx, rts.tab_id());
-            if is_active_tab {
-                cx.action(AppStateAction::RoomFocused(rts.clone()));
-            }
-            self.most_recently_selected_room = Some(rts);
-        } else {
-            dock.select_tab(cx, id!(home_tab));
-            cx.action(AppStateAction::FocusNone);
-            self.most_recently_selected_room = None;
-        }
+        self.select_room(cx, room_to_select);
 
         self.init_all_visible_tabs(cx);
     }
@@ -278,14 +276,10 @@ impl MainDesktopUI {
             dock.close_tab(cx, *tab_id);
         }
 
-        dock.select_tab(cx, id!(home_tab));
-        cx.action(AppStateAction::FocusNone);
-
         // Clear tab-related dock UI state.
         self.open_rooms.clear();
-        self.tab_to_close = None;
         self.room_order.clear();
-        self.most_recently_selected_room = None;
+        self.select_room(cx, None);
         cx.action(MainDesktopUiAction::SaveDockIntoAppState);
     }
 
@@ -539,20 +533,16 @@ impl WidgetMatchEvent for MainDesktopUI {
                 // Whenever a tab (except for the home_tab) is pressed, notify the app state.
                 DockAction::TabWasPressed(tab_id) => {
                     if tab_id == id!(home_tab) {
-                        cx.action(AppStateAction::FocusNone);
-                        self.most_recently_selected_room = None;
+                        self.select_room(cx, None);
                     }
                     else if let Some(selected_room) = self.open_rooms.get(&tab_id).cloned() {
-                        cx.action(AppStateAction::RoomFocused(selected_room.clone()));
-                        self.mark_room_as_recent(&selected_room);
-                        self.most_recently_selected_room = Some(selected_room);
+                        self.select_room(cx, Some(selected_room));
                     }
                     // Lazily initialize this tab's widget if it was deferred during dock restoration.
                     self.init_tab_if_needed(cx, tab_id);
                     should_save_dock_action = true;
                 }
                 DockAction::TabCloseWasPressed(tab_id) => {
-                    self.tab_to_close = Some(tab_id);
                     self.close_tab(cx, tab_id);
                     self.redraw(cx);
                     should_save_dock_action = true;

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -83,8 +83,8 @@ pub struct MainDesktopUI {
     #[rust]
     tab_to_close: Option<LiveId>,
 
-    /// The order in which the rooms were opened, in chronological order
-    /// from first opened (at the beginning) to last opened (at the end).
+    /// The order in which room/thread tabs were last viewed,
+    /// from oldest at the front to most recent at the end.
     #[rust]
     room_order: Vec<SelectedRoom>,
 
@@ -119,6 +119,16 @@ impl Widget for MainDesktopUI {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.widget_match_event(cx, event, scope); // invokes `WidgetMatchEvent` impl
         self.view.handle_event(cx, event, scope);
+
+        // For convenience, we support go-back gestures when viewing a thread's tab
+        // to easily go back to the most recent room.
+        if let Some(sr @ SelectedRoom::Thread { .. }) = self.most_recently_selected_room.as_ref()
+            && (event.back_pressed() || matches!(event, Event::MouseUp(e) if e.button.is_back()))
+        {
+            self.close_tab(cx, sr.tab_id());
+            self.redraw(cx);
+            cx.action(MainDesktopUiAction::SaveDockIntoAppState);
+        }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
@@ -137,6 +147,12 @@ impl Widget for MainDesktopUI {
 }
 
 impl MainDesktopUI {
+    /// Moves or adds the given room the the end of the `room_order`, the most recent spot.
+    fn mark_room_as_recent(&mut self, room: &SelectedRoom) {
+        self.room_order.retain(|sr| sr != room);
+        self.room_order.push(room.clone());
+    }
+
     /// Focuses on a room if it is already open, otherwise creates a new tab for the room.
     fn focus_or_create_tab(&mut self, cx: &mut Cx, room: SelectedRoom) {
         // Do nothing if the room to select is already created and focused.
@@ -152,6 +168,7 @@ impl MainDesktopUI {
             dock.select_tab(cx, room_tab_id);
             // Lazily initialize the tab's widget if it was deferred during dock restoration.
             self.init_tab_if_needed(cx, room_tab_id);
+            self.mark_room_as_recent(&room);
             self.most_recently_selected_room = Some(room);
             return;
         }
@@ -215,39 +232,42 @@ impl MainDesktopUI {
         self.most_recently_selected_room = Some(room);
     }
 
-    /// Closes a tab in the dock and focuses on the latest open room.
+    /// Closes a tab in the dock and selects the next most recently viewed tab.
     fn close_tab(&mut self, cx: &mut Cx, tab_id: LiveId) {
         let dock = self.view.dock(cx, ids!(dock));
-        if let Some(room_being_closed) = self.open_rooms.get(&tab_id) {
-            self.room_order.retain(|sr| sr != room_being_closed);
 
-            if self.open_rooms.len() > 1 {
-                // If the closing tab is the active one, then focus the next room
-                let active_room = self.most_recently_selected_room.as_ref();
-                if let Some(active_room) = active_room {
-                    if active_room == room_being_closed {
-                        if let Some(new_focused_room) = self.room_order.last() {
-                            // notify the app state about the new focused room
-                            cx.action(AppStateAction::RoomFocused(new_focused_room.clone()));
+        let Some(room_being_closed) = self.open_rooms.get(&tab_id).cloned() else {
+            dock.close_tab(cx, tab_id);
+            self.tab_to_close = None;
+            self.init_all_visible_tabs(cx);
+            return;
+        };
+        self.room_order.retain(|sr| sr != &room_being_closed);
 
-                            // Set the new selected room to be used in the current draw
-                            self.most_recently_selected_room = Some(new_focused_room.clone());
-                        }
-                    }
-                }
-            } else {
-                // If there is no room to focus, notify app to reset the selected room in the app state
-                cx.action(AppStateAction::FocusNone);
-                dock.select_tab(cx, id!(home_tab));
-                self.most_recently_selected_room = None;
-            }
-        }
+        let is_active_tab = self.most_recently_selected_room.as_ref() == Some(&room_being_closed);
+        let room_to_select = if is_active_tab {
+            self.room_order.last().cloned()
+        } else {
+            self.most_recently_selected_room.clone()
+        };
 
         dock.close_tab(cx, tab_id);
         self.tab_to_close = None;
         self.open_rooms.remove(&tab_id);
-        // The dock auto-selects an adjacent tab after closing, which may be
-        // an uninitialized tab that was deferred during dock restoration.
+
+        // Makepad's dock chooses an adjacent tab by itself, so we have to override that.
+        if let Some(rts) = room_to_select {
+            dock.select_tab(cx, rts.tab_id());
+            if is_active_tab {
+                cx.action(AppStateAction::RoomFocused(rts.clone()));
+            }
+            self.most_recently_selected_room = Some(rts);
+        } else {
+            dock.select_tab(cx, id!(home_tab));
+            cx.action(AppStateAction::FocusNone);
+            self.most_recently_selected_room = None;
+        }
+
         self.init_all_visible_tabs(cx);
     }
 
@@ -522,9 +542,10 @@ impl WidgetMatchEvent for MainDesktopUI {
                         cx.action(AppStateAction::FocusNone);
                         self.most_recently_selected_room = None;
                     }
-                    else if let Some(selected_room) = self.open_rooms.get(&tab_id) {
+                    else if let Some(selected_room) = self.open_rooms.get(&tab_id).cloned() {
                         cx.action(AppStateAction::RoomFocused(selected_room.clone()));
-                        self.most_recently_selected_room = Some(selected_room.clone());
+                        self.mark_room_as_recent(&selected_room);
+                        self.most_recently_selected_room = Some(selected_room);
                     }
                     // Lazily initialize this tab's widget if it was deferred during dock restoration.
                     self.init_tab_if_needed(cx, tab_id);


### PR DESCRIPTION
Makepad's dock changed its default behavior to just select
an adjacent tab after closing the active tab, which kind of
ruined Robrix's room order concept. Now we've fixed that here.

Also, this adds support for navigating back to the previous room tab
when viewing a thread tab, e.g., with the android go-back gesture
or the mouse back button. Otherwise it's a little annoying to have to
manually close the thread tab to go back to the main room.