### PR TITLE
ci(release): upload local macOS and iOS packaging scripts as CI actions

### DIFF
--- a/.github/actions/import-apple-cert/action.yml
+++ b/.github/actions/import-apple-cert/action.yml
@@ -1,0 +1,32 @@
+name: Import Apple signing certificate
+description: Decode a base64 .p12 and import it into a fresh keychain for codesign.
+inputs:
+  certificate:
+    description: base64-encoded .p12 (Developer ID Application and/or Apple Distribution)
+    required: true
+  password:
+    description: password used when the .p12 was exported
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        APPLE_CERTIFICATE: ${{ inputs.certificate }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ inputs.password }}
+      run: |
+        CERT_FILE=$(mktemp /tmp/certificate.XXXXXX.p12)
+        KEYCHAIN_FILE=$(mktemp /tmp/keychain.XXXXXX.keychain-db)
+        KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+        echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_FILE"
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_FILE"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+        security import "$CERT_FILE" -k "$KEYCHAIN_FILE" \
+          -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple: \
+          -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
+        security list-keychains -d user -s "$KEYCHAIN_FILE" login.keychain
+
+        rm -f "$CERT_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,57 +297,21 @@ jobs:
           cargo install robius-packaging-commands --locked
 
       - name: Import Apple certificate
+        uses: ./.github/actions/import-apple-cert
+        with:
+          certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      # The script signs, notarizes, and staples the DMG itself, so there's
+      # no separate notarize step. Mirrors running it locally.
+      - name: Build, sign, notarize, and staple the DMG
         env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          CERT_FILE=$(mktemp /tmp/certificate.XXXXXX.p12)
-          KEYCHAIN_FILE=$(mktemp /tmp/keychain.XXXXXX.keychain-db)
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_FILE"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_FILE"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
-          security import "$CERT_FILE" -k "$KEYCHAIN_FILE" \
-            -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_FILE"
-          security list-keychains -d user -s "$KEYCHAIN_FILE" login.keychain
-
-          rm -f "$CERT_FILE"
-
-      - name: Build DMG with Applications icon fix
-        env:
-          CARGO_PACKAGER_SIGNING_KEY: ${{ secrets.CARGO_PACKAGER_SIGNING_KEY }}
-          CARGO_PACKAGER_SIGNING_PASSWORD: ${{ secrets.CARGO_PACKAGER_SIGNING_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           chmod +x ./packaging/build-macos-dmg.sh ./packaging/fix-dmg-applications-icon.sh
           ./packaging/build-macos-dmg.sh
-
-      - name: Notarize DMG
-        env:
-          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
-          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-        run: |
-          API_KEY_FILE=$(mktemp /tmp/api_key.XXXXXX.p8)
-          echo "$APP_STORE_CONNECT_API_KEY_CONTENT" > "$API_KEY_FILE"
-
-          DMG_FILE=$(find ./dist -name '*.dmg' -print -quit)
-          if [[ -z "$DMG_FILE" ]]; then
-            echo "Error: No DMG file found in dist/"
-            exit 1
-          fi
-
-          xcrun notarytool submit "$DMG_FILE" \
-            --key "$API_KEY_FILE" \
-            --key-id "$APP_STORE_CONNECT_KEY_ID" \
-            --issuer "$APP_STORE_CONNECT_ISSUER_ID" \
-            --wait
-
-          xcrun stapler staple "$DMG_FILE"
-          rm -f "$API_KEY_FILE"
 
       - name: Upload DMG to Release
         env:
@@ -423,29 +387,71 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Package (iOS)
-        uses: project-robius/makepad-packaging-action@v1
+      - name: Install Rust nightly
+        run: rustup toolchain install nightly
+
+      - name: Setup cargo-makepad
+        uses: ./.github/actions/setup-cargo-makepad
+
+      - name: Install iOS toolchain
+        run: cargo makepad apple ios install-toolchain
+
+      - name: Install bindgen-cli for aws-lc-sys cross-compilation
+        run: cargo install --force --locked bindgen-cli
+
+      - name: Import Apple certificate
+        uses: ./.github/actions/import-apple-cert
+        with:
+          certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Install provisioning profile
         env:
-          AWS_LC_SYS_CMAKE_BUILDER: 1
-          MAKEPAD_MOBILE_CARGO_EXTRA_ARGS: >-
-            --config profile.dev.opt-level=0
-            --config profile.dev.debug=false
-            --config profile.dev.lto=false
-            --config profile.dev.strip=true
-            --config profile.dev.debug-assertions=false
-          MAKEPAD_IOS_ORG: org.robius.robrix
-          MAKEPAD_IOS_APP: Robrix
-          MAKEPAD_IOS_CREATE_IPA: 'true'
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
-          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: Apple Development
+        run: |
+          PROFILE_FILE=$(mktemp /tmp/profile.XXXXXX.mobileprovision)
+          echo "$APPLE_PROVISIONING_PROFILE" | base64 --decode > "$PROFILE_FILE"
+          security cms -D -i "$PROFILE_FILE" > /tmp/profile.plist
+          UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /tmp/profile.plist)
+          DEST="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$DEST"
+          cp "$PROFILE_FILE" "$DEST/${UUID}.mobileprovision"
+          echo "IOS_PROVISIONING_PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
+          rm -f "$PROFILE_FILE"
+
+      - name: Write App Store Connect API key
+        env:
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-        with:
-          github_token: ${{ secrets.ROBRIX_RELEASE }}
-          upload_to_testflight: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.upload_testflight == 'true' }}
-          args: --target aarch64-apple-ios
-          releaseId: ${{ needs.create_release.outputs.release_id }}
+        run: |
+          DEST="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$DEST"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_CONTENT" > "$DEST/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+          chmod 600 "$DEST/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+
+      - name: Build, sign, package, and upload to TestFlight
+        env:
+          AWS_LC_SYS_CMAKE_BUILDER: 1
+          IOS_SIGNING_IDENTITY: Apple Distribution
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          IOS_UPLOAD_TESTFLIGHT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.upload_testflight == 'true' }}
+        run: |
+          chmod +x ./packaging/build-ios-testflight.sh
+          ./packaging/build-ios-testflight.sh
+
+      - name: Upload IPA to Release
+        if: ${{ needs.create_release.outputs.release_id != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.ROBRIX_RELEASE }}
+        run: |
+          IPA_FILE=$(find target/apple/makepad-apple-app/aarch64-apple-ios/release -name '*.ipa' -print -quit)
+          if [[ -z "$IPA_FILE" ]]; then
+            echo "Error: no .ipa found to upload"
+            exit 1
+          fi
+          gh api "repos/${{ github.repository }}/releases/${{ needs.create_release.outputs.release_id }}/assets" \
+            --method POST \
+            -H "Content-Type: application/octet-stream" \
+            --input "$IPA_FILE" \
+            -f "name=$(basename "$IPA_FILE")"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 CLAUDE.md
 proxychains.conf
 testflight.sh
+
+## Filled-in release secrets for upload-release-secrets.sh (never commit)
+/packaging/release-secrets.env

--- a/packaging/build-ios-testflight.sh
+++ b/packaging/build-ios-testflight.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build, sign, and package the Robrix iOS .ipa, then optionally upload it to
+# TestFlight. This is the CI-runnable version of the local testflight.sh flow:
+# it builds with distribution flags, compiles the asset catalog, patches
+# Info.plist (compliance flag, numeric version, unique build number), re-signs,
+# packages the .ipa, and uploads via altool.
+#
+# Config (env vars; the release.yml `for_ios` job supplies these from secrets):
+#   IOS_SIGNING_IDENTITY           cert common-name to sign with (default "Apple Distribution")
+#   IOS_PROVISIONING_PROFILE_UUID  installed .mobileprovision UUID (required)
+#   ASC_KEY_ID / ASC_ISSUER_ID     App Store Connect API key ids (required to upload)
+#   IOS_UPLOAD_TESTFLIGHT          "true" to upload after packaging (default false)
+#   TESTFLIGHT_BUILD_NUMBER        CFBundleVersion (default: Pacific-time timestamp)
+#   ORG / APP                      makepad org + app (default rs.robius / robrix)
+#
+# altool auto-discovers the API key from ~/.appstoreconnect/private_keys/AuthKey_<KEY_ID>.p8.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+ORG="${ORG:-rs.robius}"
+APP="${APP:-robrix}"
+SIGNING_IDENTITY="${IOS_SIGNING_IDENTITY:-Apple Distribution}"
+PROFILE_UUID="${IOS_PROVISIONING_PROFILE_UUID:?set IOS_PROVISIONING_PROFILE_UUID}"
+BUILD_NUMBER="${TESTFLIGHT_BUILD_NUMBER:-$(TZ=America/Los_Angeles date +%Y%m%d.%H%M)}"
+APP_BUNDLE="$REPO_ROOT/target/apple/makepad-apple-app/aarch64-apple-ios/release/${APP}.app"
+
+# Resolve the signing cert's SHA-1 from its common name, so nothing is hard-coded.
+CERT_SHA1="$(security find-identity -v -p codesigning \
+  | awk -v id="$SIGNING_IDENTITY" 'index($0, id) {print $2; exit}')"
+if [[ -z "$CERT_SHA1" ]]; then
+    echo "Error: no code-signing identity matching '$SIGNING_IDENTITY' in the keychain." >&2
+    exit 1
+fi
+
+echo "==> Identity: $SIGNING_IDENTITY ($CERT_SHA1)"
+echo "==> Profile:  $PROFILE_UUID"
+echo "==> Build:    $BUILD_NUMBER"
+
+# ---- 1. Build (run-device errors with "device not found"; the .app is still built) ----
+CARGO_PROFILE_RELEASE_DEBUG=false \
+CARGO_PROFILE_RELEASE_STRIP=symbols \
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
+CARGO_PROFILE_RELEASE_LTO=fat \
+TESTFLIGHT_BUILD_NUMBER="$BUILD_NUMBER" \
+cargo makepad apple ios --org="$ORG" --app="$APP" \
+  --profile="$PROFILE_UUID" \
+  --cert="$CERT_SHA1" \
+  --device=IPhone \
+  run-device -p "$APP" --release || true
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "Error: app bundle not built at $APP_BUNDLE" >&2
+    exit 1
+fi
+
+# ---- 2. Compile asset catalog ----
+xcrun actool ./packaging/ios/icons/Assets.xcassets \
+  --compile "$APP_BUNDLE" \
+  --platform iphoneos \
+  --minimum-deployment-target 14.0 \
+  --app-icon AppIcon \
+  --output-partial-info-plist /tmp/AssetInfo.plist
+
+# ---- 3. Patch Info.plist ----
+PLIST="$APP_BUNDLE/Info.plist"
+/usr/libexec/PlistBuddy -c "Merge /tmp/AssetInfo.plist" "$PLIST"
+
+set_or_add () {  # key, type, value
+  /usr/libexec/PlistBuddy -c "Add :$1 $2 $3" "$PLIST" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Set :$1 $3" "$PLIST"
+}
+set_or_add CFBundlePackageType string APPL
+set_or_add CFBundleIconName string AppIcon
+/usr/libexec/PlistBuddy -c "Add :UILaunchScreen dict" "$PLIST" 2>/dev/null || true
+set_or_add UILaunchScreen:UIImageName string AppIcon60x60
+set_or_add UILaunchScreen:UIColorName string LaunchScreenBackground
+set_or_add ITSAppUsesNonExemptEncryption bool false
+
+VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name=="robrix") | .version' \
+  | sed 's/-.*$//')
+echo "Version $VERSION (build $BUILD_NUMBER)"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$PLIST"
+
+# ---- 4. Extract entitlements from the App Store profile ----
+security cms -D -i "$HOME/Library/MobileDevice/Provisioning Profiles/${PROFILE_UUID}.mobileprovision" \
+  > /tmp/profile.plist
+/usr/libexec/PlistBuddy -x -c "Print :Entitlements" /tmp/profile.plist > /tmp/entitlements.plist
+
+# ---- 5. Re-sign (steps 2-3 invalidated the signature) ----
+codesign --force --sign "$CERT_SHA1" \
+  --entitlements /tmp/entitlements.plist \
+  --timestamp=none \
+  "$APP_BUNDLE"
+
+# ---- 6. Verify ----
+codesign -vvv "$APP_BUNDLE"
+codesign -d --entitlements - "$APP_BUNDLE"
+
+# ---- 7. Package .ipa ----
+BUILD_DIR="$REPO_ROOT/target/apple/makepad-apple-app/aarch64-apple-ios/release"
+cd "$BUILD_DIR"
+IPA_NAME="Robrix-${VERSION}-ios.ipa"
+rm -rf Payload "$IPA_NAME"
+ditto "${APP}.app" "Payload/${APP}.app"
+ditto -c -k --sequesterRsrc --keepParent Payload "$IPA_NAME"
+ls -lh "$IPA_NAME"
+echo "==> Packaged $BUILD_DIR/$IPA_NAME"
+
+# ---- 8. Upload to TestFlight (optional) ----
+if [[ "${IOS_UPLOAD_TESTFLIGHT:-false}" == "true" ]]; then
+    : "${ASC_KEY_ID:?set ASC_KEY_ID to upload}"
+    : "${ASC_ISSUER_ID:?set ASC_ISSUER_ID to upload}"
+    echo "==> Uploading $IPA_NAME to TestFlight..."
+    xcrun altool --upload-app --type ios \
+      --file "$IPA_NAME" \
+      --apiKey "$ASC_KEY_ID" \
+      --apiIssuer "$ASC_ISSUER_ID"
+    echo "==> Uploaded to TestFlight."
+else
+    echo "==> Skipping TestFlight upload (IOS_UPLOAD_TESTFLIGHT != true)."
+fi

--- a/packaging/release-secrets.env.example
+++ b/packaging/release-secrets.env.example
@@ -1,0 +1,31 @@
+# Copy this file to `release-secrets.env` (same folder) and fill in the values,
+# then run `./packaging/upload-release-secrets.sh`.
+#
+# `release-secrets.env` is gitignored. Blank entries are skipped on upload, so
+# you can set up desktop signing first and add iOS later by re-running.
+# Quote every value; use single quotes for anything containing `$` or spaces.
+
+# Repo to upload the secrets to.
+RELEASE_REPO='project-robius/robrix'
+
+# --- Desktop updater signing (Linux, Windows) ---
+# Generate once with: cargo packager signer generate --path robrix-updater.key
+CARGO_PACKAGER_SIGNING_KEY_FILE=''      # path to that key file
+CARGO_PACKAGER_SIGNING_PASSWORD=''      # the password you set for it
+
+# --- macOS signing + notarization ---
+APPLE_CERTIFICATE_FILE=''               # path to your "Developer ID Application" .p12
+APPLE_CERTIFICATE_PASSWORD=''           # the .p12 export password
+APPLE_ID=''                             # your Apple ID email
+APPLE_PASSWORD=''                       # app-specific password from appleid.apple.com
+APPLE_TEAM_ID='HMX6XGJZ3R'              # GOSIM FOUNDATION LTD.
+
+# --- iOS (optional; leave blank to skip) ---
+APP_STORE_CONNECT_API_KEY_FILE=''       # path to AuthKey_XXXXXX.p8
+APP_STORE_CONNECT_KEY_ID=''             # the key's ID
+APP_STORE_CONNECT_ISSUER_ID=''          # issuer UUID from App Store Connect
+APPLE_PROVISIONING_PROFILE_FILE=''      # path to your .mobileprovision
+APPLE_KEYCHAIN_PASSWORD=''              # any random string (temp keychain password)
+
+# --- Release token (already set on project-robius/robrix; leave blank) ---
+ROBRIX_RELEASE=''                       # PAT with contents:write, only if not already set

--- a/packaging/upload-release-secrets.sh
+++ b/packaging/upload-release-secrets.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Upload the GitHub Actions secrets used by the Robrix release workflow.
+#
+# Fill in packaging/release-secrets.env (copy it from the .example) and run:
+#   ./packaging/upload-release-secrets.sh [path-to-env-file]
+#
+# Blank entries are skipped, so you can set up desktop signing first and add
+# iOS later by filling in more fields and re-running.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="${1:-$SCRIPT_DIR/release-secrets.env}"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: the GitHub CLI (gh) is not installed. See https://cli.github.com" >&2
+    exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: not logged in to gh. Run 'gh auth login' first." >&2
+    exit 1
+fi
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Error: $ENV_FILE not found." >&2
+    echo "Copy packaging/release-secrets.env.example there and fill it in." >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+REPO="${RELEASE_REPO:-project-robius/robrix}"
+echo "==> Uploading secrets to $REPO"
+errors=0
+
+# Secret from a literal string. No trailing newline so passwords stay exact.
+set_str() {
+    local name="$1" value="${2:-}"
+    if [[ -z "$value" ]]; then echo "  -  skip $name (blank)"; return; fi
+    printf '%s' "$value" | gh secret set "$name" -R "$REPO"
+    echo "  ok  set  $name"
+}
+
+# Secret from a file's exact contents (preserves newlines, e.g. the .p8 key).
+set_file() {
+    local name="$1" file="${2:-}"
+    if [[ -z "$file" ]]; then echo "  -  skip $name (blank)"; return; fi
+    if [[ ! -f "$file" ]]; then
+        echo "  X  FAIL $name: file not found: $file" >&2
+        errors=$(( errors + 1 )); return
+    fi
+    gh secret set "$name" -R "$REPO" < "$file"
+    echo "  ok  set  $name (from $file)"
+}
+
+# Secret from the single-line base64 of a file (for .p12 / .mobileprovision).
+set_file_b64() {
+    local name="$1" file="${2:-}"
+    if [[ -z "$file" ]]; then echo "  -  skip $name (blank)"; return; fi
+    if [[ ! -f "$file" ]]; then
+        echo "  X  FAIL $name: file not found: $file" >&2
+        errors=$(( errors + 1 )); return
+    fi
+    base64 < "$file" | tr -d '\n' | gh secret set "$name" -R "$REPO"
+    echo "  ok  set  $name (base64 of $file)"
+}
+
+echo "-- Desktop updater signing (Linux, Windows) --"
+set_file CARGO_PACKAGER_SIGNING_KEY      "${CARGO_PACKAGER_SIGNING_KEY_FILE:-}"
+set_str  CARGO_PACKAGER_SIGNING_PASSWORD "${CARGO_PACKAGER_SIGNING_PASSWORD:-}"
+
+echo "-- macOS signing + notarization --"
+set_file_b64 APPLE_CERTIFICATE          "${APPLE_CERTIFICATE_FILE:-}"
+set_str      APPLE_CERTIFICATE_PASSWORD "${APPLE_CERTIFICATE_PASSWORD:-}"
+set_str      APPLE_ID                   "${APPLE_ID:-}"
+set_str      APPLE_PASSWORD             "${APPLE_PASSWORD:-}"
+set_str      APPLE_TEAM_ID              "${APPLE_TEAM_ID:-}"
+
+echo "-- iOS (optional) --"
+set_file     APP_STORE_CONNECT_API_KEY_CONTENT "${APP_STORE_CONNECT_API_KEY_FILE:-}"
+set_str      APP_STORE_CONNECT_KEY_ID          "${APP_STORE_CONNECT_KEY_ID:-}"
+set_str      APP_STORE_CONNECT_ISSUER_ID       "${APP_STORE_CONNECT_ISSUER_ID:-}"
+set_file_b64 APPLE_PROVISIONING_PROFILE        "${APPLE_PROVISIONING_PROFILE_FILE:-}"
+set_str      APPLE_KEYCHAIN_PASSWORD           "${APPLE_KEYCHAIN_PASSWORD:-}"
+
+echo "-- Release token --"
+set_str ROBRIX_RELEASE "${ROBRIX_RELEASE:-}"
+
+echo ""
+if (( errors > 0 )); then
+    echo "==> Done with $errors error(s). Fix the file path(s) above and re-run." >&2
+    exit 1
+fi
+echo "==> Done. Verify with: gh secret list -R $REPO"


### PR DESCRIPTION
This updates the release actions and others to match what I was doing locally on my macbook.

* The macOS create-DMG job now matches my custom local script, as does the iOS TestFlight upload script.
* Added some infra to upload and manage github secrets required for codesigning and notarizing macOS and iOS builds.

Here are the key files now:
* `.github/workflows/release.yml`: the release action that builds, signs, and publishes Robrix for all platforms whenever you create/push a new git tag (like `v1.2.3`). You can also run it manually.
* `.github/actions/import-apple-cert/action.yml`: deals with the apple certificates (.p12 files), and puts em into a new keychain for each codesign invocation.
* `packaging/build-ios-testflight.sh`: builds, signs, packages, and optionally uploads the iOS `.ipa` to TestFlight, including the `actool` icon building and patching the `Info.plist` files, and then re-signing the whole bundle.
* `packaging/upload-release-secrets.sh`: a simple script used to upload secrets to github so they can be used into above action runners.
* `packaging/release-secrets.env.example`: a template for you to fill in with your secrets so that the `upload-release-secrets.sh` script can push them.

Note that none of the above two files need to be used by devs, they're just mostly docs so we can understand & repro the initial setup.