### PR TITLE
Ensure that thread timelines are freed when the thread is closed

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,10 +13,10 @@ use matrix_sdk::{RoomState, ruma::{OwnedEventId, OwnedRoomId, OwnedUserId, RoomI
 use serde::{Deserialize, Serialize};
 use crate::{
     avatar_cache::clear_avatar_cache, room_preview_cache::clear_room_preview_cache, home::{
-        event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
+        event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states, invalidate_timeline_state}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
     }, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
-    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
+    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, TimelineKind, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
         VerificationModalAction,
         VerificationModalWidgetRefExt,
     }
@@ -1115,6 +1115,29 @@ impl SelectedRoom {
             }
             other => LiveId::from_str(other.room_id().as_str()),
         }
+    }
+
+    /// Closes & cleans up the UI-side cached state and stops the backend async task
+    /// for this thread timeline (if it is one).
+    ///
+    /// Does nothing for non-thread room kinds (e.g., main room timelines).
+    ///
+    /// This should be called only when the RoomScreen showing this room thread
+    /// has been hidden (e.g., its tab was closed, or the user navigated back on mobile view mode),
+    /// but not when it's still reachable via the mobile nav stack or a saved desktop dock.
+    pub fn close_thread_timeline(&self, cx: &mut Cx) {
+        let SelectedRoom::Thread { room_name_id, thread_root_event_id } = self else { return };
+        let room_id = room_name_id.room_id().clone();
+        // Drop the stale UI cache so reopening rebuilds a fresh timeline instead of reusing
+        // a cache whose backend is about to be freed.
+        invalidate_timeline_state(cx, &TimelineKind::Thread {
+            room_id: room_id.clone(),
+            thread_root_event_id: thread_root_event_id.clone(),
+        });
+        submit_async_request(MatrixRequest::CloseThreadTimeline {
+            room_id,
+            thread_root_event_id: thread_root_event_id.clone(),
+        });
     }
 
     /// Returns the display name to be shown for this room in the UI.

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -574,11 +574,11 @@ impl Widget for HomeScreen {
                         self.apply_view_mode(cx, *new_mode);
                         self.view.redraw(cx);
                     }
-                    self.sync_effective_view_mode(cx);
+                    self.sync_effective_view_mode(cx, app_state);
                 }
 
                 if let WindowAction::WindowGeomChange(_) = action.as_widget_action().cast() {
-                    self.sync_effective_view_mode(cx);
+                    self.sync_effective_view_mode(cx, app_state);
                 }
 
                 // Handle room selections. Desktop owns tab creation in MainDesktopUI,
@@ -640,14 +640,23 @@ impl HomeScreen {
         self.applied_view_mode = mode;
     }
 
-    fn sync_effective_view_mode(&mut self, cx: &mut Cx) {
+    fn sync_effective_view_mode(&mut self, cx: &mut Cx, app_state: &mut AppState) {
         let is_desktop = effective_is_desktop(cx);
-        let Some(previous_is_desktop) = self.last_effective_is_desktop.replace(is_desktop) else {
+        let Some(was_desktop) = self.last_effective_is_desktop.replace(is_desktop) else {
             return;
         };
-        if previous_is_desktop != is_desktop {
-            self.clear_mobile_navigation_state(cx);
+        if was_desktop == is_desktop {
+            return;
         }
+        // If we transitioned from mobile --> desktop view mode, the dock will reload the tabs
+        // from its previously-saved state, so we need to free the current selected room now
+        // (if it was a thread timeline), and then also clear any thread timelines in the mobile nav stack.
+        if !was_desktop && is_desktop {
+            if let Some(room) = app_state.selected_room.as_ref() {
+                room.close_thread_timeline(cx);
+            }
+        }
+        self.clear_mobile_navigation_state(cx);
     }
 
     fn update_active_page_from_selection(
@@ -745,6 +754,12 @@ impl HomeScreen {
     }
 
     fn clear_mobile_navigation_state(&mut self, cx: &mut Cx) {
+        // When switching from mobile --> desktop view mode, we discard the nav stack,
+        // and thus we need to free & destroy any thread timelines in it.
+        // Note that freeing the current room is handled in `sync_effective_view_mode`.
+        for room in &self.mobile_screen_history {
+            room.close_thread_timeline(cx);
+        }
         self.mobile_screen_history.clear();
 
         let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
@@ -813,14 +828,18 @@ impl HomeScreen {
         match self.mobile_screen_history.pop() {
             Some(previous) => {
                 let Some(view_id) = self.populate_mobile_stack_view(cx, &stack_nav, &previous) else {
+                    // Nav failed; current_screen is restored, so don't free it.
                     app_state.selected_room = Some(current_screen);
                     self.mobile_screen_history.push(previous);
                     return;
                 };
+                // current_screen is gone for good — free its thread timeline if it is one.
+                current_screen.close_thread_timeline(cx);
                 app_state.selected_room = Some(previous);
                 stack_nav.pop_to_view(cx, view_id);
             }
             None => {
+                current_screen.close_thread_timeline(cx);
                 app_state.selected_room = None;
                 stack_nav.pop_to_root(cx);
             }

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -219,6 +219,10 @@ impl MainDesktopUI {
     fn close_tab(&mut self, cx: &mut Cx, tab_id: LiveId) {
         let dock = self.view.dock(cx, ids!(dock));
         if let Some(room_being_closed) = self.open_rooms.get(&tab_id) {
+            // Thread tab closing for good: free its timeline (no-op for a normal room). Space
+            // switching goes through save/load_dock_state_from instead, which keeps timelines
+            // around so the dock can be restored.
+            room_being_closed.close_thread_timeline(cx);
             self.room_order.retain(|sr| sr != room_being_closed);
 
             if self.open_rooms.len() > 1 {
@@ -254,7 +258,10 @@ impl MainDesktopUI {
     /// Closes all tabs
     pub fn close_all_tabs(&mut self, cx: &mut Cx) {
         let dock = self.view.dock(cx, ids!(dock));
-        for tab_id in self.open_rooms.keys() {
+        for (tab_id, room) in self.open_rooms.iter() {
+            // Free thread timelines too, like close_tab. Only hit during logout today (which
+            // clears ALL_JOINED_ROOMS anyway), but keeps things consistent if reused elsewhere.
+            room.close_thread_timeline(cx);
             dock.close_tab(cx, *tab_id);
         }
 

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -277,7 +277,6 @@ impl MainDesktopUI {
     pub fn close_all_tabs(&mut self, cx: &mut Cx) {
         let dock = self.view.dock(cx, ids!(dock));
         for (tab_id, room) in self.open_rooms.iter() {
-            // Free thread timelines here too, like close_tab.
             room.close_thread_timeline(cx);
             dock.close_tab(cx, *tab_id);
         }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -3192,16 +3192,14 @@ mod timeline_state_store {
     /// the next time that we want to show it.
     pub(super) fn invalidate(_cx: &mut Cx, kind: &TimelineKind) {
         TIMELINE_STATES.with_borrow_mut(|states| {
-            match states.get_mut(kind) {
-                // If this timeline is currently being shown, just set the flag
+            if let Some(StateEntry::Taken { invalidated, .. }) = states.get_mut(kind) {
+                // If this timeline is currently being shown (it was `Taken`), just set the flag
                 // so it'll be dropped (see `put_back()`) when it's hidden by the RoomScreen.
-                Some(StateEntry::Taken { invalidated, .. }) => {
-                    *invalidated = true;
-                    return;
-                }
-                _ => {}
+                *invalidated = true;
+                return;
             }
-            // Otherwise, if it's not being shown, just remove it now
+
+            // Otherwise, if it's not being shown, just remove it now.
             states.remove(kind);
         });
     }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2459,7 +2459,7 @@ impl RoomScreen {
         let room_id = kind.room_id().clone();
         let owner = self.widget_uid();
 
-        let (mut tl_state, mut is_first_time_being_loaded) = match timeline_state_store::take(&kind, owner) {
+        let (mut tl_state, mut is_first_time_being_loaded) = match timeline_state_store::take(cx, &kind, owner) {
             timeline_state_store::TakeResult::Taken(existing) => (existing, false),
             timeline_state_store::TakeResult::AlreadyTaken { owner: current_owner } => {
                 error!("RoomScreen::show_timeline(): timeline {kind} is already taken by widget {current_owner:?}");
@@ -2529,7 +2529,7 @@ impl RoomScreen {
                     tombstone_info,
                     pending_downloads: SmallVec::new(),
                 };
-                timeline_state_store::mark_taken(&tl_state.kind, owner);
+                timeline_state_store::mark_taken(cx, &tl_state.kind, owner);
                 (tl_state, true)
             }
         };
@@ -3079,7 +3079,14 @@ mod timeline_state_store {
         /// and can be taken by another `RoomScreen` in the future.
         Stored(TimelineUiState),
         /// A `RoomScreen` is displaying this timeline, so it's not available.
-        Taken { owner: WidgetUid },
+        Taken {
+            /// The widget UID of the RoomScreen that is currently displaying this timeline.
+            owner: WidgetUid,
+            /// A flag indicating that this timeline's backend async task that handles
+            /// timeline sync & updates was closed while the timeline was still being shown.
+            /// See [`put_back()`] for more info. 
+            invalidated: bool,
+        },
     }
 
     /// Result of trying to take ownership of a timeline's UI state.
@@ -3101,15 +3108,15 @@ mod timeline_state_store {
     }
 
     /// Attempts to take ownership of the saved UI state for `kind`.
-    pub(super) fn take(kind: &TimelineKind, owner: WidgetUid) -> TakeResult {
+    pub(super) fn take(_cx: &mut Cx, kind: &TimelineKind, owner: WidgetUid) -> TakeResult {
         TIMELINE_STATES.with_borrow_mut(|states| {
             match states.remove(kind) {
                 Some(StateEntry::Stored(state)) => {
-                    states.insert(kind.clone(), StateEntry::Taken { owner });
+                    states.insert(kind.clone(), StateEntry::Taken { owner, invalidated: false });
                     TakeResult::Taken(state)
                 }
-                Some(StateEntry::Taken { owner: current_owner }) => {
-                    states.insert(kind.clone(), StateEntry::Taken { owner: current_owner });
+                Some(StateEntry::Taken { owner: current_owner, invalidated }) => {
+                    states.insert(kind.clone(), StateEntry::Taken { owner: current_owner, invalidated });
                     TakeResult::AlreadyTaken { owner: current_owner }
                 }
                 None => TakeResult::Missing,
@@ -3121,13 +3128,13 @@ mod timeline_state_store {
     ///
     /// This is only supposed to be used when a new timeline is created by taking
     /// the backend timeline endpoints.
-    pub(super) fn mark_taken(kind: &TimelineKind, owner: WidgetUid) {
+    pub(super) fn mark_taken(_cx: &mut Cx, kind: &TimelineKind, owner: WidgetUid) {
         TIMELINE_STATES.with_borrow_mut(|states| {
-            match states.insert(kind.clone(), StateEntry::Taken { owner }) {
+            match states.insert(kind.clone(), StateEntry::Taken { owner, invalidated: false }) {
                 Some(StateEntry::Stored(_)) => {
                     error!("RoomScreen::show_timeline(): timeline {kind} unexpectedly had a stored state while creating a new state");
                 }
-                Some(StateEntry::Taken { owner: current_owner }) if current_owner != owner => {
+                Some(StateEntry::Taken { owner: current_owner, .. }) if current_owner != owner => {
                     error!("RoomScreen::show_timeline(): timeline {kind} was already taken by widget {current_owner:?}, but widget {owner:?} created a new state");
                 }
                 Some(StateEntry::Taken { .. }) | None => {}
@@ -3137,12 +3144,21 @@ mod timeline_state_store {
 
     /// Puts a timeline's UI state back into the store after a `RoomScreen` hides it,
     /// which allows a future RoomScreen to take it again.
+    ///
+    /// Note: this function gets called from drop handlers so it can't take `&mut Cx`,
+    ///       but those drop handlers are only reachable from the main UI thread anyway.
     pub(super) fn put_back(owner: WidgetUid, state: TimelineUiState) {
         let kind = state.kind.clone();
         TIMELINE_STATES.with_borrow_mut(|states| {
             match states.remove(&kind) {
-                Some(StateEntry::Taken { owner: current_owner }) if current_owner == owner => {}
-                Some(StateEntry::Taken { owner: current_owner }) => {
+                Some(StateEntry::Taken { owner: current_owner, invalidated }) if current_owner == owner => {
+                    // If it was invalidated and we (the `owner`) was the RoomScreen currently showing it,
+                    // just return here to keep it removed from the TIMELINE_STATES.
+                    if invalidated {
+                        return;
+                    }
+                }
+                Some(StateEntry::Taken { owner: current_owner, .. }) => {
                     error!("RoomScreen::save_state(): timeline {kind} was put back by widget {owner:?}, but it was taken by widget {current_owner:?}");
                 }
                 Some(StateEntry::Stored(_)) => {
@@ -3160,9 +3176,30 @@ mod timeline_state_store {
     ///
     /// This is used when all timeline UI state is being reset globally, such as
     /// during logout or session teardown.
-    pub(super) fn clear_all() {
+    pub(super) fn clear_all(_cx: &mut Cx) {
         TIMELINE_STATES.with_borrow_mut(|states| {
             states.clear();
+        });
+    }
+
+    /// Marks the given timeline's cached UI state as invalidated because we closed/stopped
+    /// the corresponding backend async timeline sync loop task for it.
+    ///
+    /// This ensures that a new timeline (and async sync task) will be re-created for it
+    /// the next time that we want to show it.
+    pub(super) fn invalidate(_cx: &mut Cx, kind: &TimelineKind) {
+        TIMELINE_STATES.with_borrow_mut(|states| {
+            match states.get_mut(kind) {
+                // If this timeline is currently being shown, just set the flag
+                // so it'll be dropped (see `put_back()`) when it's hidden by the RoomScreen.
+                Some(StateEntry::Taken { invalidated, .. }) => {
+                    *invalidated = true;
+                    return;
+                }
+                _ => {}
+            }
+            // Otherwise, if it's not being shown, just remove it now
+            states.remove(kind);
         });
     }
 }
@@ -5408,9 +5445,15 @@ impl MessageRef {
 
 /// Clears all UI-related timeline states for all known rooms.
 ///
-/// This function requires passing in a reference to `Cx`,
-/// which isn't used, but acts as a guarantee that this function
-/// must only be called by the main UI thread. 
-pub fn clear_timeline_states(_cx: &mut Cx) {
-    timeline_state_store::clear_all();
+/// Takes `&mut Cx` (unused) to enforce that it's only called from the main UI thread.
+pub fn clear_timeline_states(cx: &mut Cx) {
+    timeline_state_store::clear_all(cx);
+}
+
+/// Invalidates the UI-side cached state for a timeline whose backend was just closed, so the
+/// next show rebuilds it instead of reusing the stale cache.
+///
+/// Takes `&mut Cx` (unused) to enforce that it's only called from the main UI thread.
+pub fn invalidate_timeline_state(cx: &mut Cx, kind: &TimelineKind) {
+    timeline_state_store::invalidate(cx, kind);
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -463,6 +463,11 @@ pub enum MatrixRequest {
         room_id: OwnedRoomId,
         thread_root_event_id: OwnedEventId,
     },
+    /// Request to stop a thread timeline's backend sync loop (e.g. for when its tab was closed).
+    CloseThreadTimeline {
+        room_id: OwnedRoomId,
+        thread_root_event_id: OwnedEventId,
+    },
     /// Request to knock on (request an invite to) the given room.
     Knock {
         room_or_alias_id: OwnedRoomOrAliasId,
@@ -982,6 +987,10 @@ async fn matrix_worker_task(
                             let Some(room_info) = all_joined_rooms.get_mut(&room_id) else {
                                 return;
                             };
+                            if !room_info.pending_thread_timelines.remove(&thread_root_event_id) {
+                                log!("Thread-focused timeline for room {room_id}, thread {thread_root_event_id} was closed during creation; discarding it.");
+                                return;
+                            }
                             log!("Successfully created thread-focused timeline for room {room_id}, thread {thread_root_event_id}.");
                             let thread_timeline = Arc::new(thread_timeline);
                             let (timeline_update_sender, timeline_update_receiver) = crossbeam_channel::unbounded();
@@ -995,9 +1004,6 @@ async fn matrix_worker_task(
                                     Some(thread_root_event_id.clone()),
                                 )
                             );
-                            room_info
-                                .pending_thread_timelines
-                                .remove(&thread_root_event_id);
                             room_info.thread_timelines.insert(
                                 thread_root_event_id.clone(),
                                 PerTimelineDetails {
@@ -1028,6 +1034,20 @@ async fn matrix_worker_task(
                         }
                     }
                 });
+            }
+
+            MatrixRequest::CloseThreadTimeline { room_id, thread_root_event_id } => {
+                let mut all_joined_rooms = ALL_JOINED_ROOMS.lock().unwrap();
+                let Some(room_info) = all_joined_rooms.get_mut(&room_id) else {
+                    continue;
+                };
+                // Remove it from the pending set to handle the rare case where we showed the
+                // thread timeline but then quickly hid it before its backend task could finish being set up.
+                room_info.pending_thread_timelines.remove(&thread_root_event_id);
+                // Remove and drop the entry (see [`PerTimelineDetails::drop()`] to abort its async task.
+                if room_info.thread_timelines.remove(&thread_root_event_id).is_some() {
+                    log!("Closed thread timeline for room {room_id}, thread {thread_root_event_id}.");
+                }
             }
 
             MatrixRequest::Knock { room_or_alias_id, reason, server_names } => {
@@ -2388,6 +2408,11 @@ struct PerTimelineDetails {
     /// The async task that listens for updates for this timeline.
     timeline_subscriber_handler_task: JoinHandle<()>,
 }
+impl Drop for PerTimelineDetails {
+    fn drop(&mut self) {
+        self.timeline_subscriber_handler_task.abort();
+    }
+}
 
 struct JoinedRoomDetails {
     /// The room ID of this joined room.
@@ -2406,10 +2431,8 @@ struct JoinedRoomDetails {
 impl Drop for JoinedRoomDetails {
     fn drop(&mut self) {
         log!("Dropping JoinedRoomDetails for room {}", self.room_id);
-        self.main_timeline.timeline_subscriber_handler_task.abort();
-        for thread_timeline in self.thread_timelines.values() {
-            thread_timeline.timeline_subscriber_handler_task.abort();
-        }
+        // main_timeline and each thread_timelines entry abort their own task via
+        // PerTimelineDetails::Drop, so just tear down the room-level subscriptions here.
         drop(self.typing_notice_subscriber.take());
         drop(self.pinned_events_subscriber.take());
     }


### PR DESCRIPTION
this includes both the Timeline UI state that's cached by the main UI thread, as well as the backend async task that is spawned to subscribe to updates for that timeline.