### PR TITLE
Fix link preview image fit; decouple image viewer from room media cache

### DIFF
--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -148,6 +148,12 @@ script_mod! {
                 image := TextOrImage {
                     width: 120, height: Fill,
                     align: Align{ y: 0.5 }
+                    image_view +: {
+                        height: Fill,
+                        flow: Down,
+                        align: Align{ x: 0.5, y: 0.5 }
+                        image +: { height: Fill }
+                    }
                 }
             }
 

--- a/src/home/room_image_viewer.rs
+++ b/src/home/room_image_viewer.rs
@@ -1,45 +1,30 @@
+use std::sync::{Arc, Mutex};
+
 use makepad_widgets::*;
 use matrix_sdk_ui::timeline::EventTimelineItem;
 use matrix_sdk::{
-    media::MediaFormat,
+    media::{MediaFormat, MediaRequestParameters},
     ruma::events::room::{message::MessageType, MediaSource},
 };
 use matrix_sdk::reqwest::StatusCode;
 
-use crate::{media_cache::{MediaCache, MediaCacheEntry}, shared::{attachment_download::media_source_mxc, image_viewer::{ImageViewerAction, ImageViewerError, LoadState}}};
+use crate::{home::room_screen::TimelineUpdate, media_cache::{error_to_media_cache_entry, MediaCacheEntry}, shared::image_viewer::ImageViewerError, sliding_sync::{submit_async_request, MatrixRequest}};
 
-/// Populates the image viewer modal with the given media content.
+/// Fetches the full-size image for the image viewer.
 ///
-/// * If the media is already cached, it will be immediately displayed.
-/// * If the media is not cached, it will be fetched from the server.
-/// * If the media fetch fails, an error message will be displayed.
-pub fn populate_matrix_image_modal(
-    cx: &mut Cx,
-    media_source: MediaSource,
-    media_cache: &mut MediaCache,
-) {
-    // Try to get media from cache or trigger fetch
-    let media_entry = media_cache.try_get_media_or_fetch(&media_source, MediaFormat::File);
-
-    // Handle the different media states
-    match media_entry {
-        (MediaCacheEntry::Loaded(data), MediaFormat::File) => {
-            cx.action(ImageViewerAction::Show(LoadState::Loaded(data)));
-        }
-        (MediaCacheEntry::Failed(status_code), MediaFormat::File) => {
-            let error = match status_code {
-                StatusCode::NOT_FOUND => ImageViewerError::NotFound,
-                StatusCode::INTERNAL_SERVER_ERROR => ImageViewerError::ConnectionFailed,
-                StatusCode::PARTIAL_CONTENT => ImageViewerError::BadData,
-                StatusCode::UNAUTHORIZED => ImageViewerError::Unauthorized,
-                _ => ImageViewerError::Unknown,
-            };
-            cx.action(ImageViewerAction::Show(LoadState::Error(error)));
-            // Remove failed media entry from cache for MediaFormat::File so as to start all over again from loading Thumbnail.
-            media_cache.remove_cache_entry(media_source_mxc(&media_source), Some(MediaFormat::File));
-        }
-        _ => {}
-    }
+/// The image viewer is already showing a thumbnail, so this returns nothing.
+/// [`show_fetched_image_in_viewer`] will be called when the full image arrives.
+pub fn fetch_full_image_for_viewer(media_source: MediaSource) {
+    submit_async_request(MatrixRequest::FetchMedia {
+        media_request: MediaRequestParameters {
+            source: media_source,
+            format: MediaFormat::File,
+        },
+        on_fetched: show_fetched_image_in_viewer,
+        // this isn't used
+        destination: Arc::new(Mutex::new(MediaCacheEntry::Requested)),
+        update_sender: None,
+    });
 }
 
 /// Gets the image's file name and size in bytes from an event timeline item.
@@ -54,4 +39,32 @@ pub fn get_image_name_and_filesize(event_tl_item: &EventTimelineItem) -> (String
         }
     }
     ("Unknown Image".to_string(), 0)
+}
+
+/// The result of the image viewer's request to fetch a full-size image.
+#[derive(Clone, Debug)]
+pub enum ImageViewerFetchAction {
+    Loaded(Arc<[u8]>),
+    Failed(ImageViewerError),
+}
+
+fn show_fetched_image_in_viewer(
+    _destination: &Mutex<MediaCacheEntry>,
+    request: MediaRequestParameters,
+    data: matrix_sdk::Result<Vec<u8>>,
+    _update_sender: Option<crossbeam_channel::Sender<TimelineUpdate>>,
+) {
+    let action = match data {
+        Ok(data) => ImageViewerFetchAction::Loaded(data.into()),
+        Err(e) => ImageViewerFetchAction::Failed(
+            match error_to_media_cache_entry(e, &request) {
+                MediaCacheEntry::Failed(StatusCode::NOT_FOUND) => ImageViewerError::NotFound,
+                MediaCacheEntry::Failed(StatusCode::INTERNAL_SERVER_ERROR) => ImageViewerError::ConnectionFailed,
+                MediaCacheEntry::Failed(StatusCode::PARTIAL_CONTENT) => ImageViewerError::BadData,
+                MediaCacheEntry::Failed(StatusCode::UNAUTHORIZED) => ImageViewerError::Unauthorized,
+                _ => ImageViewerError::Unknown,
+            }
+        ),
+    };
+    Cx::post_action(action);
 }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -6,6 +6,7 @@ use std::{borrow::Cow, cell::RefCell, ops::{DerefMut, Range}, sync::Arc};
 use hashbrown::{HashMap, HashSet};
 use imbl::Vector;
 use makepad_widgets::{image_cache::ImageBuffer, *};
+use matrix_sdk::reqwest::StatusCode;
 use matrix_sdk::{
     OwnedServerName, media::{MediaFormat, MediaRequestParameters}, room::RoomMember, ruma::{
         EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedMxcUri, OwnedRoomId, UserId, events::{
@@ -26,7 +27,7 @@ use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, e
 
 use matrix_sdk_ui::sync_service::State;
 use crate::{
-    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{get_image_name_and_filesize, populate_matrix_image_modal}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
         user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     },
@@ -1788,12 +1789,8 @@ impl RoomScreen {
                     self.view.room_input_bar(cx, ids!(room_input_bar))
                         .set_room_context(cx, ui, tl.kind.clone(), tl.room_members.clone());
                 },
-                TimelineUpdate::MediaFetched(request) => {
+                TimelineUpdate::MediaFetched(_request) => {
                     log!("process_timeline_updates(): media fetched for room {}", tl.kind.room_id());
-                    // Set Image to image viewer modal if the media is not a thumbnail.
-                    if let (MediaFormat::File, media_source) = (request.format, request.source) {
-                        populate_matrix_image_modal(cx, media_source, &mut tl.media_cache);
-                    }
                     // Here, to be most efficient, we could redraw only the media items in the timeline,
                     // but for now we just fall through and let the final `redraw()` call re-draw the whole timeline view.
                 }
@@ -2055,7 +2052,7 @@ impl RoomScreen {
         let Some(media_source) = mxc_uri else {
             return;
         };
-        let Some(tl_state) = self.tl_state.as_mut() else { return };
+        let Some(tl_state) = self.tl_state.as_ref() else { return };
         let Some(event_tl_item) = tl_state.items.get(item_id).and_then(|item| item.as_event()) else { return };
 
         let timestamp_millis = event_tl_item.timestamp();
@@ -2080,7 +2077,7 @@ impl RoomScreen {
             }),
         )));
 
-        populate_matrix_image_modal(cx, media_source, &mut tl_state.media_cache);
+        fetch_full_image_for_viewer(media_source);
     }
 
     /// Looks up the event specified by the given message details in the given timeline.
@@ -4461,6 +4458,12 @@ fn populate_image_message_content(
 
     let mut fully_drawn = false;
 
+    // Fall back to fetching the full-size image instead of a failed thumbnail if it's not too big.
+    const MAX_FULL_IMAGE_SIZE: u64 = 1024 * 1024; // 1MiB
+    let should_fetch_full_size = image_info_source
+        .and_then(|info| info.size)
+        .is_none_or(|size| u64::from(size) <= MAX_FULL_IMAGE_SIZE);
+
     let mut fetch_and_show_media_source = |cx: &mut Cx, media_source: MediaSource, image_info: &ImageInfo| {
         match media_cache.try_get_media_or_fetch(&media_source, MEDIA_THUMBNAIL_FORMAT.into()) {
             (MediaCacheEntry::Loaded(data), media_format) => {
@@ -4526,6 +4529,25 @@ fn populate_image_message_content(
                     }
                 }
                 fully_drawn = false;
+            }
+            (MediaCacheEntry::Failed(status_code), MediaFormat::Thumbnail(_))
+                if should_fetch_full_size && status_code != StatusCode::NOT_FOUND =>
+            {
+                match media_cache.try_get_media_or_fetch(&media_source, MediaFormat::File) {
+                    (MediaCacheEntry::Loaded(data), _) => {
+                        let cache_key = format!("{}#full", media_source_mxc(&media_source));
+                        let res = text_or_image_ref.show_image(cx, Some(media_source.clone()), |cx, img| {
+                            utils::load_image_with_cache_key(&img, cx, std::path::Path::new(&cache_key), Arc::clone(&data))
+                                .map(|()| img.size_in_pixels(cx).unwrap_or_default())
+                        });
+                        if let Err(e) = res {
+                            error!("Failed to display full-size image: {e:?}");
+                        }
+                        fully_drawn = true;
+                    }
+                    (MediaCacheEntry::Requested, _) => fully_drawn = false,
+                    (MediaCacheEntry::Failed(_), _) => fully_drawn = true,
+                }
             }
             (MediaCacheEntry::Failed(_status_code), _media_format) => {
                 text_or_image_ref.show_text(

--- a/src/media_cache.rs
+++ b/src/media_cache.rs
@@ -203,7 +203,7 @@ pub(crate) fn error_to_media_cache_entry(error: Error, request: &MediaRequestPar
     match error {
         Error::Http(http_error) => {
             if let Some(client_error) = http_error.as_client_api_error() {
-                error!("Erro {client_error} for request: {:?}", request);
+                error!("Error {client_error} for request: {:?}", request);
                 MediaCacheEntry::Failed(client_error.status_code)
             } else {
                 match *http_error {

--- a/src/media_cache.rs
+++ b/src/media_cache.rs
@@ -196,54 +196,14 @@ impl MediaCache {
         });
     }
 
-    /// Removes a specific media format from the cache for the given MXC URI.
-    /// If `format` is None, removes the entire cache entry for the URI.
-    /// Returns the removed cache entry if found, None otherwise.
-    pub fn remove_cache_entry(&mut self, mxc_uri: &OwnedMxcUri, format: Option<MediaFormat>) -> Option<MediaCacheEntryRef> {
-        match format {
-            Some(MediaFormat::Thumbnail(_)) => {
-                if let Some(cache_value) = self.cache.get_mut(mxc_uri) {
-                    if let Some((removed_entry, _)) = cache_value.thumbnail.take() {
-                        // If both thumbnail and full_file are None, remove the entire entry
-                        if cache_value.full_file.is_none() {
-                            self.cache.remove(mxc_uri);
-                        }
-                        return Some(removed_entry);
-                    }
-                }
-                None
-            }
-            Some(MediaFormat::File) => {
-                if let Some(cache_value) = self.cache.get_mut(mxc_uri) {
-                    if let Some(removed_entry) = cache_value.full_file.take() {
-                        // If both thumbnail and full_file are None, remove the entire entry
-                        if cache_value.thumbnail.is_none() {
-                            self.cache.remove(mxc_uri);
-                        }
-                        return Some(removed_entry);
-                    }
-                }
-                None
-            }
-            None => {
-                // Remove the entire entry for this MXC URI
-                self.cache.remove(mxc_uri).map(|cache_value| {
-                    // Return the full_file entry if it exists, otherwise the thumbnail entry
-                    cache_value.full_file
-                        .or_else(|| cache_value.thumbnail.map(|(entry, _)| entry))
-                        .unwrap_or_else(|| Arc::new(Mutex::new(MediaCacheEntry::Requested)))
-                })
-            }
-        }
-    }
 }
 
 /// Converts a Matrix SDK error to a MediaCacheEntry::Failed with appropriate status codes.
-fn error_to_media_cache_entry(error: Error, request: &MediaRequestParameters) -> MediaCacheEntry {
+pub(crate) fn error_to_media_cache_entry(error: Error, request: &MediaRequestParameters) -> MediaCacheEntry {
     match error {
         Error::Http(http_error) => {
             if let Some(client_error) = http_error.as_client_api_error() {
-                error!("Client error for media cache: {client_error} for request: {:?}", request);
+                error!("Erro {client_error} for request: {:?}", request);
                 MediaCacheEntry::Failed(client_error.status_code)
             } else {
                 match *http_error {

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -12,6 +12,8 @@ use makepad_widgets::{
 };
 use matrix_sdk_ui::timeline::EventTimelineItem;
 
+use crate::home::room_image_viewer::ImageViewerFetchAction;
+
 use crate::utils::format_decimal_file_size;
 use thiserror::Error;
 use crate::{
@@ -765,6 +767,15 @@ impl MatchEvent for ImageViewer {
         }
 
         for action in actions.iter() {
+            match action.downcast_ref() {
+                Some(ImageViewerFetchAction::Loaded(bytes)) => {
+                    cx.action(ImageViewerAction::Show(LoadState::Loaded(bytes.clone())));
+                }
+                Some(ImageViewerFetchAction::Failed(error)) => {
+                    cx.action(ImageViewerAction::Show(LoadState::Error(error.clone())));
+                }
+                None => {}
+            }
             if let Some(ImageViewerAction::Show(state)) = action.downcast_ref() {
                 match state {
                     LoadState::Loading(texture, metadata) => {


### PR DESCRIPTION
* The ImageViewer now directly handles fetching the full-size image instead of trying to route it through the room screen. So we basically rely on the matrix SDK's cache instead of our own.
* Make a bit more effort to obtain a full-size image (esp for link previews) if the thumbnail isn't available on the homeserver.
* Make sure link preview images are centered and fit within the image box