### PR TITLE
Fix AdaptiveView redraw bug in makepad, simplifying SpacesBar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "bit-vec",
 ]
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "bitflags"
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "bitmaps"
@@ -724,7 +724,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "byteorder"
@@ -735,7 +735,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "bytes"
@@ -794,7 +794,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "cfg_aliases"
@@ -805,7 +805,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "chacha20"
@@ -1142,7 +1142,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "crypto-bigint"
@@ -1522,7 +1522,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "dunce"
@@ -1630,7 +1630,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "errno"
@@ -1808,7 +1808,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "foreign-types"
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
 ]
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
 ]
@@ -2198,7 +2198,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "hilog-sys"
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
  "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
@@ -2832,7 +2832,7 @@ dependencies = [
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
  "windows-link 0.2.1",
@@ -2906,7 +2906,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "loom"
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3058,22 +3058,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "weezl",
 ]
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
  "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3106,7 +3106,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "ttf-parser",
 ]
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3147,12 +3147,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3183,12 +3183,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
@@ -3225,12 +3225,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3261,12 +3261,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
  "makepad-error-log",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "simd-adler32",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3752,7 +3752,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "mime"
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
  "bit-set",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "num_cpus"
@@ -4163,7 +4163,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4452,7 +4452,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "pollster"
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "rustc-hash"
@@ -5506,7 +5506,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
  "bytemuck",
@@ -5600,7 +5600,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "scopeguard"
@@ -5611,7 +5611,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "sealed"
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "siphasher"
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "socket2"
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
 ]
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "tungstenite"
@@ -6784,7 +6784,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-bidi"
@@ -6795,17 +6795,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-ident"
@@ -6816,7 +6816,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-normalization"
@@ -6836,12 +6836,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6852,7 +6852,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "unicode-xid"
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "log 0.4.29",
  "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "whoami"
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7460,7 +7460,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "windows-numerics"
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#a67d497c5b1fe657ec5a243f20ddaad88c894ee7"
+source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
 
 [[package]]
 name = "zerocopy-derive"

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -443,12 +443,6 @@ impl Widget for SpacesBarWrapper {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        // TODO: i want to uncomment this, but adding it back in will break
-        //       the animation of showing the SpacesBarWrapper.
-        //       I'm not sure why the SpacesBar is getting redrawn constantly though.
-        // if walk.height.to_fixed().is_some_and(|h| h < 0.01) {
-        //     return DrawStep::done();
-        // }
         self.view.draw_walk(cx, scope, walk)
     }
 }

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -13,7 +13,7 @@ use matrix_sdk::{RoomDisplayName, RoomState};
 use ruma::{OwnedRoomAliasId, OwnedRoomId, room::JoinRuleSummary};
 
 use crate::{
-    home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetRefExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction}, utils::{self, RoomNameId}
+    home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{effective_is_desktop, AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction}, utils::{self, RoomNameId}
 };
 
 script_mod! {
@@ -168,6 +168,7 @@ pub struct SpacesBarEntry {
     #[deref] inner: NavigationBarButton,
 
     #[rust] space_name_id: Option<RoomNameId>,
+    #[rust] last_avatar: Option<FetchedRoomAvatar>,
 }
 
 impl Widget for SpacesBarEntry {
@@ -205,16 +206,52 @@ impl Widget for SpacesBarEntry {
 }
 
 impl SpacesBarEntry {
-    fn set_metadata(&mut self, cx: &mut Cx, space_name_id: RoomNameId, is_selected: bool) {
-        self.inner.set_tooltip_text(space_name_id.to_string());
+    fn set_metadata(
+        &mut self,
+        cx: &mut Cx,
+        space_name_id: RoomNameId,
+        avatar: &FetchedRoomAvatar,
+        is_selected: bool,
+    ) {
+        let space_name = space_name_id.to_string();
+        // The name label isn't visible by default, but we populate it anyway.
+        self.inner.view.label(cx, ids!(space_name)).set_text(cx, &space_name);
+
+        // Only populate the avatar if it has actually changed.
+        if self.last_avatar.as_ref() != Some(avatar) {
+            let avatar_ref = self.inner.view.avatar(cx, ids!(avatar));
+            match avatar {
+                FetchedRoomAvatar::Text(text) => avatar_ref.show_text(cx, None, None, text),
+                FetchedRoomAvatar::Image(image) => {
+                    let res = avatar_ref.show_image(
+                        cx,
+                        None,
+                        |cx, img_ref| utils::load_avatar_image(&img_ref, cx, image),
+                    );
+                    if res.is_err() {
+                        avatar_ref.show_text(cx, None, None, &space_name);
+                    }
+                }
+            }
+            self.last_avatar = Some(avatar.clone());
+        }
+
         self.space_name_id = Some(space_name_id);
+        self.inner.set_tooltip_text(space_name);
         self.inner.set_selected(cx, is_selected);
     }
 }
+
 impl SpacesBarEntryRef {
-    pub fn set_metadata(&self, cx: &mut Cx, space_name_id: RoomNameId, is_selected: bool) {
+    pub fn set_metadata(
+        &self,
+        cx: &mut Cx,
+        space_name_id: RoomNameId,
+        avatar: &FetchedRoomAvatar,
+        is_selected: bool,
+    ) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.set_metadata(cx, space_name_id, is_selected);
+        inner.set_metadata(cx, space_name_id, avatar, is_selected);
     }
 }
 
@@ -470,33 +507,10 @@ impl Widget for SpacesBar {
                         .and_then(|space_id| self.all_joined_spaces.get(space_id))
                     {
                         let item = list.item(cx, portal_list_index, id!(spaces_bar_entry));
-                        // Populate the space name and avatar (although this isn't visible by default).
-                        let space_name = space.space_name_id.to_string();
-                        item.label(cx, ids!(space_name)).set_text(cx, &space_name);
-                        let avatar_ref = item.avatar(cx, ids!(avatar));
-                        match &space.space_avatar {
-                            FetchedRoomAvatar::Text(text) => {
-                                avatar_ref.show_text(cx, None, None, text);
-                            }
-                            FetchedRoomAvatar::Image(avatar_image) => {
-                                let res = avatar_ref.show_image(
-                                    cx,
-                                    None,
-                                    |cx, img_ref| utils::load_avatar_image(&img_ref, cx, avatar_image),
-                                );
-                                if res.is_err() {
-                                    avatar_ref.show_text(
-                                        cx,
-                                        None,
-                                        None,
-                                        &space_name,
-                                    );
-                                }
-                            }
-                        }
                         item.as_spaces_bar_entry().set_metadata(
                             cx,
                             space.space_name_id.clone(),
+                            &space.space_avatar,
                             self.selected_space.as_ref().is_some_and(|id| id == space.space_name_id.room_id()),
                         );
                         item


### PR DESCRIPTION
Also, be more efficient when redrawing the SpacesBar and its entries by avoiding repopulating (loading + decoding) the avatar image every time