### PR TITLE
efficiency: avoid redundant work or allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "bit-vec",
 ]
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "bitflags"
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "bitmaps"
@@ -724,7 +724,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "byteorder"
@@ -735,7 +735,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "bytes"
@@ -794,7 +794,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "cfg_aliases"
@@ -805,7 +805,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "chacha20"
@@ -1142,7 +1142,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "crypto-bigint"
@@ -1522,7 +1522,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "dunce"
@@ -1630,7 +1630,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "errno"
@@ -1808,7 +1808,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "foreign-types"
@@ -1965,9 +1965,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
@@ -2163,9 +2163,9 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
@@ -2198,7 +2198,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "hilog-sys"
@@ -2637,10 +2637,10 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
@@ -2832,9 +2832,9 @@ dependencies = [
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "windows-link 0.2.1",
 ]
 
@@ -2906,7 +2906,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "loom"
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3042,15 +3042,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3058,22 +3058,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "weezl",
 ]
@@ -3081,10 +3081,10 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
- "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
+ "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "num-traits 0.2.20",
  "zerocopy 0.8.39",
 ]
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3106,7 +3106,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "ttf-parser",
 ]
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3147,12 +3147,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3183,15 +3183,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3213,7 +3213,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3225,12 +3225,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3238,13 +3238,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3261,14 +3261,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3322,13 +3322,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "simd-adler32",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3752,7 +3752,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "mime"
@@ -3815,23 +3815,23 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "bit-set",
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
- "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
+ "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "hexf-parse",
- "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "makepad-error-log",
  "makepad-half",
  "num-traits 0.2.20",
- "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "unicode-ident",
 ]
 
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "num_cpus"
@@ -4163,7 +4163,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4452,7 +4452,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "pollster"
@@ -4597,10 +4597,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "unicase 2.9.0",
 ]
 
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "rustc-hash"
@@ -5506,12 +5506,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5600,7 +5600,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "scopeguard"
@@ -5611,7 +5611,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "sealed"
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "siphasher"
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "socket2"
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6320,9 +6320,9 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
- "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "tungstenite"
@@ -6784,7 +6784,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-bidi"
@@ -6795,17 +6795,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-ident"
@@ -6816,7 +6816,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-normalization"
@@ -6836,12 +6836,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6852,7 +6852,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "unicode-xid"
@@ -7178,11 +7178,11 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "downcast-rs",
  "libc",
- "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
  "smallvec 1.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys",
 ]
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7219,10 +7219,10 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "log 0.4.29",
- "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback)",
+ "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw)",
 ]
 
 [[package]]
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "whoami"
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7460,7 +7460,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "windows-numerics"
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=gl_sampling_fallback#625e9e90799db77375a54f0c09fd5024e7222b83"
+source = "git+https://github.com/kevinaboos/makepad?branch=button_text_dont_redraw#d0ed6b71a0c79fe14aa494a68e6e7a354e7fa013"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "gl_sampling_fallback", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "gl_sampling_fallback" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "button_text_dont_redraw", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "button_text_dont_redraw" }
 
 
 robius-directories = { git = "https://github.com/project-robius/robius" }

--- a/src/home/event_source_modal.rs
+++ b/src/home/event_source_modal.rs
@@ -317,9 +317,9 @@ impl EventSourceModal {
         event_id: Option<OwnedEventId>,
         latest_json: Option<String>,
     ) {
-        self.room_id = Some(room_id.clone());
-        self.event_id = event_id.clone();
-        self.latest_json = latest_json.clone();
+        self.room_id = Some(room_id);
+        self.event_id = event_id;
+        self.latest_json = latest_json;
 
         self.view.button(cx, ids!(close_button)).reset_hover(cx);
         self.view.button(cx, ids!(room_id_copy_button)).reset_hover(cx);

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -503,8 +503,7 @@ impl Widget for HomeScreen {
                 match action.downcast_ref() {
                     Some(NavigationBarAction::GoToHome) => {
                         if !matches!(app_state.selected_tab, SelectedTab::Home) {
-                            self.previous_selection = app_state.selected_tab.clone();
-                            app_state.selected_tab = SelectedTab::Home;
+                            self.previous_selection = std::mem::replace(&mut app_state.selected_tab, SelectedTab::Home);
                             cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
                             self.update_active_page_from_selection(cx, app_state);
                             self.view.redraw(cx);
@@ -512,8 +511,7 @@ impl Widget for HomeScreen {
                     }
                     Some(NavigationBarAction::GoToAddRoom) => {
                         if !matches!(app_state.selected_tab, SelectedTab::AddRoom) {
-                            self.previous_selection = app_state.selected_tab.clone();
-                            app_state.selected_tab = SelectedTab::AddRoom;
+                            self.previous_selection = std::mem::replace(&mut app_state.selected_tab, SelectedTab::AddRoom);
                             cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
                             self.update_active_page_from_selection(cx, app_state);
                             self.view.redraw(cx);
@@ -522,8 +520,7 @@ impl Widget for HomeScreen {
                     Some(NavigationBarAction::GoToSpace { space_name_id }) => {
                         let new_space_selection = SelectedTab::Space { space_name_id: space_name_id.clone() };
                         if app_state.selected_tab != new_space_selection {
-                            self.previous_selection = app_state.selected_tab.clone();
-                            app_state.selected_tab = new_space_selection;
+                            self.previous_selection = std::mem::replace(&mut app_state.selected_tab, new_space_selection);
                             cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
                             self.update_active_page_from_selection(cx, app_state);
                             self.view.redraw(cx);
@@ -532,8 +529,7 @@ impl Widget for HomeScreen {
                     // Only open the settings screen if it is not currently open.
                     Some(NavigationBarAction::OpenSettings) => {
                         if !matches!(app_state.selected_tab, SelectedTab::Settings) {
-                            self.previous_selection = app_state.selected_tab.clone();
-                            app_state.selected_tab = SelectedTab::Settings;
+                            self.previous_selection = std::mem::replace(&mut app_state.selected_tab, SelectedTab::Settings);
                             cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
                             if let Some(settings_page) = self.update_active_page_from_selection(cx, app_state) {
                                 settings_page

--- a/src/home/invite_modal.rs
+++ b/src/home/invite_modal.rs
@@ -175,9 +175,9 @@ impl WidgetMatchEvent for InviteModal {
                     if let Some(room_name_id) = &self.room_name_id {
                         submit_async_request(MatrixRequest::InviteUser {
                             room_id: room_name_id.room_id().clone(),
-                            user_id: user_id.to_owned(),
+                            user_id: user_id.clone(),
                         });
-                        self.state = InviteModalState::WaitingForInvite(user_id.to_owned());
+                        self.state = InviteModalState::WaitingForInvite(user_id);
                         script_apply_eval!(cx, status_label, {
                             text: "Sending invite...",
                             draw_text +: {

--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -356,13 +356,15 @@ impl LinkPreviewRef {
                 let num_links = accepted_links.len();
                 // Reuse as many old link preview child instances as we can.
                 inner.children.truncate(num_links);
-                // A reused preview keeps the bg color it had, so clear any old hover coloring.
-                for item in inner.children.iter() {
-                    reset_hover(cx, item);
-                }
                 while inner.children.len() < num_links {
                     let child = widget_ref_from_live_ptr(cx, inner.preview_template).as_view();
                     inner.children.push(child);
+                }
+                // Reset each preview's per-link visual state: a reused one keeps its old
+                // hover color and image, and a new one shows TextOrImage's default view.
+                for item in inner.children.iter() {
+                    reset_hover(cx, item);
+                    item.text_or_image(cx, ids!(image)).clear(cx);
                 }
                 inner.last_populated_links = accepted_links;
                 inner.is_expanded = false;
@@ -440,17 +442,14 @@ where
         image_view.set_visible(cx, false);
         return true;
     };
-    image_view.set_visible(cx, true);
-    text_or_image.clear(cx);
     let mut image_info = ImageInfo::default();
     image_info.mimetype = data.image_type.clone();
     image_info.size = data.image_size;
     let source = MediaSource::Plain(OwnedMxcUri::from(image.clone()));
     let fully_drawn = populate_image_fn(cx, &text_or_image, Some(&image_info), source, "", media_cache);
-    // If there's no image, or it failed to drawn, hide the image area.
-    if fully_drawn && text_or_image.status().is_text() {
-        image_view.set_visible(cx, false);
-    }
+    // Only show the image area once there's an actual image in it. Anything else means
+    // it's still loading or couldn't be fetched, and an error message doesn't belong here.
+    image_view.set_visible(cx, text_or_image.status().is_image());
     fully_drawn
 }
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1364,12 +1364,14 @@ impl Widget for RoomScreen {
                             }
                         }
                         TimelineItemKind::Virtual(VirtualTimelineItem::DateDivider(millis)) => {
-                            let item = list.item(cx, item_id, id!(DateDivider));
-                            let text = unix_time_millis_to_datetime(*millis)
-                                // format the time as a shortened date (Sat, Sept 5, 2021)
-                                .map(|dt| format!("{}", dt.date_naive().format("%a %b %-d, %Y")))
-                                .unwrap_or_else(|| format!("{:?}", millis));
-                            item.label(cx, ids!(date)).set_text(cx, &text);
+                            let (item, existed) = list.item_with_existed(cx, item_id, id!(DateDivider));
+                            if !(existed && item_drawn_status.content_drawn) {
+                                let text = unix_time_millis_to_datetime(*millis)
+                                    // format the time as a shortened date (Sat, Sept 5, 2021)
+                                    .map(|dt| format!("{}", dt.date_naive().format("%a %b %-d, %Y")))
+                                    .unwrap_or_else(|| format!("{:?}", millis));
+                                item.label(cx, ids!(date)).set_text(cx, &text);
+                            }
                             (item, ItemDrawnStatus::both_drawn())
                         }
                         TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker) => {
@@ -2974,8 +2976,9 @@ impl RoomScreen {
                             receipt_type: ReceiptType::FullyRead,
                         });
                     } else {
-                        if let Some(own_user_receipt_timestamp) = &tl_state.latest_own_user_receipt.clone()
-                        .and_then(|receipt| receipt.ts) {
+                        if let Some(own_user_receipt_timestamp) = tl_state.latest_own_user_receipt
+                            .as_ref().and_then(|receipt| receipt.ts)
+                        {
                             let Some((_first_event_id, first_timestamp)) = tl_state
                                 .items
                                 .get(first_index)
@@ -2985,8 +2988,8 @@ impl RoomScreen {
                                     *index = first_index;
                                     return;
                                 };
-                            if own_user_receipt_timestamp >= &first_timestamp
-                                && own_user_receipt_timestamp <= &last_timestamp
+                            if own_user_receipt_timestamp >= first_timestamp
+                                && own_user_receipt_timestamp <= last_timestamp
                             {
                                 tl_state.scrolled_past_read_marker = true;
                                 submit_async_request(MatrixRequest::ReadReceipt {
@@ -3856,7 +3859,7 @@ fn populate_message_view(
                             image.source.clone(),
                             msg.body(),
                             media_cache,
-                            image.filename().to_owned(),
+                            image.filename(),
                             image.info.as_ref().and_then(|i| i.size).map(u64::from),
                             DownloadKind::Image,
                         );
@@ -4043,12 +4046,12 @@ fn populate_message_view(
 
             let text_or_image_ref = item.text_or_image(cx, ids!(content.message.image));
             let media_source: MediaSource = source.clone().into();
-            let filename = if body.is_empty() { "sticker".to_owned() } else { body.clone() };
+            let filename = if body.is_empty() { "sticker" } else { body.as_str() };
             let size = info.size.map(u64::from);
             download_info = if was_cached {
                 text_or_image_ref.status().is_text().then(|| DownloadableAttachment {
                     media_source,
-                    filename,
+                    filename: filename.to_owned(),
                     size,
                     kind: DownloadKind::Image,
                 })
@@ -4404,7 +4407,7 @@ fn populate_image_message_content_with_fallback(
     original_source: MediaSource,
     body: &str,
     media_cache: &mut MediaCache,
-    filename: String,
+    filename: &str,
     size: Option<u64>,
     kind: DownloadKind,
 ) -> (bool, Option<DownloadableAttachment>) {
@@ -4418,7 +4421,7 @@ fn populate_image_message_content_with_fallback(
     );
     let fallback = text_or_image_ref.status().is_text().then(|| DownloadableAttachment {
         media_source: original_source,
-        filename,
+        filename: filename.to_owned(),
         size,
         kind,
     });

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -1395,7 +1395,9 @@ impl Widget for RoomsList {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let app_state = scope.data.get_mut::<AppState>().unwrap();
         // Update the currently-selected room from the AppState data.
-        self.current_active_room = app_state.selected_room.clone();
+        if self.current_active_room != app_state.selected_room {
+            self.current_active_room = app_state.selected_room.clone();
+        }
 
         // Based on the various displayed room lists and is_expanded state of each room header,
         // calculate the indexes in the PortalList where the headers and rooms should be drawn.

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -365,7 +365,7 @@ impl RoomsListEntryContent {
     ) {
         // Note: in general, we must always set all fields in case a rooms list entry widget
         // was re-used by the portal list, to avoid showing any old content for a different entry.
-        self.view.label(cx, ids!(room_name)).set_text(cx, &room_info.room_name_id.to_string());
+        self.view.label(cx, ids!(room_name)).set_text(cx, &room_info.room_name_id.display());
         let timestamp = self.view.label(cx, ids!(timestamp));
         let latest_message = self.view.html_or_plaintext(cx, ids!(latest_message));
         if let Some((ts, msg)) = room_info.latest.as_ref() {
@@ -392,7 +392,7 @@ impl RoomsListEntryContent {
         cx: &mut Cx,
         room_info: &InvitedRoomInfo,
     ) {
-        self.view.label(cx, ids!(room_name)).set_text(cx, &room_info.room_name_id.to_string());
+        self.view.label(cx, ids!(room_name)).set_text(cx, &room_info.room_name_id.display());
         // Hide the timestamp field, and use the latest message field to show the inviter.
         self.view.label(cx, ids!(timestamp)).set_text(cx, "");
         let inviter_string = match &room_info.inviter_info {

--- a/src/home/rooms_list_header.rs
+++ b/src/home/rooms_list_header.rs
@@ -155,7 +155,7 @@ impl Widget for RoomsListHeader {
                     let header_title = self.view.label(cx, ids!(header_title));
                     match tab {
                         SelectedTab::Space { space_name_id } => {
-                            header_title.set_text(cx, &space_name_id.to_string());
+                            header_title.set_text(cx, &space_name_id.display());
                         }
                         _ => header_title.set_text(cx, "All Rooms"),
                     }

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -7,6 +7,7 @@
 //!
 
 use std::cell::RefCell;
+use std::fmt::Write as _;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use imbl::Vector;
 use makepad_widgets::*;
@@ -1319,45 +1320,40 @@ impl Widget for SpaceLobbyScreen {
                             // Build the info label with join status, member count, and topic
                             // Note: Public/Private is intentionally not shown per-item to reduce clutter
                             let info_label = item.child_by_path(ids!(main_entry.content.info_label)).as_label();
-                            let mut info_parts = Vec::new();
+                            let mut info_text = String::new();
 
                             // Add join status for rooms we haven't joined
                             if let Some(state) = &info.state {
-                                match state {
-                                    RoomState::Joined => info_parts.push("✅ Joined".to_string()),
-                                    RoomState::Left => info_parts.push("Left".to_string()),
-                                    RoomState::Invited => info_parts.push("Invited".to_string()),
-                                    RoomState::Knocked => info_parts.push("Knocked".to_string()),
-                                    RoomState::Banned => info_parts.push("Banned".to_string()),
-                                }
+                                info_text.push_str(match state {
+                                    RoomState::Joined => "✅ Joined",
+                                    RoomState::Left => "Left",
+                                    RoomState::Invited => "Invited",
+                                    RoomState::Knocked => "Knocked",
+                                    RoomState::Banned => "Banned",
+                                });
+                                info_text.push_str("  |  ");
                             }
 
                             // Add member count
-                            info_parts.push(format!(
+                            let _ = write!(
+                                info_text,
                                 "{} {}",
                                 info.num_joined_members,
-                                if info.num_joined_members == 1 { "member" } else { "members" }
-                            ));
+                                if info.num_joined_members == 1 { "member" } else { "members" },
+                            );
 
                             // Add children count for spaces
-                            if let Some(c) = info.children_count {
-                                if c > 0 {
-                                    info_parts.push(format!(
-                                        "~{} {}",
-                                        c,
-                                        if c == 1 { "room" } else { "rooms" }
-                                    ));
-                                }
+                            if let Some(c) = info.children_count.filter(|c| *c > 0) {
+                                let _ = write!(info_text, "  |  ~{} {}", c, if c == 1 { "room" } else { "rooms" });
                             }
 
                             // Add topic if available (Label handles truncation via flow: Flow.Right{wrap: false})
-                            if let Some(topic) = &info.topic {
-                                if !topic.is_empty() {
-                                    info_parts.push(topic.to_string());
-                                }
+                            if let Some(topic) = info.topic.as_deref().filter(|t| !t.is_empty()) {
+                                info_text.push_str("  |  ");
+                                info_text.push_str(topic);
                             }
 
-                            info_label.set_text(cx, &info_parts.join("  |  "));
+                            info_label.set_text(cx, &info_text);
 
                             item
                         }
@@ -1741,7 +1737,7 @@ impl SpaceLobbyScreen {
     }
 
     pub fn set_displayed_space(&mut self, cx: &mut Cx, space_name_id: &RoomNameId) {
-        let space_name = space_name_id.to_string();
+        let space_name = space_name_id.display();
         let parent_name = self.view.label(cx, ids!(header.parent_space_row.parent_name));
         parent_name.set_text(cx, &space_name);
 

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -213,7 +213,7 @@ impl SpacesBarEntry {
         avatar: &FetchedRoomAvatar,
         is_selected: bool,
     ) {
-        let space_name = space_name_id.to_string();
+        let space_name = space_name_id.display();
         // The name label isn't visible by default, but we populate it anyway.
         self.inner.view.label(cx, ids!(space_name)).set_text(cx, &space_name);
 
@@ -236,8 +236,8 @@ impl SpacesBarEntry {
             self.last_avatar = Some(avatar.clone());
         }
 
-        self.space_name_id = Some(space_name_id);
         self.inner.set_tooltip_text(space_name);
+        self.space_name_id = Some(space_name_id);
         self.inner.set_selected(cx, is_selected);
     }
 }

--- a/src/home/upload_progress.rs
+++ b/src/home/upload_progress.rs
@@ -133,8 +133,9 @@ impl Widget for UploadProgressView {
 
             // Handle retry button
             if self.button(cx, ids!(retry_button)).clicked(actions) {
-                if let UploadViewState::Error { upload: Some(upload) } = &self.state {
-                    let upload = upload.clone();
+                if let UploadViewState::Error { upload } = &mut self.state
+                    && let Some(upload) = upload.take()
+                {
                     self.hide_current(cx);
                     submit_attachment_upload(upload);
                 }

--- a/src/media_cache.rs
+++ b/src/media_cache.rs
@@ -80,8 +80,6 @@ impl MediaCache {
     ///   this function will fetch the thumbnail, and return the full-size image (if it exists).
     /// * If the `media_format` is requesting a full-size image that is not yet in the cache,
     ///   this function will fetch the full-size image, and return a thumbnail (if it exists).
-    /// * If a previously-requested thumbnail failed, this function falls back to fetching
-    ///   the full-size image, since some homeservers only serve pre-generated thumbnails.
     ///
     /// Returns a tuple of the media cache entry and the media format of that cached entry.
     pub fn try_get_media_or_fetch(
@@ -92,8 +90,6 @@ impl MediaCache {
         let mxc_uri = media_source_mxc(source);
         let mut post_request_retval = (MediaCacheEntry::Requested, requested_format.clone());
         let entry_ref_to_fetch: MediaCacheEntryRef;
-        // Differs from `requested_format` when we fall back to the full-size image.
-        let mut format_to_fetch = requested_format.clone();
 
         let entry = self.cache.raw_entry_mut().from_key(mxc_uri);
 
@@ -102,25 +98,11 @@ impl MediaCache {
                 let value = occupied.get_mut();
                 match requested_format {
                     MediaFormat::Thumbnail(ref requested_mts) => {
-                        let cached_thumbnail = value.thumbnail.as_ref().map(|(entry_ref, mts)| {
-                            (entry_ref.lock().unwrap().deref().clone(), mts.clone())
-                        });
-                        if let Some((thumbnail, existing_mts)) = cached_thumbnail {
-                            let MediaCacheEntry::Failed(_) = thumbnail else {
-                                return (thumbnail, MediaFormat::Thumbnail(existing_mts));
-                            };
-                            // The thumbnail failed, so use the full-size image instead.
-                            if let Some(existing_file) = value.full_file.as_ref() {
-                                return (
-                                    existing_file.lock().unwrap().deref().clone(),
-                                    MediaFormat::File,
-                                );
-                            }
-                            let entry_ref = Arc::new(Mutex::new(MediaCacheEntry::Requested));
-                            value.full_file = Some(Arc::clone(&entry_ref));
-                            entry_ref_to_fetch = entry_ref;
-                            format_to_fetch = MediaFormat::File;
-                            post_request_retval = (MediaCacheEntry::Requested, MediaFormat::File);
+                        if let Some((entry_ref, existing_mts)) = value.thumbnail.as_ref() {
+                            return (
+                                entry_ref.lock().unwrap().deref().clone(),
+                                MediaFormat::Thumbnail(existing_mts.clone()),
+                            );
                         } else {
                             // Here, a thumbnail was requested but not found, so fetch it.
                             let entry_ref = Arc::new(Mutex::new(MediaCacheEntry::Requested));
@@ -181,7 +163,7 @@ impl MediaCache {
         sliding_sync::submit_async_request(MatrixRequest::FetchMedia {
             media_request: MediaRequestParameters {
                 source: source.clone(),
-                format: format_to_fetch,
+                format: requested_format,
             },
             on_fetched: insert_into_cache,
             destination: entry_ref_to_fetch,

--- a/src/shared/avatar.rs
+++ b/src/shared/avatar.rs
@@ -113,17 +113,16 @@ impl Widget for Avatar {
             }
         }
 
-        let Some(info) = self.info.clone() else { return };
+        let Some(info) = self.info.as_ref() else { return };
         let area = self.view.area();
-        let widget_uid = self.widget_uid();
         match event.hits(cx, area) {
             Hit::FingerDown(_fde) => {
                 cx.set_key_focus(area);
             }
             Hit::FingerUp(fue) if fue.is_over && fue.is_primary_hit() && fue.was_tap() => {
                 cx.widget_action(
-                    widget_uid,
-                    ShowUserProfileAction::ShowUserProfile(info),
+                    self.widget_uid(),
+                    ShowUserProfileAction::ShowUserProfile(info.clone()),
                 );
             }
             _ =>()

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2693,16 +2693,17 @@ impl RoomListServiceRoomInfo {
         fetch_power_levels: bool,
     ) -> Self {
         // Parallelize fetching of independent room data.
+        // Only joined rooms actually use tags and power levels.
         let (is_direct, tags, display_name, user_power_levels) = tokio::join!(
             room.is_direct(),
-            room.tags(),
+            async {
+                if room.state() == RoomState::Joined { room.tags().await } else { Ok(None) }
+            },
             room.display_name(),
             async {
-                if fetch_power_levels && let Some(user_id) = current_user_id {
-                    UserPowerLevels::from_room(&room, user_id.deref()).await
-                } else {
-                    None
-                }
+                if !fetch_power_levels || room.state() != RoomState::Joined { return None; }
+                let Some(user_id) = current_user_id else { return None; };
+                UserPowerLevels::from_room(&room, user_id.deref()).await
             }
         );
 
@@ -4170,14 +4171,16 @@ async fn get_latest_event_details(
 ) -> Option<(MilliSecondsSinceUnixEpoch, String)> {
     macro_rules! get_sender_username {
         ($profile:expr, $sender:expr, $is_own:expr) => {{
-            let sender_username_opt = if let TimelineDetails::Ready(profile) = $profile {
-                profile.display_name.clone()
-            } else if $is_own {
-                own_display_name(client).await
-            } else {
-                None
-            };
-            sender_username_opt.unwrap_or_else(|| $sender.to_string())
+            match $profile {
+                TimelineDetails::Ready(profile) => match profile.display_name.as_deref() {
+                    Some(name) => Cow::Borrowed(name),
+                    None => Cow::Borrowed($sender.as_str()),
+                },
+                _ => match if $is_own { own_display_name(client).await } else { None } {
+                    Some(name) => Cow::Owned(name),
+                    None => Cow::Borrowed($sender.as_str()),
+                },
+            }
         }};
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,10 @@ pub const GEO_URI_SCHEME: &str = "geo:";
 
 /// Formats a byte count using decimal units with user-facing byte suffixes, e.g. KB/MB/GB.
 pub fn format_decimal_file_size(bytes: u64) -> String {
-    bytesize::ByteSize::b(bytes).display().si().to_string().to_uppercase()
+    let mut size = bytesize::ByteSize::b(bytes).display().si().to_string();
+    // SI suffixes are always ASCII
+    size.make_ascii_uppercase();
+    size
 }
 
 pub fn deserialize_or_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
@@ -737,6 +740,7 @@ pub fn linkify_get_urls<'t>(
     const MAILTO: &str = "mailto:";
 
     use linkify::{Link, LinkFinder, LinkKind};
+    use std::fmt::Write as _;
     let mut links = LinkFinder::new()
         .links(text)
         .peekable();
@@ -753,8 +757,9 @@ pub fn linkify_get_urls<'t>(
         }
     };
 
-    let mut linkified_text = String::new();
+    let mut linkified_text = String::with_capacity(text.len() + 64);
     let mut last_end_index = 0;
+    let mut did_linkify = false;
     for link in links {
         let link_txt = link.as_str();
 
@@ -779,10 +784,7 @@ pub fn linkify_get_urls<'t>(
             || is_link_within_html_tag(&link)
             || is_mailto_link_within_href_attr(&link)
         {
-            linkified_text = format!(
-                "{linkified_text}{}",
-                text.get(last_end_index..link.end()).unwrap_or_default(),
-            );
+            linkified_text.push_str(text.get(last_end_index..link.end()).unwrap_or_default());
             if let Some(links_found) = links_found.as_mut() {
                 if let Ok(url) = Url::parse(link_txt) {
                     links_found.push(url);
@@ -791,12 +793,14 @@ pub fn linkify_get_urls<'t>(
         } else {
             match link.kind() {
                 LinkKind::Url => {
-                    linkified_text = format!(
-                        "{linkified_text}{}<a href=\"{}\">{}</a>",
+                    let _ = write!(
+                        linkified_text,
+                        "{}<a href=\"{}\">{}</a>",
                         escaped(text.get(last_end_index..link.start()).unwrap_or_default()),
                         htmlize::escape_attribute(link_txt),
                         htmlize::escape_text(link_txt),
                     );
+                    did_linkify = true;
                     if let Some(links_found) = links_found.as_mut() {
                         if let Ok(url) = Url::parse(link_txt) {
                             links_found.push(url);
@@ -804,17 +808,22 @@ pub fn linkify_get_urls<'t>(
                     }
                 }
                 LinkKind::Email => {
-                    linkified_text = format!(
-                        "{linkified_text}{}<a href=\"mailto:{}\">{}</a>",
+                    let _ = write!(
+                        linkified_text,
+                        "{}<a href=\"mailto:{}\">{}</a>",
                         escaped(text.get(last_end_index..link.start()).unwrap_or_default()),
                         htmlize::escape_attribute(link_txt),
                         htmlize::escape_text(link_txt),
                     );
+                    did_linkify = true;
                 }
                 _ => return Cow::Borrowed(text), // unreachable
             }
         }
         last_end_index = link.end();
+    }
+    if !did_linkify && is_html {
+        return Cow::Borrowed(text);
     }
     linkified_text.push_str(
         &escaped(text.get(last_end_index..).unwrap_or_default())
@@ -1032,6 +1041,17 @@ impl RoomNameId {
             room.display_name().await.unwrap_or(RoomDisplayName::Empty),
             room.room_id().to_owned(),
         )
+    }
+
+    /// Returns an efficient displayable/string representation.
+    pub fn display(&self) -> Cow<'_, str> {
+        match &self.display_name {
+            RoomDisplayName::Named(n)
+            | RoomDisplayName::Aliased(n)
+            | RoomDisplayName::Calculated(n) => Cow::Borrowed(n),
+            RoomDisplayName::Empty => Cow::Owned(format!("Room ID {}", self.room_id)),
+            RoomDisplayName::EmptyWas(name) => Cow::Owned(format!("Empty Room (was \"{name}\")")),
+        }
     }
 
     /// Get a reference to the underlying display name.


### PR DESCRIPTION
* Avoid RoomNameId to_string calls via new `display()` method
* Don't recreate widget state in draw walk fns, e.g., rooms list, space lobby
* Only fetch room tags and power levels for joined rooms; other rooms don't use it
* Repo-wide audit for unnecessary allocs/clones/etc, just borrow instead