### PR TITLE
refactor context menus into one shared widget, increase size a bit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::{
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states, invalidate_timeline_state}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
     }, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
-    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, TimelineKind, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
+    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, context_menu::menu_position_margin, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, TimelineKind, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
         VerificationModalAction,
         VerificationModalWidgetRefExt,
     }
@@ -320,14 +320,7 @@ impl MatchEvent for App {
                 // Use the overlay container's rect (not the window's) to correctly position
                 // the context menu relative to the body area, which excludes the caption bar.
                 let rect = self.ui.view(cx, ids!(overlay_container)).area().rect(cx);
-                let pos_x = min(abs_pos.x - rect.pos.x, rect.size.x - expected_dimensions.x);
-                let pos_y = min(abs_pos.y - rect.pos.y, rect.size.y - expected_dimensions.y);
-                let margin = Inset {
-                    left: pos_x as f64,
-                    top: pos_y as f64,
-                    right: 0.0,
-                    bottom: 0.0,
-                };
+                let margin = menu_position_margin(rect, abs_pos, expected_dimensions);
                 let mut main_content_view = new_message_context_menu.view(cx, ids!(main_content));
                 script_apply_eval!(cx, main_content_view, {
                     margin: #(margin)
@@ -344,14 +337,7 @@ impl MatchEvent for App {
                 // Use the overlay container's rect (not the window's) to correctly position
                 // the context menu relative to the body area, which excludes the caption bar.
                 let rect = self.ui.view(cx, ids!(overlay_container)).area().rect(cx);
-                let pos_x = min(pos.x - rect.pos.x, rect.size.x - expected_dimensions.x);
-                let pos_y = min(pos.y - rect.pos.y, rect.size.y - expected_dimensions.y);
-                let margin = Inset {
-                    left: pos_x as f64,
-                    top: pos_y as f64,
-                    right: 0.0,
-                    bottom: 0.0,
-                };
+                let margin = menu_position_margin(rect, pos, expected_dimensions);
                 let mut main_content_view = room_context_menu.view(cx, ids!(main_content));
                 script_apply_eval!(cx, main_content_view, {
                     margin: #(margin)

--- a/src/home/new_message_context_menu.rs
+++ b/src/home/new_message_context_menu.rs
@@ -6,7 +6,7 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedEventId;
 use matrix_sdk_ui::timeline::{EventTimelineItem, MsgLikeContent, TimelineEventItemId};
 
-use crate::{shared::context_menu::{BUTTON_HEIGHT, expected_menu_size}, sliding_sync::UserPowerLevels};
+use crate::{shared::context_menu::{BUTTON_HEIGHT, ContextMenuClosed, expected_menu_size}, sliding_sync::UserPowerLevels};
 
 use super::room_screen::MessageAction;
 
@@ -556,6 +556,7 @@ impl NewMessageContextMenu {
         self.details = None;
         cx.revert_key_focus();
         cx.unblock_scrolling();
+        cx.action(ContextMenuClosed);
         self.redraw(cx);
     }
 }

--- a/src/home/new_message_context_menu.rs
+++ b/src/home/new_message_context_menu.rs
@@ -6,31 +6,13 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedEventId;
 use matrix_sdk_ui::timeline::{EventTimelineItem, MsgLikeContent, TimelineEventItemId};
 
-use crate::sliding_sync::UserPowerLevels;
+use crate::{shared::context_menu::{BUTTON_HEIGHT, expected_menu_size}, sliding_sync::UserPowerLevels};
 
 use super::room_screen::MessageAction;
-
-const BUTTON_HEIGHT: f64 = 35.0; // KEEP IN SYNC WITH BUTTON_HEIGHT BELOW
-const MENU_WIDTH: f64 = 215.0;   // KEEP IN SYNC WITH MENU_WIDTH BELOW
 
 script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
-
-
-    mod.widgets.NEW_MESSAGE_CONTEXT_MENU_BUTTON_HEIGHT = 35  // KEEP IN SYNC WITH BUTTON_HEIGHT ABOVE
-    mod.widgets.NEW_MESSAGE_CONTEXT_MENU_WIDTH = 215    // KEEP IN SYNC WITH MENU_WIDTH ABOVE
-
-    mod.widgets.NewMessageContextMenuButton = RobrixIconButton {
-        height: (mod.widgets.NEW_MESSAGE_CONTEXT_MENU_BUTTON_HEIGHT)
-        width: Fill,
-        margin: 0,
-        icon_walk: Walk{width: 16, height: 16, margin: Inset{right: 3}}
-        // Override the blue default back to neutral for context menu items
-        draw_bg +: { color: (COLOR_PRIMARY), color_hover: #EBEBEB, color_down: #DCDCDC }
-        draw_icon.color: #000
-        draw_text +: { color: #000, color_hover: #000, color_down: #000 }
-    }
 
     mod.widgets.NewMessageContextMenu = set_type_default() do #(NewMessageContextMenu::register_widget(vm)) {
         ..mod.widgets.SolidView
@@ -50,36 +32,21 @@ script_mod! {
             color: #0000004D
         }
 
-        main_content := RoundedView {
-            flow: Down
-            width: (mod.widgets.NEW_MESSAGE_CONTEXT_MENU_WIDTH),
-            height: Fit,
-            padding: 10
-            spacing: 0,
-            align: Align{x: 0, y: 0}
-
-            show_bg: true
-            draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 5.0
-                border_size: 0.5
-                border_color: #888
-            }
-
+        main_content := mod.widgets.ContextMenuContent {
             // Shows either the "Add Reaction" button or a reaction text input.
             react_view := View {
                 flow: Overlay
-                height: (mod.widgets.NEW_MESSAGE_CONTEXT_MENU_BUTTON_HEIGHT)
+                height: #(BUTTON_HEIGHT)
                 align: Align{y: 0.5}
 
-                react_button := mod.widgets.NewMessageContextMenuButton {
+                react_button := mod.widgets.ContextMenuButton {
                     draw_icon +: { svg: (ICON_ADD_REACTION) }
                     text: "Add Reaction"
                 }
 
                 reaction_input_view := View {
                     width: Fill,
-                    height: (mod.widgets.NEW_MESSAGE_CONTEXT_MENU_BUTTON_HEIGHT)
+                    height: #(BUTTON_HEIGHT)
                     align: Align{y: 0.5}
                     flow: Right,
                     visible: false, // will be shown once the react_button is clicked
@@ -100,7 +67,7 @@ script_mod! {
                         empty_text: "Enter reaction..."
                     }
                     reaction_send_button := RobrixPositiveIconButton {
-                        height: (mod.widgets.NEW_MESSAGE_CONTEXT_MENU_BUTTON_HEIGHT)
+                        height: #(BUTTON_HEIGHT)
                         align: Align{x: 0.5, y: 0.5}
                         padding: Inset{left: 10, right: 10, top: 8, bottom: 8}
                         spacing: 0,
@@ -110,82 +77,64 @@ script_mod! {
                 }
             }
 
-            reply_button := mod.widgets.NewMessageContextMenuButton {
+            reply_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_REPLY) }
-                icon_walk +: { margin: Inset{top: 1, right: 3}}
+                icon_walk +: { margin: Inset{top: 1} }
                 text: "Reply"
             }
 
-            reply_in_thread_button := mod.widgets.NewMessageContextMenuButton {
+            reply_in_thread_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_REPLY_IN_THREAD) }
-                icon_walk +: { margin: Inset{top: 1, right: 3}}
+                icon_walk +: { margin: Inset{top: 1} }
                 text: "Reply In Thread"
             }
 
-            divider_after_react_reply := LineH {
-                margin: Inset{top: 3, bottom: 3}
-                width: Fill,
-            }
+            divider_after_react_reply := mod.widgets.ContextMenuDivider { }
 
-            edit_message_button := mod.widgets.NewMessageContextMenuButton {
+            edit_message_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_EDIT) }
-                icon_walk +: { margin: Inset{top: -3, right: 3} }
+                icon_walk +: { margin: Inset{top: -3} }
                 text: "Edit Message"
             }
 
             // TODO: check if the current user is allowed to pin/unpin messages:
             //       <https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk_base/struct.RoomMember.html#method.can_pin_or_unpin_event>
-            pin_button := mod.widgets.NewMessageContextMenuButton {
+            pin_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_PIN) }
                 text: "" // set dynamically to "Pin Message" or "Unpin Message"
             }
 
-            copy_text_button := mod.widgets.NewMessageContextMenuButton {
+            copy_text_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_COPY) }
                 text: "Copy Text"
             }
 
-            copy_html_button := mod.widgets.NewMessageContextMenuButton {
+            copy_html_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_HTML_FILE) }
-                icon_walk +: { margin: Inset{left: 1.5, right: 1.5} }
+                icon_walk +: { margin: Inset{left: 1.5} }
                 text: "Copy Text as HTML"
             }
 
-            copy_link_to_message_button := mod.widgets.NewMessageContextMenuButton {
+            copy_link_to_message_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_LINK) }
                 text: "Copy Link to Message"
             }
 
-            view_source_button := mod.widgets.NewMessageContextMenuButton {
+            view_source_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_VIEW_SOURCE) }
                 text: "View Source"
             }
 
-            jump_to_related_button := mod.widgets.NewMessageContextMenuButton {
+            jump_to_related_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_JUMP) }
                 text: "Jump to Related Event"
             }
 
-            divider_before_report_delete := LineH {
-                margin: Inset{top: 3, bottom: 3}
-                width: Fill,
-            }
+            divider_before_report_delete := mod.widgets.ContextMenuDivider { }
 
-            // report_button = ContextMenuButton {
-            //     draw_icon +: {
-            //         svg: (ICON_TRASH) // TODO: ICON_REPORT/WARNING/FLAG
-            //         color: (COLOR_FG_DANGER_RED),
-            //     }
-            //     icon_walk +: { margin: Inset{left: -2, right: 3} }
-            //
-            //     draw_bg +: {
-            //         border_color: (COLOR_FG_DANGER_RED),
-            //         color: (COLOR_BG_DANGER_RED)
-            //     }
+            // report_button = mod.widgets.ContextMenuDangerButton {
+            //     draw_icon.svg: (ICON_TRASH) // TODO: ICON_REPORT/WARNING/FLAG
             //     text: "Report"
-            //     draw_text +: {
-            //         color: (COLOR_FG_DANGER_RED),
-            //     }
             // }
 
             // Note: we don't yet support deleting others' messages via admin/moderator power levels.
@@ -193,16 +142,8 @@ script_mod! {
             //       The caller needs to use `can_redact_own()` or `can_redact_other()`:
             //       https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk_base/struct.RoomMember.html#method.can_redact_own
 
-            delete_button := mod.widgets.NewMessageContextMenuButton {
-                draw_icon +: {
-                    svg: (ICON_TRASH)
-                    color: (COLOR_FG_DANGER_RED),
-                }
-                draw_bg +: {
-                    border_color: (COLOR_FG_DANGER_RED),
-                    color: (COLOR_BG_DANGER_RED)
-                }
-                draw_text.color: (COLOR_FG_DANGER_RED),
+            delete_button := mod.widgets.ContextMenuDangerButton {
+                draw_icon.svg: (ICON_TRASH)
                 text: "Delete"
             }
         }
@@ -499,7 +440,7 @@ impl NewMessageContextMenu {
 
     /// Shows this context menu with the given message details.
     ///
-    /// Returns the expected (approximate) dimensions of the context menu,
+    /// Returns the expected dimensions of the context menu,
     /// which can be used to proactively reposition it such that it fits on screen.
     pub fn show(&mut self, cx: &mut Cx, details: MessageDetails) -> DVec2 {
         self.details = Some(details);
@@ -507,16 +448,14 @@ impl NewMessageContextMenu {
         cx.set_key_focus(self.view.area());
 
         // log!("Showing context menu for message: {:?}", self.details);
-        let height = self.set_button_visibility(cx);
-
-        dvec2(MENU_WIDTH, height)
+        self.set_button_visibility(cx)
     }
 
     /// Sets up all of the buttons based this context menu's inner details.
     ///
-    /// Returns the total height of all visible items.
-    fn set_button_visibility(&mut self, cx: &mut Cx) -> f64 {
-        let Some(details) = self.details.as_ref() else { return 0.0 };
+    /// Returns the expected dimensions of all visible items.
+    fn set_button_visibility(&mut self, cx: &mut Cx) -> DVec2 {
+        let Some(details) = self.details.as_ref() else { return DVec2::default() };
 
         let react_button = self.view.button(cx, ids!(react_button));
         let reply_button = self.view.button(cx, ids!(reply_button));
@@ -593,25 +532,23 @@ impl NewMessageContextMenu {
         self.redraw(cx);
 
         let num_visible_buttons =
-            show_react as u8
-            + show_reply_to as u8
-            + show_reply_in_thread as u8
-            + show_edit as u8
-            + show_pin as u8
-            + show_copy_text as u8
-            + show_copy_html as u8
-            + show_copy_link as u8
-            + show_view_source as u8
-            + show_jump_to_related as u8
-            // + show_report as u8
-            + show_delete as u8;
+            show_react as usize
+            + show_reply_to as usize
+            + show_reply_in_thread as usize
+            + show_edit as usize
+            + show_pin as usize
+            + show_copy_text as usize
+            + show_copy_html as usize
+            + show_copy_link as usize
+            + show_view_source as usize
+            + show_jump_to_related as usize
+            // + show_report as usize
+            + show_delete as usize;
+        let num_visible_dividers =
+            show_divider_after_react_reply as usize
+            + show_divider_before_report_delete as usize;
 
-        // Calculate and return the total expected height:
-        (num_visible_buttons as f64 * BUTTON_HEIGHT)
-            + if show_divider_after_react_reply { 10.0 } else { 0.0 }
-            + if show_divider_before_report_delete { 10.0 } else { 0.0 }
-            + 20.0  // top and bottom padding
-            + 1.0   // top and bottom border
+        expected_menu_size(num_visible_buttons, num_visible_dividers)
     }
 
     fn close(&mut self, cx: &mut Cx) {

--- a/src/home/room_context_menu.rs
+++ b/src/home/room_context_menu.rs
@@ -3,29 +3,15 @@
 
 use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
-use crate::{home::invite_modal::InviteModalAction, shared::popup_list::{PopupKind, enqueue_popup_notification}, sliding_sync::{MatrixRequest, submit_async_request}, utils::RoomNameId};
+use crate::{home::invite_modal::InviteModalAction, shared::{context_menu::expected_menu_size, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, submit_async_request}, utils::RoomNameId};
 
-const BUTTON_HEIGHT: f64 = 35.0;
-const MENU_WIDTH: f64 = 215.0;
+/// Nothing here is conditionally shown, so keep these matching the DSL below.
+const NUM_BUTTONS: usize = 8;
+const NUM_DIVIDERS: usize = 2;
 
 script_mod! {
     use mod.prelude.widgets.*
     use mod.widgets.*
-
-
-    mod.widgets.ROOM_CONTEXT_MENU_BUTTON_HEIGHT = 35
-    mod.widgets.ROOM_CONTEXT_MENU_WIDTH = 215
-
-    mod.widgets.RoomContextMenuButton = RobrixIconButton {
-        height: (mod.widgets.ROOM_CONTEXT_MENU_BUTTON_HEIGHT)
-        width: Fill,
-        margin: 0,
-        icon_walk: Walk{width: 16, height: 16, margin: Inset{right: 3}}
-        // Override the blue default back to neutral for context menu items
-        draw_bg +: { color: (COLOR_PRIMARY), color_hover: #EBEBEB, color_down: #DCDCDC }
-        draw_icon.color: #000
-        draw_text +: { color: #000, color_hover: #000, color_down: #000 }
-    }
 
     mod.widgets.RoomContextMenu = set_type_default() do #(RoomContextMenu::register_widget(vm)) {
         ..mod.widgets.SolidView
@@ -42,73 +28,48 @@ script_mod! {
             color: #0000004d
         }
 
-        main_content := RoundedView {
-            flow: Down
-            width: (mod.widgets.ROOM_CONTEXT_MENU_WIDTH),
-            height: Fit,
-            padding: 5
-            spacing: 0,
-            align: Align{x: 0, y: 0}
-
-            show_bg: true
-            draw_bg +: {
-                color: (COLOR_PRIMARY)
-                border_radius: 5.0
-                border_size: 0.5
-                border_color: #888
-            }
-
-            mark_unread_button := mod.widgets.RoomContextMenuButton {
+        main_content := mod.widgets.ContextMenuContent {
+            mark_unread_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_CHECKMARK) }
                 text: "Mark as Unread"
             }
 
-            favorite_button := mod.widgets.RoomContextMenuButton {
+            favorite_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_PIN) }
                 text: "Favorite"
             }
 
-            priority_button := mod.widgets.RoomContextMenuButton {
-                draw_icon +: { svg: (ICON_TOMBSTONE) } 
+            priority_button := mod.widgets.ContextMenuButton {
+                draw_icon +: { svg: (ICON_TOMBSTONE) }
                 text: "Set Low Priority"
             }
 
-            copy_link_button := mod.widgets.RoomContextMenuButton {
+            copy_link_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_LINK) }
                 text: "Copy Link to Room"
             }
-            
-            divider1 := LineH {
-                margin: Inset{top: 3, bottom: 3}
-                width: Fill,
-            }
 
-            room_settings_button := mod.widgets.RoomContextMenuButton {
+            divider1 := mod.widgets.ContextMenuDivider { }
+
+            room_settings_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_SETTINGS) }
                 text: "Settings"
             }
 
-            notifications_button := mod.widgets.RoomContextMenuButton {
+            notifications_button := mod.widgets.ContextMenuButton {
                 // TODO: use a proper bell icon
                 draw_icon +: { svg: (ICON_INFO) }
                 text: "Notifications"
             }
 
-            invite_button := mod.widgets.RoomContextMenuButton {
+            invite_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_ADD_USER) }
                 text: "Invite"
             }
 
-            divider2 := LineH {
-                margin: Inset{top: 3, bottom: 3}
-                width: Fill,
-            }
+            divider2 := mod.widgets.ContextMenuDivider { }
 
-            leave_button := RobrixNegativeIconButton {
-                height: (mod.widgets.ROOM_CONTEXT_MENU_BUTTON_HEIGHT)
-                width: Fill,
-                margin: 0,
-                icon_walk: Walk{width: 16, height: 16, margin: Inset{right: 3}}
+            leave_button := mod.widgets.ContextMenuDangerButton {
                 draw_icon.svg: (ICON_LOGOUT)
                 text: "Leave Room"
             }
@@ -261,14 +222,14 @@ impl RoomContextMenu {
     }
 
     pub fn show(&mut self, cx: &mut Cx, details: RoomContextMenuDetails) -> DVec2 {
-        let height = self.update_buttons(cx, &details);
+        self.update_buttons(cx, &details);
         self.details = Some(details);
         self.visible = true;
         cx.set_key_focus(self.view.area());
-        dvec2(MENU_WIDTH, height)
+        expected_menu_size(NUM_BUTTONS, NUM_DIVIDERS)
     }
-    
-    fn update_buttons(&mut self, cx: &mut Cx, details: &RoomContextMenuDetails) -> f64 {
+
+    fn update_buttons(&mut self, cx: &mut Cx, details: &RoomContextMenuDetails) {
         let mark_unread_button = self.button(cx, ids!(mark_unread_button));
         if details.is_marked_unread {
             mark_unread_button.set_text(cx, "Mark as Read");
@@ -299,12 +260,8 @@ impl RoomContextMenu {
         self.button(cx, ids!(notifications_button)).reset_hover(cx);
         self.button(cx, ids!(invite_button)).reset_hover(cx);
         self.button(cx, ids!(leave_button)).reset_hover(cx);
-        
+
         self.redraw(cx);
-        
-        // Calculate height (rudimentary) - sum of visible buttons + padding
-        // 8 buttons * 35.0 + 2 dividers * ~10.0 + padding
-        (8.0 * BUTTON_HEIGHT) + 20.0 + 10.0 // approx
     }
 
     fn close(&mut self, cx: &mut Cx) {

--- a/src/home/room_context_menu.rs
+++ b/src/home/room_context_menu.rs
@@ -3,7 +3,7 @@
 
 use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
-use crate::{home::invite_modal::InviteModalAction, shared::{context_menu::expected_menu_size, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, submit_async_request}, utils::RoomNameId};
+use crate::{home::invite_modal::InviteModalAction, shared::{context_menu::{ContextMenuClosed, expected_menu_size}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, submit_async_request}, utils::RoomNameId};
 
 /// Nothing here is conditionally shown, so keep these matching the DSL below.
 const NUM_BUTTONS: usize = 8;
@@ -269,6 +269,7 @@ impl RoomContextMenu {
         self.details = None;
         cx.revert_key_focus();
         cx.unblock_scrolling();
+        cx.action(ContextMenuClosed);
         self.redraw(cx);
     }
 }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -5526,7 +5526,7 @@ impl Widget for Message {
                     };
                     cx.widget_action(room_screen_widget_uid, action);
                 }
-                // A touch release leaves nothing hovering, so only a mouse still over us stays lit.
+                // A released hit clears all hovers, unless the mouse is still hovering over us
                 self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
             }
             _ => { }
@@ -5620,7 +5620,7 @@ impl Widget for Message {
                 self.animator_play(cx, ids!(hover.off));
             }
             Hit::FingerUp(fe) => {
-                // A touch release leaves nothing hovering, so only a mouse still over us stays lit.
+                // A released hit clears all hovers, unless the mouse is still hovering over us
                 self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
             }
             Hit::FingerHoverIn(..) => {
@@ -5635,17 +5635,17 @@ impl Widget for Message {
         }
 
         if let Event::Actions(actions) = event {
-            // A context menu covers us while it's open, so we never see a hover-out.
-            // Drop the highlight once it closes.
-            if actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some()) {
-                self.animator_play(cx, ids!(hover.off));
-            }
-
             for action in actions {
+                if action.downcast_ref::<ContextMenuClosed>().is_some() {
+                    self.animator_play(cx, ids!(hover.off));
+                    continue;
+                }
+
                 match action.as_widget_action().widget_uid_eq(room_screen_widget_uid).cast_ref() {
                     MessageAction::HighlightMessage(id) if id == &self.details.as_ref().unwrap().item_id => { // guaranteed to be Some()
                         self.animator_play(cx, ids!(highlight.on));
                         self.redraw(cx);
+                        continue;
                     }
                     _ => {}
                 }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -33,7 +33,7 @@ use crate::{
     },
     room::{BasicRoomDetails, reply_preview::{CollapsiblePreviewRef, CollapsiblePreviewWidgetRefExt}, room_input_bar::{RoomInputBarState, RoomInputBarWidgetRefExt}, typing_notice::TypingNoticeWidgetExt},
     shared::{
-        attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, TimelineUpdateSenderOption, TransferKind, media_source_mxc, start_attachment_download, start_attachment_share}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, file_upload_modal::FileUploadAttemptId, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuRef, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
+        attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, TimelineUpdateSenderOption, TransferKind, media_source_mxc, start_attachment_download, start_attachment_share}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, context_menu::ContextMenuClosed, file_upload_modal::FileUploadAttemptId, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuRef, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
     },
     sliding_sync::{BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, submit_async_request, take_timeline_endpoints}, utils::{self, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
 };
@@ -226,6 +226,7 @@ script_mod! {
             highlight: instance(0.0)
             hover: instance(0.0)
             color: instance((COLOR_PRIMARY)) // default color)
+            color_hover: instance(COLOR_LIST_ITEM_BG_HOVER)
 
             mentions_bar_color: instance((COLOR_PRIMARY))
             mentions_bar_width: instance(4.0)
@@ -233,7 +234,7 @@ script_mod! {
             pixel: fn() {
                 let base_color = mix(
                     self.color,
-                    #fafafa,
+                    self.color_hover,
                     self.hover
                 );
 
@@ -5487,16 +5488,23 @@ impl Widget for Message {
             Hit::FingerHoverOut(_fho) => {
                 self.animator_play(cx, ids!(hover.off));
             }
-            Hit::FingerDown(fe) if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) => {
-                cx.widget_action(
-                    room_screen_widget_uid,
-                    MessageAction::OpenMessageContextMenu {
-                        details: self.details.clone().unwrap(), // guaranteed to be Some()
-                        abs_pos: fe.abs,
-                    }
-                );
+            Hit::FingerMove(fe) if !fe.is_over => {
+                self.animator_play(cx, ids!(hover.off));
+            }
+            Hit::FingerDown(fe) => {
+                self.animator_play(cx, ids!(hover.on));
+                if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
+                    cx.widget_action(
+                        room_screen_widget_uid,
+                        MessageAction::OpenMessageContextMenu {
+                            details: self.details.clone().unwrap(), // guaranteed to be Some()
+                            abs_pos: fe.abs,
+                        }
+                    );
+                }
             }
             Hit::FingerLongPress(lp) => {
+                self.animator_play(cx, ids!(hover.on));
                 cx.widget_action(
                     room_screen_widget_uid,
                     MessageAction::OpenMessageContextMenu {
@@ -5505,17 +5513,21 @@ impl Widget for Message {
                     }
                 );
             }
-            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
-                // Tapping on a collapsed reply preview expands it.
-                // Tapping on an expanded reply preview jumps to the replied-to message.
-                let action = if reply.is_collapsed() {
-                    MessageAction::ToggleReplyPreviewExpanded(
-                        self.details.as_ref().unwrap().timeline_event_id.clone(), // guaranteed to be Some()
-                    )
-                } else {
-                    MessageAction::JumpToRelated(self.details.clone().unwrap()) // guaranteed to be Some()
-                };
-                cx.widget_action(room_screen_widget_uid, action);
+            Hit::FingerUp(fe) => {
+                if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
+                    // Tapping on a collapsed reply preview expands it.
+                    // Tapping on an expanded reply preview jumps to the replied-to message.
+                    let action = if reply.is_collapsed() {
+                        MessageAction::ToggleReplyPreviewExpanded(
+                            self.details.as_ref().unwrap().timeline_event_id.clone(), // guaranteed to be Some()
+                        )
+                    } else {
+                        MessageAction::JumpToRelated(self.details.clone().unwrap()) // guaranteed to be Some()
+                    };
+                    cx.widget_action(room_screen_widget_uid, action);
+                }
+                // A touch release leaves nothing hovering, so only a mouse still over us stays lit.
+                self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
             }
             _ => { }
         }
@@ -5581,11 +5593,12 @@ impl Widget for Message {
         let message_view_area = self.view.area();
         match event.hits(cx, message_view_area) {
             Hit::FingerDown(fe) => {
+                self.animator_play(cx, ids!(hover.on));
                 cx.set_key_focus(message_view_area);
                 // A right click means we should display the context menu.
                 if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
                     cx.widget_action(
-                        room_screen_widget_uid, 
+                        room_screen_widget_uid,
                         MessageAction::OpenMessageContextMenu {
                             details: self.details.clone().unwrap(), // guaranteed to be Some()
                             abs_pos: fe.abs,
@@ -5594,13 +5607,21 @@ impl Widget for Message {
                 }
             }
             Hit::FingerLongPress(lp) => {
+                self.animator_play(cx, ids!(hover.on));
                 cx.widget_action(
-                    room_screen_widget_uid, 
+                    room_screen_widget_uid,
                     MessageAction::OpenMessageContextMenu {
                         details: self.details.clone().unwrap(), // guaranteed to be Some()
                         abs_pos: lp.abs,
                     }
                 );
+            }
+            Hit::FingerMove(fe) if !fe.is_over => {
+                self.animator_play(cx, ids!(hover.off));
+            }
+            Hit::FingerUp(fe) => {
+                // A touch release leaves nothing hovering, so only a mouse still over us stays lit.
+                self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
             }
             Hit::FingerHoverIn(..) => {
                 self.animator_play(cx, ids!(hover.on));
@@ -5614,6 +5635,12 @@ impl Widget for Message {
         }
 
         if let Event::Actions(actions) = event {
+            // A context menu covers us while it's open, so we never see a hover-out.
+            // Drop the highlight once it closes.
+            if actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some()) {
+                self.animator_play(cx, ids!(hover.off));
+            }
+
             for action in actions {
                 match action.as_widget_action().widget_uid_eq(room_screen_widget_uid).cast_ref() {
                     MessageAction::HighlightMessage(id) if id == &self.details.as_ref().unwrap().item_id => { // guaranteed to be Some()

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -5,6 +5,7 @@ use crate::{
     room::FetchedRoomAvatar,
     shared::{
     avatar::AvatarWidgetExt,
+        context_menu::ContextMenuClosed,
         html_or_plaintext::HtmlOrPlaintextWidgetExt, unread_badge::UnreadBadgeWidgetExt as _,
     },
     utils::{self, relative_format}
@@ -116,19 +117,27 @@ script_mod! {
         spacing: 10,
         padding: 10,
         width: Fill, height: Fit
+        cursor: MouseCursor.Default,
 
         show_bg: true
         draw_bg +: {
             active: instance(0.0)
+            hover: instance(0.0)
             color: instance(#0000)
+            color_hover: instance(COLOR_LIST_ITEM_BG_HOVER)
             color_selected: instance(COLOR_ACTIVE_PRIMARY)
+            color_selected_hover: instance(COLOR_ACTIVE_PRIMARY_DARKER)
             border_color: instance(#0000)
             border_size: uniform(0.0)
             border_radius: uniform(4.0)
             border_inset: uniform(vec4(0.0))
 
             get_color: fn() -> vec4 {
-                return mix(self.color, self.color_selected, self.active)
+                return mix(
+                    mix(self.color, self.color_hover, self.hover),
+                    mix(self.color_selected, self.color_selected_hover, self.hover),
+                    self.active
+                )
             }
 
             pixel: fn() {
@@ -163,12 +172,28 @@ script_mod! {
                     }
                 }
             }
+            // Snap both ways: the resting color is transparent, so a faded
+            // mid-blend would composite darker than either end.
+            hover: {
+                default: @off
+                off: AnimatorState{
+                    from: {all: Snap}
+                    apply: {
+                        draw_bg: {hover: 0.0}
+                    }
+                }
+                on: AnimatorState{
+                    from: {all: Snap}
+                    apply: {
+                        draw_bg: {hover: 1.0}
+                    }
+                }
+            }
         }
     }
 
     mod.widgets.RoomsListEntry = #(RoomsListEntry::register_widget(vm)) {
         flow: Down, height: Fit
-        cursor: MouseCursor.Default,
 
         // Wrap the RoomsListEntryContent in an AdaptiveView to change the displayed content
         // (and its layout) based on the available space in the sidebar.
@@ -241,7 +266,6 @@ script_mod! {
 #[derive(Script, Widget)]
 pub struct RoomsListEntry {
     #[deref] view: View,
-    #[rust] room_id: Option<OwnedRoomId>,
 }
 
 impl ScriptHook for RoomsListEntry {
@@ -277,46 +301,10 @@ impl RoomsListEntry {
 
 impl Widget for RoomsListEntry {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        let uid = self.widget_uid();
-        // We handle hits on this widget first to ensure that any clicks on it
-        // will just select the room, rather than resulting in a click on any child view
-        // within the RoomsListEntry content itself, such as links or avatars.
-        if let Some(room_id) = &self.room_id {
-            let area = self.view.area();
-            match event.hits(cx, area) {
-                Hit::FingerDown(fe) => {
-                    cx.set_key_focus(area);
-                    if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
-                        cx.widget_action(
-                            uid, 
-                            RoomsListEntryAction::SecondaryClicked(room_id.clone(), fe.abs),
-                        );
-                    }
-                }
-                Hit::FingerLongPress(fe) => {
-                    cx.widget_action(
-                        uid, 
-                        RoomsListEntryAction::SecondaryClicked(room_id.clone(), fe.abs),
-                    );
-                }
-                Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
-                    cx.widget_action(uid,  RoomsListEntryAction::PrimaryClicked(room_id.clone()));
-                }
-                _ => { }
-            }
-        }
-
         self.view.handle_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        if let Some(room_info) = scope.props.get::<JoinedRoomInfo>() {
-            self.room_id = Some(room_info.room_name_id.room_id().clone());
-        }
-        else if let Some(room_info) = scope.props.get::<InvitedRoomInfo>() {
-            self.room_id = Some(room_info.room_name_id.room_id().clone());
-        }
-
         self.view.draw_walk(cx, scope, walk)
     }
 }
@@ -326,6 +314,8 @@ pub struct RoomsListEntryContent {
     #[source] source: ScriptObjectRef,
     #[deref] view: View,
     #[apply_default] animator: Animator,
+
+    #[rust] room_id: Option<OwnedRoomId>,
 
     /// The preview colors that were last drawn for this entry.
     /// * Some(true): this entry was last drawn as selected.
@@ -342,13 +332,74 @@ impl Widget for RoomsListEntryContent {
         if self.animator_handle_event(cx, event).must_redraw() {
             self.redraw(cx);
         }
+
+        // A context menu covers us while it's open, so we never see a hover-out.
+        // Drop the highlight once it closes.
+        if let Event::Actions(actions) = event
+            && actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some())
+        {
+            self.animator_play(cx, ids!(hover.off));
+        }
+
+        let uid = self.widget_uid();
+        let area = self.view.area();
+        // We handle hits on this widget first to ensure that any clicks on it
+        // will just select the room, rather than resulting in a click on any child view
+        // within the RoomsListEntry content itself, such as links or avatars.
+        match event.hits(cx, area) {
+            Hit::FingerHoverIn(_) => {
+                self.animator_play(cx, ids!(hover.on));
+            }
+            Hit::FingerHoverOut(_) => {
+                self.animator_play(cx, ids!(hover.off));
+            }
+            // Un-press as soon as the finger leaves us, since a drag-scroll of the
+            // rooms list won't deliver anything else.
+            Hit::FingerMove(fe) if !fe.is_over => {
+                self.animator_play(cx, ids!(hover.off));
+            }
+            Hit::FingerDown(fe) => {
+                self.animator_play(cx, ids!(hover.on));
+                cx.set_key_focus(area);
+                if fe.device.mouse_button().is_some_and(|b| b.is_secondary())
+                    && let Some(room_id) = self.room_id.as_ref()
+                {
+                    cx.widget_action(
+                        uid,
+                        RoomsListEntryAction::SecondaryClicked(room_id.clone(), fe.abs),
+                    );
+                }
+            }
+            Hit::FingerLongPress(fe) => {
+                self.animator_play(cx, ids!(hover.on));
+                if let Some(room_id) = self.room_id.as_ref() {
+                    cx.widget_action(
+                        uid,
+                        RoomsListEntryAction::SecondaryClicked(room_id.clone(), fe.abs),
+                    );
+                }
+            }
+            Hit::FingerUp(fe) => {
+                if fe.is_over && fe.is_primary_hit() && fe.was_tap()
+                    && let Some(room_id) = self.room_id.as_ref()
+                {
+                    cx.widget_action(uid, RoomsListEntryAction::PrimaryClicked(room_id.clone()));
+                }
+                // A touch release leaves nothing hovering, so only a mouse still over us stays lit.
+                self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
+            }
+            _ => { }
+        }
+
         self.view.handle_event(cx, event, scope);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         if let Some(joined_room_info) = scope.props.get::<JoinedRoomInfo>() {
+            self.room_id = Some(joined_room_info.room_name_id.room_id().clone());
             self.draw_joined_room(cx, joined_room_info);
         } else if let Some(invited_room_info) = scope.props.get::<InvitedRoomInfo>() {
+            self.room_id = Some(invited_room_info.room_name_id.room_id().clone());
             self.draw_invited_room(cx, invited_room_info);
         }
 

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -172,8 +172,6 @@ script_mod! {
                     }
                 }
             }
-            // Snap both ways: the resting color is transparent, so a faded
-            // mid-blend would composite darker than either end.
             hover: {
                 default: @off
                 off: AnimatorState{
@@ -333,8 +331,6 @@ impl Widget for RoomsListEntryContent {
             self.redraw(cx);
         }
 
-        // A context menu covers us while it's open, so we never see a hover-out.
-        // Drop the highlight once it closes.
         if let Event::Actions(actions) = event
             && actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some())
         {
@@ -353,8 +349,7 @@ impl Widget for RoomsListEntryContent {
             Hit::FingerHoverOut(_) => {
                 self.animator_play(cx, ids!(hover.off));
             }
-            // Un-press as soon as the finger leaves us, since a drag-scroll of the
-            // rooms list won't deliver anything else.
+            // De-select it as soon as the finger isn't over us, e.g., a touch drag scroll.
             Hit::FingerMove(fe) if !fe.is_over => {
                 self.animator_play(cx, ids!(hover.off));
             }
@@ -385,7 +380,7 @@ impl Widget for RoomsListEntryContent {
                 {
                     cx.widget_action(uid, RoomsListEntryAction::PrimaryClicked(room_id.clone()));
                 }
-                // A touch release leaves nothing hovering, so only a mouse still over us stays lit.
+                // A released hit clears all hovers, unless the mouse is still hovering over us
                 self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
             }
             _ => { }

--- a/src/shared/context_menu.rs
+++ b/src/shared/context_menu.rs
@@ -74,6 +74,11 @@ script_mod! {
     }
 }
 
+/// Broadcast when a context menu closes, so the widget it was opened from can drop
+/// the hover highlight that the menu left it holding.
+#[derive(Clone, Debug)]
+pub struct ContextMenuClosed;
+
 pub fn expected_menu_size(num_buttons: usize, num_dividers: usize) -> DVec2 {
     let height = num_buttons as f64 * BUTTON_HEIGHT
         + num_dividers as f64 * DIVIDER_HEIGHT

--- a/src/shared/context_menu.rs
+++ b/src/shared/context_menu.rs
@@ -1,5 +1,4 @@
-//! Shared sizing and styling for Robrix's popup context menus,
-//! matching that of the `RoomInputPopupMenu`.
+//! Shared widgets and DSL styling definitions for context menus.
 
 use makepad_widgets::*;
 
@@ -74,8 +73,7 @@ script_mod! {
     }
 }
 
-/// Broadcast when a context menu closes, so the widget it was opened from can drop
-/// the hover highlight that the menu left it holding.
+/// An action broadcast when a context menu was closed.
 #[derive(Clone, Debug)]
 pub struct ContextMenuClosed;
 
@@ -87,7 +85,8 @@ pub fn expected_menu_size(num_buttons: usize, num_dividers: usize) -> DVec2 {
     dvec2(MENU_WIDTH, height)
 }
 
-/// Places the menu at `anchor_pos`, pulled back so it stays within `container_rect`.
+/// Returns a margin that positions the context menu at `anchor_pos`,
+/// but ensuring that it stays within the given `container_rect`.
 pub fn menu_position_margin(container_rect: Rect, anchor_pos: DVec2, menu_size: DVec2) -> Inset {
     Inset {
         left: (anchor_pos.x - container_rect.pos.x)

--- a/src/shared/context_menu.rs
+++ b/src/shared/context_menu.rs
@@ -1,0 +1,97 @@
+//! Shared sizing and styling for Robrix's popup context menus,
+//! matching that of the `RoomInputPopupMenu`.
+
+use makepad_widgets::*;
+
+pub const BUTTON_HEIGHT: f64 = 38.0;
+const MENU_WIDTH: f64 = 235.0;
+const MENU_PADDING: f64 = 6.0;
+const MENU_SPACING: f64 = 2.0;
+const DIVIDER_MARGIN: f64 = 3.0;
+const DIVIDER_HEIGHT: f64 = 2.0 + 2.0 * DIVIDER_MARGIN; // a `LineH` is 2pt tall
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    mod.widgets.ContextMenuButton = RobrixIconButton {
+        height: #(BUTTON_HEIGHT)
+        width: Fill
+        margin: 0
+        padding: Inset{left: 10, right: 12, top: 9, bottom: 9}
+        spacing: 10
+        align: Align{x: 0, y: 0.5}
+        icon_walk: Walk{width: 18, height: 18}
+
+        draw_bg +: {
+            color: (COLOR_PRIMARY)
+            color_hover: #EBEBEB
+            color_down: #DCDCDC
+            border_radius: 4.0
+        }
+        draw_icon.color: #000
+        draw_text +: {
+            color: #000, color_hover: #000, color_down: #000
+            text_style: REGULAR_TEXT {font_size: 11}
+        }
+    }
+
+    mod.widgets.ContextMenuDangerButton = mod.widgets.ContextMenuButton {
+        draw_bg +: {
+            color: (COLOR_BG_DANGER_RED)
+            color_hover: #F0D4D4
+            color_down: #E0B8B8
+        }
+        draw_icon.color: (COLOR_FG_DANGER_RED)
+        draw_text +: {
+            color: (COLOR_FG_DANGER_RED)
+            color_hover: (COLOR_FG_DANGER_RED)
+            color_down: (COLOR_FG_DANGER_RED)
+        }
+    }
+
+    mod.widgets.ContextMenuDivider = LineH {
+        width: Fill
+        margin: Inset{top: #(DIVIDER_MARGIN), bottom: #(DIVIDER_MARGIN)}
+    }
+
+    // Deliberately has no children, since those don't inherit; each menu declares its own.
+    mod.widgets.ContextMenuContent = RoundedView {
+        flow: Down
+        width: #(MENU_WIDTH)
+        height: Fit
+        padding: #(MENU_PADDING)
+        spacing: #(MENU_SPACING)
+        align: Align{x: 0, y: 0}
+
+        show_bg: true
+        draw_bg +: {
+            color: (COLOR_PRIMARY)
+            border_radius: 5.0
+            border_size: 0.5
+            border_color: #888
+        }
+    }
+}
+
+pub fn expected_menu_size(num_buttons: usize, num_dividers: usize) -> DVec2 {
+    let height = num_buttons as f64 * BUTTON_HEIGHT
+        + num_dividers as f64 * DIVIDER_HEIGHT
+        + (num_buttons + num_dividers).saturating_sub(1) as f64 * MENU_SPACING
+        + 2.0 * MENU_PADDING;
+    dvec2(MENU_WIDTH, height)
+}
+
+/// Places the menu at `anchor_pos`, pulled back so it stays within `container_rect`.
+pub fn menu_position_margin(container_rect: Rect, anchor_pos: DVec2, menu_size: DVec2) -> Inset {
+    Inset {
+        left: (anchor_pos.x - container_rect.pos.x)
+            .min(container_rect.size.x - menu_size.x)
+            .max(0.0),
+        top: (anchor_pos.y - container_rect.pos.y)
+            .min(container_rect.size.y - menu_size.y)
+            .max(0.0),
+        right: 0.0,
+        bottom: 0.0,
+    }
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -3,6 +3,7 @@ use makepad_widgets::ScriptVm;
 pub mod attachment_download;
 pub mod avatar;
 pub mod collapsible_header;
+pub mod context_menu;
 pub mod expand_arrow;
 pub mod confirmation_modal;
 pub mod file_upload_modal;
@@ -33,6 +34,7 @@ pub fn script_mod(vm: &mut ScriptVm) {
     styles::script_mod(vm);
     helpers::script_mod(vm);
     icon_button::script_mod(vm);
+    context_menu::script_mod(vm);
     navigation_bar_button::script_mod(vm);
     expand_arrow::script_mod(vm);
     unread_badge::script_mod(vm);

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -146,6 +146,9 @@ script_mod! {
     mod.widgets.COLOR_SECONDARY = #E3E3E3
     mod.widgets.COLOR_SECONDARY_DARKER = #C8C8C8
 
+    // Shown behind a hovered or pressed list item: a rooms list entry, a timeline message.
+    mod.widgets.COLOR_LIST_ITEM_BG_HOVER = #f0f0f0
+
     mod.widgets.COLOR_ACTIVE_PRIMARY = #0f88fe
 
     mod.widgets.COLOR_ACTIVE_PRIMARY_DARKER = #106fcc


### PR DESCRIPTION
context menus were mostly duplicated code across the room one and the message one, now they're combined.
We also made them a bit larger to match the size and spacing of the room input popup menu, which looked better.