### PR TITLE
packaging: fix wrong macOS bundle version, app label, asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,9 @@ jobs:
           ## TODO: flip to true once this has passed on all four Linux legs.
           ## Until then it reports problems without blocking releases.
           verify_strict: false
+          ## Nothing in Robrix consumes updater metadata, and .deb has no updater
+          ## format mapping anyway, so latest.json would ship empty and misleading.
+          uploadUpdaterJson: false
 
   for_macos:
     name: Release Robrix for macOS (${{ matrix.os }}, ${{ matrix.arch }})
@@ -378,6 +381,7 @@ jobs:
           github_token: ${{ secrets.ROBRIX_RELEASE }}
           packager_formats: nsis
           releaseId: ${{ needs.create_release.outputs.release_id }}
+          uploadUpdaterJson: false
 
   for_android:
     name: Release Robrix for Android (aarch64)
@@ -404,7 +408,9 @@ jobs:
         with:
           github_token: ${{ secrets.ROBRIX_RELEASE }}
           args: --target aarch64-linux-android
+          app_name: Robrix
           releaseId: ${{ needs.create_release.outputs.release_id }}
+          uploadUpdaterJson: false
 
   for_ios:
     name: Release Robrix for iOS

--- a/packaging/build-ios-testflight.sh
+++ b/packaging/build-ios-testflight.sh
@@ -93,10 +93,12 @@ set_or_add UILaunchScreen:UIImageName string AppIcon60x60
 set_or_add UILaunchScreen:UIColorName string LaunchScreenBackground
 set_or_add ITSAppUsesNonExemptEncryption bool false
 
-VERSION=$(cargo metadata --no-deps --format-version 1 \
-  | jq -r '.packages[] | select(.name=="robrix") | .version' \
-  | sed 's/-.*$//')
-echo "Version $VERSION (build $BUILD_NUMBER)"
+FULL_VERSION=$(cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name=="robrix") | .version')
+# App Store Connect rejects semver pre-release suffixes, so the bundle carries the
+# numeric part only. The asset name keeps the full version to match the other builds.
+VERSION="${FULL_VERSION%%-*}"
+echo "Version $VERSION (from $FULL_VERSION, build $BUILD_NUMBER)"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$PLIST"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$PLIST"
 
@@ -118,7 +120,7 @@ codesign -d --entitlements - "$APP_BUNDLE"
 # ---- 7. Package .ipa ----
 BUILD_DIR="$REPO_ROOT/target/apple/makepad-apple-app/aarch64-apple-ios/release"
 cd "$BUILD_DIR"
-IPA_NAME="Robrix-${VERSION}-ios.ipa"
+IPA_NAME="robrix-${FULL_VERSION}-ios-aarch64-release.ipa"
 rm -rf Payload "$IPA_NAME"
 ditto "${APP}.app" "Payload/${APP}.app"
 ditto -c -k --sequesterRsrc --keepParent Payload "$IPA_NAME"

--- a/packaging/build-macos-dmg.sh
+++ b/packaging/build-macos-dmg.sh
@@ -163,7 +163,16 @@ rm -rf "$PROJECT_DIR/dist/Robrix.app" \
 # way to find notarization credentials. Result: unsigned .app + DMG.
 
 sed -i.bak 's/^signing_identity[[:space:]]*=/#&/' "$CARGO_TOML"
-trap 'mv "$CARGO_TOML.bak" "$CARGO_TOML" 2>/dev/null && echo "Restored Cargo.toml"' EXIT
+
+# cargo-packager copies our custom Info.plist verbatim, so the version keys in it
+# would otherwise stay frozen at whatever was committed. Stamp them from Cargo.toml.
+INFO_PLIST="$PROJECT_DIR/packaging/Info.plist"
+cp "$INFO_PLIST" "$INFO_PLIST.bak"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $PRODUCT_VERSION" "$INFO_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $(date +%Y%m%d.%H%M)" "$INFO_PLIST"
+echo "==> Info.plist version set to $PRODUCT_VERSION (build $(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST"))"
+
+trap 'mv "$CARGO_TOML.bak" "$CARGO_TOML" 2>/dev/null && echo "Restored Cargo.toml"; mv "$INFO_PLIST.bak" "$INFO_PLIST" 2>/dev/null && echo "Restored Info.plist"' EXIT
 
 TS_MARKER=$(mktemp)
 


### PR DESCRIPTION
and don't upload cargo packager's `latest.json`, we don't use it