### PR TITLE
Improve hover highlight in rooms list and messages, plus context menu fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "bit-vec",
 ]
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "bitflags"
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "bitmaps"
@@ -724,7 +724,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "byteorder"
@@ -735,7 +735,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "bytes"
@@ -794,7 +794,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "cfg_aliases"
@@ -805,7 +805,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "chacha20"
@@ -1142,7 +1142,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "crypto-bigint"
@@ -1522,7 +1522,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "dunce"
@@ -1630,7 +1630,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "errno"
@@ -1808,7 +1808,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "foreign-types"
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2198,7 +2198,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "hilog-sys"
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -2826,13 +2826,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "windows-link 0.2.1",
@@ -2906,7 +2906,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "loom"
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3058,22 +3058,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "weezl",
 ]
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3106,7 +3106,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "ttf-parser",
 ]
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3147,12 +3147,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3183,12 +3183,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3225,12 +3225,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3261,12 +3261,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "makepad-error-log",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "simd-adler32",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3752,7 +3752,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "mime"
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bit-set",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "num_cpus"
@@ -4163,7 +4163,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4452,7 +4452,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "pollster"
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "rustc-hash"
@@ -5506,7 +5506,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bytemuck",
@@ -5600,7 +5600,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "scopeguard"
@@ -5611,7 +5611,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "sealed"
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "siphasher"
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "socket2"
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "tungstenite"
@@ -6784,7 +6784,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-bidi"
@@ -6795,17 +6795,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-ident"
@@ -6816,7 +6816,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-normalization"
@@ -6836,12 +6836,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6852,7 +6852,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "unicode-xid"
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "log 0.4.29",
  "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "whoami"
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7460,7 +7460,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "windows-numerics"
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#7622a2b9bb447fb0c81a0189a5d74b3a29b29e65"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
 
 [[package]]
 name = "zerocopy-derive"

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::{
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states, invalidate_timeline_state}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
     }, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
-    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, context_menu::menu_position_margin, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, TimelineKind, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
+    }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, context_menu::{ContextMenuClosed, menu_position_margin}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, TimelineKind, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
         VerificationModalAction,
         VerificationModalWidgetRefExt,
     }
@@ -343,6 +343,12 @@ impl MatchEvent for App {
                     margin: #(margin)
                 });
                 self.ui.redraw(cx);
+                continue;
+            }
+
+            // Hide the tooltip when the context menu is closed (since we're clearing hovers).
+            if action.downcast_ref::<ContextMenuClosed>().is_some() {
+                self.ui.callout_tooltip(cx, ids!(app_tooltip)).hide(cx);
                 continue;
             }
 
@@ -842,7 +848,7 @@ impl App {
 
     fn handle_shutdown(&mut self, cx: &mut Cx) {
         if self.lifecycle.shutdown_started {
-            log!("Ignoring duplicate shutdown lifecycle event.");
+            // log!("Ignoring duplicate shutdown lifecycle event.");
             return;
         }
         self.lifecycle.shutdown_started = true;

--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -310,6 +310,16 @@ impl LinkPreview {
 }
 
 impl LinkPreviewRef {
+    /// Clears the hover highlight on every preview card and the show more/fewer buttons.
+    pub fn reset_hovers(&self, cx: &mut Cx) {
+        let Some(inner) = self.borrow() else { return };
+        for item in inner.children.iter() {
+            reset_hover(cx, item);
+        }
+        inner.view.button(cx, ids!(collapsible_buttons.expand_button)).reset_hover(cx);
+        inner.view.button(cx, ids!(collapsible_buttons.collapse_button)).reset_hover(cx);
+    }
+
     /// Clears any displayed link preview(s), resetting this widget to its empty state.
     ///
     /// Needed for messages that never show link previews (e.g. redacted messages).

--- a/src/home/new_message_context_menu.rs
+++ b/src/home/new_message_context_menu.rs
@@ -111,7 +111,6 @@ script_mod! {
 
             copy_html_button := mod.widgets.ContextMenuButton {
                 draw_icon +: { svg: (ICON_HTML_FILE) }
-                icon_walk +: { margin: Inset{left: 1.5} }
                 text: "Copy Text as HTML"
             }
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -27,13 +27,13 @@ use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, e
 
 use matrix_sdk_ui::sync_service::State;
 use crate::{
-    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetExt, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
         user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     },
     room::{BasicRoomDetails, reply_preview::{CollapsiblePreviewRef, CollapsiblePreviewWidgetRefExt}, room_input_bar::{RoomInputBarState, RoomInputBarWidgetRefExt}, typing_notice::TypingNoticeWidgetExt},
     shared::{
-        attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, TimelineUpdateSenderOption, TransferKind, media_source_mxc, start_attachment_download, start_attachment_share}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, context_menu::ContextMenuClosed, file_upload_modal::FileUploadAttemptId, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuRef, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
+        attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, TimelineUpdateSenderOption, TransferKind, media_source_mxc, start_attachment_download, start_attachment_share}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, context_menu::ContextMenuClosed, file_upload_modal::FileUploadAttemptId, hover_highlight::handle_hover_hit, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetExt, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuRef, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
     },
     sliding_sync::{BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, submit_async_request, take_timeline_endpoints}, utils::{self, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
 };
@@ -232,9 +232,11 @@ script_mod! {
             mentions_bar_width: instance(4.0)
 
             pixel: fn() {
+                // Multiply rather than replace, so a mention-highlighted message
+                // keeps its yellow on hover, just darker.
                 let base_color = mix(
                     self.color,
-                    self.color_hover,
+                    self.color * self.color_hover,
                     self.hover
                 );
 
@@ -274,7 +276,7 @@ script_mod! {
                     apply: { draw_bg: {highlight: 1.0} }
                 }
             }
-            hover: {
+            bg_hover: {
                 default: @off
                 off: AnimatorState{
                     redraw: true,
@@ -5439,6 +5441,8 @@ pub struct Message {
     #[apply_default] animator: Animator,
 
     #[rust] details: Option<MessageDetails>,
+    /// `True` while a context menu that we opened is being shown.
+    #[rust] is_context_menu_open: bool,
     /// Set on file/image/audio/video messages so the download button knows
     /// what to save when the user clicks it. `None` for plain text messages,
     /// which hide the download button entirely.
@@ -5476,58 +5480,61 @@ impl Widget for Message {
         let room_screen_widget_uid = d.room_screen_widget_uid;
         let thread_root_event_id = d.thread_root_event_id.clone();
 
+        // A right-click or long-press anywhere on a message widget should show its context menu,
+        // so we have to handle the raw events instead of relying on the hit system.
+        if let Event::MouseDown(mde) = event
+            && mde.button.is_secondary()
+            && mde.handled.get().is_empty()
+            && self.view.area().clipped_rect(cx).contains(mde.abs)
+            && !self.is_within_excluded_child(cx, mde.abs, false)
+        {
+            mde.handled.set(self.view.area());
+            let details = d.clone();
+            self.animator_play(cx, ids!(bg_hover.on));
+            self.open_context_menu(cx, room_screen_widget_uid, details, mde.abs);
+        }
+        else if let Event::LongPress(lpe) = event {
+            let msg_rect = self.view.area().clipped_rect(cx);
+            // the long press must've been captured by this message originally (on touch-down).
+            let capture_is_ours = cx.fingers.touch_capture_area(lpe.uid)
+                .is_none_or(|a| {
+                    let r = a.clipped_rect(cx);
+                    msg_rect.contains(r.pos) && msg_rect.contains(r.pos + r.size)
+                });
+            if msg_rect.contains(lpe.abs)
+                && capture_is_ours
+                && !self.is_within_excluded_child(cx, lpe.abs, true)
+            {
+                let details = d.clone();
+                self.animator_play(cx, ids!(bg_hover.on));
+                self.open_context_menu(cx, room_screen_widget_uid, details, lpe.abs);
+            }
+        }
+
         // We first handle a click on the replied-to message preview, if present,
         // because we don't want any widgets within the replied-to message to be
         // clickable or otherwise interactive.
         let reply = self.replied_to_message_view(cx);
         let reply_content_area = reply.content_area(cx);
-        match event.hits(cx, reply_content_area) {
+        let reply_hit = event.hits(cx, reply_content_area);
+        match reply_hit {
             Hit::FingerHoverIn(..) => {
-                self.animator_play(cx, ids!(hover.on));
+                self.animator_play(cx, ids!(bg_hover.on));
             }
-            Hit::FingerHoverOut(_fho) => {
-                self.animator_play(cx, ids!(hover.off));
+            Hit::FingerDown(_) => {
+                self.animator_play(cx, ids!(bg_hover.on));
             }
-            Hit::FingerMove(fe) if !fe.is_over => {
-                self.animator_play(cx, ids!(hover.off));
-            }
-            Hit::FingerDown(fe) => {
-                self.animator_play(cx, ids!(hover.on));
-                if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
-                    cx.widget_action(
-                        room_screen_widget_uid,
-                        MessageAction::OpenMessageContextMenu {
-                            details: self.details.clone().unwrap(), // guaranteed to be Some()
-                            abs_pos: fe.abs,
-                        }
-                    );
-                }
-            }
-            Hit::FingerLongPress(lp) => {
-                self.animator_play(cx, ids!(hover.on));
-                cx.widget_action(
-                    room_screen_widget_uid,
-                    MessageAction::OpenMessageContextMenu {
-                        details: self.details.clone().unwrap(), // guaranteed to be Some()
-                        abs_pos: lp.abs,
-                    }
-                );
-            }
-            Hit::FingerUp(fe) => {
-                if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
-                    // Tapping on a collapsed reply preview expands it.
-                    // Tapping on an expanded reply preview jumps to the replied-to message.
-                    let action = if reply.is_collapsed() {
-                        MessageAction::ToggleReplyPreviewExpanded(
-                            self.details.as_ref().unwrap().timeline_event_id.clone(), // guaranteed to be Some()
-                        )
-                    } else {
-                        MessageAction::JumpToRelated(self.details.clone().unwrap()) // guaranteed to be Some()
-                    };
-                    cx.widget_action(room_screen_widget_uid, action);
-                }
-                // A released hit clears all hovers, unless the mouse is still hovering over us
-                self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
+            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
+                // Tapping on a collapsed reply preview expands it.
+                // Tapping on an expanded reply preview jumps to the replied-to message.
+                let action = if reply.is_collapsed() {
+                    MessageAction::ToggleReplyPreviewExpanded(
+                        self.details.as_ref().unwrap().timeline_event_id.clone(), // guaranteed to be Some()
+                    )
+                } else {
+                    MessageAction::JumpToRelated(self.details.clone().unwrap()) // guaranteed to be Some()
+                };
+                cx.widget_action(room_screen_widget_uid, action);
             }
             _ => { }
         }
@@ -5541,39 +5548,31 @@ impl Widget for Message {
                     draw_bg.color: #(bg_color)
                 });
             };
-            match event.hits(cx, thread_root_summary.area()) {
-                Hit::FingerDown(fe) => {
+            let summary_hit = event.hits(cx, thread_root_summary.area());
+            match summary_hit {
+                Hit::FingerDown(_) => {
+                    self.animator_play(cx, ids!(bg_hover.on));
                     apply_hover(cx, COLOR_THREAD_SUMMARY_BG_HOVER);
-                    if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
-                        cx.widget_action(
-                            room_screen_widget_uid, 
-                            MessageAction::OpenMessageContextMenu {
-                                details: self.details.clone().unwrap(), // guaranteed to be Some()
-                                abs_pos: fe.abs,
-                            }
-                        );
-                    }
                 }
                 Hit::FingerHoverIn(_) => {
+                    self.animator_play(cx, ids!(bg_hover.on));
                     apply_hover(cx, COLOR_THREAD_SUMMARY_BG_HOVER);
                 }
                 Hit::FingerHoverOut(_) => {
                     apply_hover(cx, COLOR_THREAD_SUMMARY_BG);
                 }
-                Hit::FingerLongPress(lp) => {
-                    cx.widget_action(
-                        room_screen_widget_uid, 
-                        MessageAction::OpenMessageContextMenu {
-                            details: self.details.clone().unwrap(), // guaranteed to be Some()
-                            abs_pos: lp.abs,
-                        }
-                    );
+                Hit::FingerMove(fe) if !fe.is_over => {
+                    apply_hover(cx, COLOR_THREAD_SUMMARY_BG);
+                }
+                Hit::FingerLongPress(_) => {
+                    apply_hover(cx, COLOR_THREAD_SUMMARY_BG_HOVER);
                 }
                 Hit::FingerUp(fe) => {
-                    apply_hover(cx, COLOR_THREAD_SUMMARY_BG);
+                    let still_hovered = fe.device.has_hovers() && fe.is_over;
+                    apply_hover(cx, if still_hovered { COLOR_THREAD_SUMMARY_BG_HOVER } else { COLOR_THREAD_SUMMARY_BG });
                     if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
                         cx.widget_action(
-                            room_screen_widget_uid, 
+                            room_screen_widget_uid,
                             MessageAction::OpenThread(thread_root_event_id.clone()),
                         );
                     }
@@ -5591,56 +5590,39 @@ impl Widget for Message {
 
         // Finally, handle any hits on the rest of the message body itself.
         let message_view_area = self.view.area();
-        match event.hits(cx, message_view_area) {
-            Hit::FingerDown(fe) => {
-                self.animator_play(cx, ids!(hover.on));
+        let body_hit = handle_hover_hit(self, cx, event, message_view_area, self.is_context_menu_open);
+        match body_hit {
+            Hit::FingerDown(_) => {
                 cx.set_key_focus(message_view_area);
-                // A right click means we should display the context menu.
-                if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
-                    cx.widget_action(
-                        room_screen_widget_uid,
-                        MessageAction::OpenMessageContextMenu {
-                            details: self.details.clone().unwrap(), // guaranteed to be Some()
-                            abs_pos: fe.abs,
-                        }
-                    );
-                }
-            }
-            Hit::FingerLongPress(lp) => {
-                self.animator_play(cx, ids!(hover.on));
-                cx.widget_action(
-                    room_screen_widget_uid,
-                    MessageAction::OpenMessageContextMenu {
-                        details: self.details.clone().unwrap(), // guaranteed to be Some()
-                        abs_pos: lp.abs,
-                    }
-                );
-            }
-            Hit::FingerMove(fe) if !fe.is_over => {
-                self.animator_play(cx, ids!(hover.off));
-            }
-            Hit::FingerUp(fe) => {
-                // A released hit clears all hovers, unless the mouse is still hovering over us
-                self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
             }
             Hit::FingerHoverIn(..) => {
-                self.animator_play(cx, ids!(hover.on));
                 // TODO: here, show the "action bar" buttons upon hover-in
             }
             Hit::FingerHoverOut(_fho) => {
-                self.animator_play(cx, ids!(hover.off));
                 // TODO: here, hide the "action bar" buttons upon hover-out
             }
             _ => { }
         }
 
         if let Event::Actions(actions) = event {
-            for action in actions {
-                if action.downcast_ref::<ContextMenuClosed>().is_some() {
-                    self.animator_play(cx, ids!(hover.off));
-                    continue;
-                }
+            // when the context menu overlay is closed, clear all hovers.
+            if self.is_context_menu_open
+                && actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some())
+            {
+                self.is_context_menu_open = false;
+                self.animator_play(cx, ids!(bg_hover.off));
+                self.button(cx, ids!(replied_to_message.reply_expand_button)).reset_hover(cx);
+                self.button(cx, ids!(replied_to_message.reply_collapse_button)).reset_hover(cx);
+                self.link_preview(cx, ids!(content.link_preview_view)).reset_hovers(cx);
+                self.html_or_plaintext(cx, ids!(content.message)).reset_link_hovers(cx);
+                let mut summary = self.thread_root_summary_view(cx);
+                script_apply_eval!(cx, summary, {
+                    draw_bg.color: #(COLOR_THREAD_SUMMARY_BG)
+                });
+                self.redraw(cx);
+            }
 
+            for action in actions {
                 match action.as_widget_action().widget_uid_eq(room_screen_widget_uid).cast_ref() {
                     MessageAction::HighlightMessage(id) if id == &self.details.as_ref().unwrap().item_id => { // guaranteed to be Some()
                         self.animator_play(cx, ids!(highlight.on));
@@ -5711,6 +5693,32 @@ impl Message {
         let reply = self.view.widget(cx, ids!(replied_to_message)).as_collapsible_preview();
         self.replied_to_message_view = Some(reply.clone());
         reply
+    }
+
+    /// Whether a click/tap at `abs` is within a child widget (within this message) that has its own hit behavior.
+    ///
+    /// This currently includes: reactions, download/share buttons, the read receipts row.
+    /// On long-presses specifically, it also excludes timestamps, edited indicators, and TSP sign indicators.
+    fn is_within_excluded_child(&self, cx: &mut Cx, abs: DVec2, is_long_press: bool) -> bool {
+        self.view.widget(cx, ids!(reaction_list)).area().clipped_rect(cx).contains(abs)
+            || self.view.widget(cx, ids!(avatar_row)).area().clipped_rect(cx).contains(abs)
+            || self.view.widget(cx, ids!(content.download_section)).area().clipped_rect(cx).contains(abs)
+            || (is_long_press && (
+                self.view.widget(cx, ids!(timestamp)).area().clipped_rect(cx).contains(abs)
+                || self.view.widget(cx, ids!(edited_indicator)).area().clipped_rect(cx).contains(abs)
+                || self.view.widget(cx, ids!(tsp_sign_indicator)).area().clipped_rect(cx).contains(abs)
+            ))
+    }
+
+    fn open_context_menu(&mut self, cx: &mut Cx, room_screen_widget_uid: WidgetUid, details: MessageDetails, abs_pos: DVec2) {
+        self.is_context_menu_open = true;
+        cx.widget_action(
+            room_screen_widget_uid,
+            MessageAction::OpenMessageContextMenu {
+                details,
+                abs_pos,
+            },
+        );
     }
 
     fn thread_root_summary_view(&mut self, cx: &mut Cx) -> ViewRef {

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -6,6 +6,7 @@ use crate::{
     shared::{
     avatar::AvatarWidgetExt,
         context_menu::ContextMenuClosed,
+        hover_highlight::handle_hover_hit,
         html_or_plaintext::HtmlOrPlaintextWidgetExt, unread_badge::UnreadBadgeWidgetExt as _,
     },
     utils::{self, relative_format}
@@ -172,7 +173,7 @@ script_mod! {
                     }
                 }
             }
-            hover: {
+            bg_hover: {
                 default: @off
                 off: AnimatorState{
                     from: {all: Snap}
@@ -315,6 +316,9 @@ pub struct RoomsListEntryContent {
 
     #[rust] room_id: Option<OwnedRoomId>,
 
+    /// `True` while a context menu that we opened is being shown.
+    #[rust] is_context_menu_open: bool,
+
     /// The preview colors that were last drawn for this entry.
     /// * Some(true): this entry was last drawn as selected.
     /// * Some(false): this entry was last drawn as not selected.
@@ -331,59 +335,44 @@ impl Widget for RoomsListEntryContent {
             self.redraw(cx);
         }
 
-        if let Event::Actions(actions) = event
+        if self.is_context_menu_open
+            && let Event::Actions(actions) = event
             && actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some())
         {
-            self.animator_play(cx, ids!(hover.off));
+            self.is_context_menu_open = false;
+            self.animator_play(cx, ids!(bg_hover.off));
         }
 
-        let uid = self.widget_uid();
-        let area = self.view.area();
         // We handle hits on this widget first to ensure that any clicks on it
         // will just select the room, rather than resulting in a click on any child view
         // within the RoomsListEntry content itself, such as links or avatars.
-        match event.hits(cx, area) {
-            Hit::FingerHoverIn(_) => {
-                self.animator_play(cx, ids!(hover.on));
-            }
-            Hit::FingerHoverOut(_) => {
-                self.animator_play(cx, ids!(hover.off));
-            }
-            // De-select it as soon as the finger isn't over us, e.g., a touch drag scroll.
-            Hit::FingerMove(fe) if !fe.is_over => {
-                self.animator_play(cx, ids!(hover.off));
-            }
-            Hit::FingerDown(fe) => {
-                self.animator_play(cx, ids!(hover.on));
-                cx.set_key_focus(area);
-                if fe.device.mouse_button().is_some_and(|b| b.is_secondary())
-                    && let Some(room_id) = self.room_id.as_ref()
-                {
+        if self.room_id.is_some() {
+            let uid = self.widget_uid();
+            let area = self.view.area();
+            let hit = handle_hover_hit(self, cx, event, area, self.is_context_menu_open);
+            match hit {
+                Hit::FingerDown(fe) => {
+                    cx.set_key_focus(area);
+                    if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
+                        self.is_context_menu_open = true;
+                        cx.widget_action(
+                            uid,
+                            RoomsListEntryAction::SecondaryClicked(self.room_id.clone().unwrap(), fe.abs),
+                        );
+                    }
+                }
+                Hit::FingerLongPress(fe) => {
+                    self.is_context_menu_open = true;
                     cx.widget_action(
                         uid,
-                        RoomsListEntryAction::SecondaryClicked(room_id.clone(), fe.abs),
+                        RoomsListEntryAction::SecondaryClicked(self.room_id.clone().unwrap(), fe.abs),
                     );
                 }
-            }
-            Hit::FingerLongPress(fe) => {
-                self.animator_play(cx, ids!(hover.on));
-                if let Some(room_id) = self.room_id.as_ref() {
-                    cx.widget_action(
-                        uid,
-                        RoomsListEntryAction::SecondaryClicked(room_id.clone(), fe.abs),
-                    );
+                Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
+                    cx.widget_action(uid, RoomsListEntryAction::PrimaryClicked(self.room_id.clone().unwrap()));
                 }
+                _ => { }
             }
-            Hit::FingerUp(fe) => {
-                if fe.is_over && fe.is_primary_hit() && fe.was_tap()
-                    && let Some(room_id) = self.room_id.as_ref()
-                {
-                    cx.widget_action(uid, RoomsListEntryAction::PrimaryClicked(room_id.clone()));
-                }
-                // A released hit clears all hovers, unless the mouse is still hovering over us
-                self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(hover.on), ids!(hover.off));
-            }
-            _ => { }
         }
 
         self.view.handle_event(cx, event, scope);

--- a/src/shared/hover_highlight.rs
+++ b/src/shared/hover_highlight.rs
@@ -1,0 +1,69 @@
+//! Shared logic for handling gray hover/press highlights for list items.
+
+use makepad_widgets::*;
+use makepad_widgets::makepad_platform::event::finger::TouchState;
+
+/// Hit-tests `area`, drives the widget's `hover` animator, and returns the hit.
+///
+/// Pass `true` for `keep_hovered` to leave the hover on even if it should be off.
+///
+/// Note the animator group is `bg_hover`, not `hover`: `View` drives its own
+/// `hover` group off any hit a child steals, which would fight us.
+pub fn handle_hover_hit<W: AnimatorImpl>(
+    widget: &mut W,
+    cx: &mut Cx,
+    event: &Event,
+    area: Area,
+    keep_hovered: bool,
+) -> Hit {
+    // Drive from the mouse position, not from hover hits: a child widget steals those,
+    // and scrolling slides us off the area the hover was recorded against.
+    if let Event::MouseMove(mm) = event {
+        let rect = area.clipped_rect(cx);
+        if !rect.contains(mm.abs) {
+            if !keep_hovered {
+                widget.animator_play(cx, ids!(bg_hover.off));
+            }
+        }
+        // Whatever claimed a move inside our rect is us or a child, unless it's
+        // layered on top, which is always bigger. Stay dark under a menu or modal.
+        else {
+            let claimed = mm.handled.get().rect(cx).size;
+            if claimed.x <= rect.size.x && claimed.y <= rect.size.y {
+                widget.animator_play(cx, ids!(bg_hover.on));
+            }
+        }
+    }
+
+    // Touch has no mouse moves, and a child may have captured the press, so our own
+    // FingerUp below can't be relied on. Any release ends the hover.
+    if !keep_hovered
+        && let Event::TouchUpdate(tu) = event
+        && tu.touches.iter().any(|t| t.state == TouchState::Stop)
+    {
+        widget.animator_play(cx, ids!(bg_hover.off));
+    }
+
+    let hit = event.hits(cx, area);
+    match &hit {
+        Hit::FingerHoverIn(_) | Hit::FingerDown(_) | Hit::FingerLongPress(_) => {
+            widget.animator_play(cx, ids!(bg_hover.on));
+        }
+        // Touch sends no mouse moves, so it needs the drag-off case handled here.
+        Hit::FingerMove(fe) if !keep_hovered && !fe.is_over => {
+            widget.animator_play(cx, ids!(bg_hover.off));
+        }
+        // A released hit clears all hovers, unless the mouse is still hovering over us.
+        Hit::FingerUp(fe) if !keep_hovered => {
+            widget.animator_toggle(
+                cx,
+                fe.device.has_hovers() && fe.is_over,
+                Animate::Yes,
+                ids!(bg_hover.on),
+                ids!(bg_hover.off),
+            );
+        }
+        _ => { }
+    }
+    hit
+}

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -785,6 +785,18 @@ impl HtmlOrPlaintext {
             }
         });
     }
+
+    /// Clears the hover highlight on every link, for when an overlay ate the hover-out.
+    pub fn reset_link_hovers(&mut self, cx: &mut Cx) {
+        let html_ref = self.html(cx, ids!(html_view.html));
+        let Some(html) = html_ref.borrow() else { return };
+        html.text_flow.children(&mut |_id, item| {
+            let Some(link) = item.borrow_mut::<RobrixHtmlLink>() else { return };
+            if let Some(mut html_link) = link.html_link(cx, ids!(html_link)).borrow_mut() {
+                html_link.animator_cut(cx, ids!(hover.off));
+            }
+        });
+    }
 }
 
 impl HtmlOrPlaintextRef {
@@ -806,6 +818,13 @@ impl HtmlOrPlaintextRef {
     pub fn set_link_color(&self, cx: &mut Cx, color: Option<Vec4>) {
         if let Some(mut inner) = self.borrow_mut() {
             inner.set_link_color(cx, color);
+        }
+    }
+
+    /// See [`HtmlOrPlaintext::reset_link_hovers()`].
+    pub fn reset_link_hovers(&self, cx: &mut Cx) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.reset_link_hovers(cx);
         }
     }
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -8,6 +8,7 @@ pub mod expand_arrow;
 pub mod confirmation_modal;
 pub mod file_upload_modal;
 pub mod helpers;
+pub mod hover_highlight;
 pub mod html_or_plaintext;
 pub mod icon_button;
 pub mod jump_to_bottom_button;

--- a/src/shared/styles.rs
+++ b/src/shared/styles.rs
@@ -146,8 +146,8 @@ script_mod! {
     mod.widgets.COLOR_SECONDARY = #E3E3E3
     mod.widgets.COLOR_SECONDARY_DARKER = #C8C8C8
 
-    // Shown behind a hovered or pressed list item: a rooms list entry, a timeline message.
-    mod.widgets.COLOR_LIST_ITEM_BG_HOVER = #f0f0f0
+    // What a rooms list entry or timeline message darkens to on hover or press.
+    mod.widgets.COLOR_LIST_ITEM_BG_HOVER = #f4f4f4
 
     mod.widgets.COLOR_ACTIVE_PRIMARY = #0f88fe
 


### PR DESCRIPTION
Now the rooms list entries also show a light gray bg when hovered over or pressed down on mobile.

We also finally fixed the minor issue where different parts of a message would handle hover states and long-press/right-click differently. Now that's all unified, such that you can hover into a subwidget within the message (like buttons, the reply preview, the thread root preview, etc) and the parent message widget will all still be highlighted. THis also applies to long-press/right-click behavior for a context menu: you can now do that gesture in any part of the message and it'll work like it should.

Also, when context menus are shown and then closed, we reset hover states since makepad doesn't emit a hover-out action on those cases.