### PR TITLE
Don't persist `selected_room` in `AppState`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -973,7 +973,10 @@ impl App {
 pub struct AppState {
     /// The currently-selected room, which is highlighted (selected) in the RoomsList
     /// and considered "active" in the main rooms screen.
-    #[serde(default, deserialize_with = "crate::utils::deserialize_or_default")]
+    ///
+    /// This isn't persisted because in mobile view mode, the rooms list shows no selection,
+    /// and in desktop view mode, the selected room is obtained from the saved dock state
+    #[serde(skip)]
     pub selected_room: Option<SelectedRoom>,
     /// The currently-selected navigation tab: defines which top-level view is shown.
     ///

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -640,11 +640,6 @@ impl HomeScreen {
     fn sync_effective_view_mode(&mut self, cx: &mut Cx, app_state: &mut AppState) {
         let is_desktop = effective_is_desktop(cx);
         let Some(was_desktop) = self.last_effective_is_desktop.replace(is_desktop) else {
-            // Mobile mode starts on the rooms list with no room open, so no
-            // room should be drawn as selected until one is actually clicked.
-            if !is_desktop {
-                cx.action(AppStateAction::FocusNone);
-            }
             return;
         };
         if was_desktop == is_desktop {


### PR DESCRIPTION
This ensures that in mobile view mode, the app doesn't start showing a previously-selected room as selected.

Fix/remove other places where we tried to ensure this.