### PR TITLE
Use makepad clear hover and widget ancestor touch stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "bit-vec",
 ]
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "bitflags"
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "bitmaps"
@@ -724,7 +724,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "byteorder"
@@ -735,7 +735,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "bytes"
@@ -794,7 +794,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "cfg_aliases"
@@ -805,7 +805,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "chacha20"
@@ -1142,7 +1142,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "crypto-bigint"
@@ -1522,7 +1522,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "dunce"
@@ -1630,7 +1630,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "errno"
@@ -1808,7 +1808,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "foreign-types"
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2198,7 +2198,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "hilog-sys"
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -2826,13 +2826,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "windows-link 0.2.1",
@@ -2906,7 +2906,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "loom"
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3058,22 +3058,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "weezl",
 ]
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3106,7 +3106,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "ttf-parser",
 ]
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3147,12 +3147,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3183,12 +3183,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3225,12 +3225,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3261,12 +3261,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "makepad-error-log",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "simd-adler32",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3752,7 +3752,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "mime"
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bit-set",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "num_cpus"
@@ -4163,7 +4163,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4452,7 +4452,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "pollster"
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "rustc-hash"
@@ -5506,7 +5506,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bytemuck",
@@ -5600,7 +5600,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "scopeguard"
@@ -5611,7 +5611,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "sealed"
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "siphasher"
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "socket2"
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "tungstenite"
@@ -6784,7 +6784,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-bidi"
@@ -6795,17 +6795,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-ident"
@@ -6816,7 +6816,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-normalization"
@@ -6836,12 +6836,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6852,7 +6852,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "unicode-xid"
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "log 0.4.29",
  "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "whoami"
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7460,7 +7460,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "windows-numerics"
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "bit-vec",
 ]
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "bitflags"
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "bitmaps"
@@ -724,7 +724,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "byteorder"
@@ -735,7 +735,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "bytes"
@@ -794,7 +794,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "cfg_aliases"
@@ -805,7 +805,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "chacha20"
@@ -1142,7 +1142,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "crypto-bigint"
@@ -1522,7 +1522,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "dunce"
@@ -1630,7 +1630,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "errno"
@@ -1808,7 +1808,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "foreign-types"
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2198,7 +2198,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "hilog-sys"
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -2826,13 +2826,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "windows-link 0.2.1",
@@ -2906,7 +2906,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "loom"
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3058,22 +3058,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "weezl",
 ]
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3106,7 +3106,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "ttf-parser",
 ]
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3147,12 +3147,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3183,12 +3183,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3225,12 +3225,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3261,12 +3261,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "makepad-error-log",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "simd-adler32",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3752,7 +3752,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "mime"
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bit-set",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "num_cpus"
@@ -4163,7 +4163,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4452,7 +4452,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "pollster"
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "rustc-hash"
@@ -5506,7 +5506,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bytemuck",
@@ -5600,7 +5600,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "scopeguard"
@@ -5611,7 +5611,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "sealed"
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "siphasher"
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "socket2"
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "tungstenite"
@@ -6784,7 +6784,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-bidi"
@@ -6795,17 +6795,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-ident"
@@ -6816,7 +6816,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-normalization"
@@ -6836,12 +6836,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6852,7 +6852,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "unicode-xid"
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "log 0.4.29",
  "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "whoami"
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7460,7 +7460,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "windows-numerics"
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#5374b74d9ea4d6ed45f94da3438bf1686a520796"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "bit-vec",
 ]
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "bitflags"
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "bitmaps"
@@ -724,7 +724,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "byteorder"
@@ -735,7 +735,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "bytes"
@@ -794,7 +794,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "cfg_aliases"
@@ -805,7 +805,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "chacha20"
@@ -1142,7 +1142,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "crypto-bigint"
@@ -1522,7 +1522,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "dunce"
@@ -1630,7 +1630,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "errno"
@@ -1808,7 +1808,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "foreign-types"
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2198,7 +2198,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "hilog-sys"
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -2826,13 +2826,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "windows-link 0.2.1",
@@ -2906,7 +2906,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "loom"
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3058,22 +3058,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "weezl",
 ]
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3106,7 +3106,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "ttf-parser",
 ]
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3147,12 +3147,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3183,12 +3183,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3225,12 +3225,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3261,12 +3261,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "makepad-error-log",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "simd-adler32",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3752,7 +3752,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "mime"
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bit-set",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "num_cpus"
@@ -4163,7 +4163,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4452,7 +4452,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "pollster"
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "rustc-hash"
@@ -5506,7 +5506,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bytemuck",
@@ -5600,7 +5600,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "scopeguard"
@@ -5611,7 +5611,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "sealed"
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "siphasher"
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "socket2"
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "tungstenite"
@@ -6784,7 +6784,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-bidi"
@@ -6795,17 +6795,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-ident"
@@ -6816,7 +6816,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-normalization"
@@ -6836,12 +6836,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6852,7 +6852,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "unicode-xid"
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "log 0.4.29",
  "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "whoami"
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7460,7 +7460,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "windows-numerics"
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#b59a4b3b5cf36f3186fefe0df3e1502ab5aaaefb"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#85b0d60a75f844c3b0deeb1572fb200eefd0bd17"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -584,7 +584,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "bit-vec",
 ]
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "bitflags"
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "bitmaps"
@@ -724,7 +724,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "byteorder"
@@ -735,7 +735,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "bytes"
@@ -794,7 +794,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "cfg_aliases"
@@ -805,7 +805,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "chacha20"
@@ -1142,7 +1142,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "crypto-bigint"
@@ -1522,7 +1522,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "dunce"
@@ -1630,7 +1630,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "errno"
@@ -1808,7 +1808,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "foreign-types"
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -2198,7 +2198,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "hilog-sys"
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -2826,13 +2826,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "windows-link 0.2.1",
@@ -2906,7 +2906,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "loom"
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3016,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3058,22 +3058,22 @@ dependencies = [
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "weezl",
 ]
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3106,7 +3106,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "ttf-parser",
 ]
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3131,7 +3131,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3147,12 +3147,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3183,12 +3183,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "ash",
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -3225,12 +3225,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3261,12 +3261,12 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "makepad-error-log",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "simd-adler32",
 ]
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3752,7 +3752,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "mime"
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bit-set",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "num_cpus"
@@ -4163,7 +4163,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4452,7 +4452,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "pollster"
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "rustc-hash"
@@ -5506,7 +5506,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
  "bytemuck",
@@ -5600,7 +5600,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "scopeguard"
@@ -5611,7 +5611,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "sealed"
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "siphasher"
@@ -5936,7 +5936,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "socket2"
@@ -5960,7 +5960,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6320,7 +6320,7 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
 ]
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "tungstenite"
@@ -6784,7 +6784,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-bidi"
@@ -6795,17 +6795,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-ident"
@@ -6816,7 +6816,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-normalization"
@@ -6836,12 +6836,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -6852,7 +6852,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "unicode-xid"
@@ -7178,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7190,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7200,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "log 0.4.29",
  "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes)",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "whoami"
@@ -7323,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7342,7 +7342,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7396,7 +7396,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7460,7 +7460,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "windows-numerics"
@@ -7504,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7521,7 +7521,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#80bf53c2f94e289041f801e14af001e26b709b50"
+source = "git+https://github.com/kevinaboos/makepad?branch=macos_android_fixes#1e9a74c198de127e13707def2cb3ca617f15442f"
 
 [[package]]
 name = "zerocopy-derive"

--- a/src/app.rs
+++ b/src/app.rs
@@ -346,9 +346,7 @@ impl MatchEvent for App {
                 continue;
             }
 
-            // Hide the tooltip when the context menu is closed (since we're clearing hovers).
             if action.downcast_ref::<ContextMenuClosed>().is_some() {
-                self.ui.callout_tooltip(cx, ids!(app_tooltip)).hide(cx);
                 continue;
             }
 

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -328,8 +328,7 @@ impl ReactionListRef {
         inner.timeline_event_id = Some(timeline_event_item_id.clone());
     }
 
-    /// Whether `abs` is within one of the reaction buttons.
-    /// The list is `width: Fill`, so testing its own area would be far too wide.
+    /// Returns `true` if the `abs` coord is within one of the reaction buttons.
     pub fn contains_button(&self, cx: &Cx, abs: DVec2) -> bool {
         let Some(inner) = self.borrow() else { return false };
         inner.children.iter().any(|(button, _)|

--- a/src/home/event_reaction_list.rs
+++ b/src/home/event_reaction_list.rs
@@ -133,7 +133,7 @@ impl Widget for ReactionList {
         for (button, _) in self.children.iter_mut() {
             let _ = button.draw(cx, scope);
         }
-        cx.end_turtle();
+        cx.end_turtle_with_area(&mut self.area);
         DrawStep::done()
     }
 
@@ -326,6 +326,15 @@ impl ReactionListRef {
         }
         inner.timeline_kind = Some(timeline_kind.clone());
         inner.timeline_event_id = Some(timeline_event_item_id.clone());
+    }
+
+    /// Whether `abs` is within one of the reaction buttons.
+    /// The list is `width: Fill`, so testing its own area would be far too wide.
+    pub fn contains_button(&self, cx: &Cx, abs: DVec2) -> bool {
+        let Some(inner) = self.borrow() else { return false };
+        inner.children.iter().any(|(button, _)|
+            button.area().clipped_rect(cx).contains(abs)
+        )
     }
 
     /// Returns any `RoomScreenTooltipActions` that occurred in the given list of `actions`.

--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -229,6 +229,14 @@ pub struct LinkPreview {
 
 impl Widget for LinkPreview {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if let Event::ClearHover = event {
+            for item in self.children.iter() {
+                reset_hover(cx, item);
+            }
+            self.view.button(cx, ids!(collapsible_buttons.expand_button)).reset_hover(cx);
+            self.view.button(cx, ids!(collapsible_buttons.collapse_button)).reset_hover(cx);
+        }
+
         // Handle collapsible button clicks
         if let Event::Actions(actions) = event {
             let expand_btn = self.view.button(cx, ids!(collapsible_buttons.expand_button));
@@ -310,16 +318,6 @@ impl LinkPreview {
 }
 
 impl LinkPreviewRef {
-    /// Clears the hover highlight on every preview card and the show more/fewer buttons.
-    pub fn reset_hovers(&self, cx: &mut Cx) {
-        let Some(inner) = self.borrow() else { return };
-        for item in inner.children.iter() {
-            reset_hover(cx, item);
-        }
-        inner.view.button(cx, ids!(collapsible_buttons.expand_button)).reset_hover(cx);
-        inner.view.button(cx, ids!(collapsible_buttons.collapse_button)).reset_hover(cx);
-    }
-
     /// Clears any displayed link preview(s), resetting this widget to its empty state.
     ///
     /// Needed for messages that never show link previews (e.g. redacted messages).

--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -229,6 +229,7 @@ pub struct LinkPreview {
 
 impl Widget for LinkPreview {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        // clear hovers on every link preview card and the show more/fewer buttons
         if let Event::ClearHover = event {
             for item in self.children.iter() {
                 reset_hover(cx, item);

--- a/src/home/new_message_context_menu.rs
+++ b/src/home/new_message_context_menu.rs
@@ -556,6 +556,7 @@ impl NewMessageContextMenu {
         cx.revert_key_focus();
         cx.unblock_scrolling();
         cx.action(ContextMenuClosed);
+        cx.clear_all_hovers();
         self.redraw(cx);
     }
 }

--- a/src/home/room_context_menu.rs
+++ b/src/home/room_context_menu.rs
@@ -270,6 +270,7 @@ impl RoomContextMenu {
         cx.revert_key_focus();
         cx.unblock_scrolling();
         cx.action(ContextMenuClosed);
+        cx.clear_all_hovers();
         self.redraw(cx);
     }
 }

--- a/src/home/room_read_receipt.rs
+++ b/src/home/room_read_receipt.rs
@@ -75,6 +75,7 @@ pub struct AvatarRow {
     label: Option<LabelRef>,
     /// The area of the widget
     #[redraw]
+    #[area]
     #[rust]
     area: Area,
     /// The read receipts for this row
@@ -127,12 +128,12 @@ impl Widget for AvatarRow {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        let Some(read_receipts) = &self.read_receipts else {
+        // Clear the area when we draw nothing, so a recycled row doesn't
+        // keep hit-testing against the previous message's avatars.
+        let Some(read_receipts) = self.read_receipts.as_ref().filter(|r| !r.is_empty()) else {
+            self.area = Area::Empty;
             return DrawStep::done();
         };
-        if read_receipts.is_empty() {
-            return DrawStep::done();
-        }
         cx.begin_turtle(walk, Layout::default());
         for (avatar_ref, _) in self.buttons.iter_mut() {
             let _ = avatar_ref.draw(cx, scope);

--- a/src/home/room_read_receipt.rs
+++ b/src/home/room_read_receipt.rs
@@ -128,9 +128,8 @@ impl Widget for AvatarRow {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        // Clear the area when we draw nothing, so a recycled row doesn't
-        // keep hit-testing against the previous message's avatars.
         let Some(read_receipts) = self.read_receipts.as_ref().filter(|r| !r.is_empty()) else {
+            // If we drew nothing, clear the widget's area
             self.area = Area::Empty;
             return DrawStep::done();
         };

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -5450,8 +5450,8 @@ pub struct Message {
     /// Cached so `set_data` can reset_hover only on the button that just
     /// transitioned into visibility, not on every redraw.
     #[rust] download_state: DownloadDisplayState,
-    /// Uid of the touch whose press was claimed by us or a descendant,
-    /// so a later raw `LongPress` can be attributed to this message.
+    /// The UID of the touch that was claimed by this message or one of its children.
+    /// This is used to determine if a future long press was on this message.
     #[rust] pressed_touch_uid: Option<u64>,
 
     // Belowhere: cached references to child widgets, for efficiency.
@@ -5483,7 +5483,7 @@ impl Widget for Message {
         let room_screen_widget_uid = d.room_screen_widget_uid;
         let thread_root_event_id = d.thread_root_event_id.clone();
 
-        // Claim state at our dispatch entry; any claim appearing after this came from within us.
+        // determine if any other ancestor widget has already claimed this pointer event.
         let claim_before = event.pointer_claimed_area();
 
         // A right-click or long-press anywhere on a message widget should show its context menu,
@@ -5540,8 +5540,8 @@ impl Widget for Message {
                     };
                     cx.widget_action(room_screen_widget_uid, action);
                 }
-                // We captured this press, so the body's hit test below won't see the
-                // release; settle here or a touch tap would leave us lit forever.
+                // since we already captured this finger-up, the hit test on the message body itself
+                // won't result in anything, so we have to un-set the hover here.
                 if !self.is_context_menu_open {
                     self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(bg_hover.on), ids!(bg_hover.off));
                 }
@@ -5637,11 +5637,8 @@ impl Widget for Message {
             }
         }
 
-        // Everything else resets itself on ClearHover; the thread summary's color
-        // is set imperatively, so it's ours to reset.
-        if let Event::ClearHover = event
-            && thread_root_event_id.is_some()
-        {
+        // TODO: use regular animator states for the thread root summary hover too.
+        if let Event::ClearHover = event && thread_root_event_id.is_some() {
             let mut summary = self.thread_root_summary_view(cx);
             script_apply_eval!(cx, summary, {
                 draw_bg.color: #(COLOR_THREAD_SUMMARY_BG)
@@ -5649,13 +5646,12 @@ impl Widget for Message {
         }
 
         if let Event::Actions(actions) = event {
-            if self.is_context_menu_open
-                && actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some())
-            {
-                self.is_context_menu_open = false;
-            }
-
             for action in actions {
+                if self.is_context_menu_open && action.downcast_ref::<ContextMenuClosed>().is_some() {
+                    self.is_context_menu_open = false;
+                    continue;
+                }
+
                 match action.as_widget_action().widget_uid_eq(room_screen_widget_uid).cast_ref() {
                     MessageAction::HighlightMessage(id) if id == &self.details.as_ref().unwrap().item_id => { // guaranteed to be Some()
                         self.animator_play(cx, ids!(highlight.on));
@@ -5776,11 +5772,8 @@ impl Message {
         let prev_section_visible = self.download_info.is_some();
         let prev_state = self.download_state;
 
-        // A reused widget may be given a different message while it holds hover
-        // state, the menu-open latch, or an in-flight press; none belong to the new message.
-        if self.details.as_ref()
-            .is_none_or(|d| d.timeline_event_id != details.timeline_event_id)
-        {
+        // If the message details changed, reset any UI state that belongs to the old message.
+        if self.details.as_ref().is_none_or(|d| d.timeline_event_id != details.timeline_event_id) {
             self.is_context_menu_open = false;
             self.pressed_touch_uid = None;
             self.animator_cut(cx, ids!(bg_hover.off));

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, cell::RefCell, ops::{DerefMut, Range}, sync::Arc};
 
 use hashbrown::{HashMap, HashSet};
 use imbl::Vector;
-use makepad_widgets::{image_cache::ImageBuffer, *};
+use makepad_widgets::{image_cache::ImageBuffer, makepad_platform::event::finger::TouchState, *};
 use matrix_sdk::reqwest::StatusCode;
 use matrix_sdk::{
     OwnedServerName, media::{MediaFormat, MediaRequestParameters}, room::RoomMember, ruma::{
@@ -27,13 +27,13 @@ use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, e
 
 use matrix_sdk_ui::sync_service::State;
 use crate::{
-    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetExt, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
         user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     },
     room::{BasicRoomDetails, reply_preview::{CollapsiblePreviewRef, CollapsiblePreviewWidgetRefExt}, room_input_bar::{RoomInputBarState, RoomInputBarWidgetRefExt}, typing_notice::TypingNoticeWidgetExt},
     shared::{
-        attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, TimelineUpdateSenderOption, TransferKind, media_source_mxc, start_attachment_download, start_attachment_share}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, context_menu::ContextMenuClosed, file_upload_modal::FileUploadAttemptId, hover_highlight::handle_hover_hit, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetExt, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuRef, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
+        attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, TimelineUpdateSenderOption, TransferKind, media_source_mxc, start_attachment_download, start_attachment_share}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, context_menu::ContextMenuClosed, file_upload_modal::FileUploadAttemptId, hover_highlight::handle_hover_hit, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuRef, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
     },
     sliding_sync::{BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, submit_async_request, take_timeline_endpoints}, utils::{self, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
 };
@@ -5450,6 +5450,9 @@ pub struct Message {
     /// Cached so `set_data` can reset_hover only on the button that just
     /// transitioned into visibility, not on every redraw.
     #[rust] download_state: DownloadDisplayState,
+    /// Uid of the touch whose press was claimed by us or a descendant,
+    /// so a later raw `LongPress` can be attributed to this message.
+    #[rust] pressed_touch_uid: Option<u64>,
 
     // Belowhere: cached references to child widgets, for efficiency.
     #[rust] replied_to_message_view: Option<CollapsiblePreviewRef>,
@@ -5480,6 +5483,9 @@ impl Widget for Message {
         let room_screen_widget_uid = d.room_screen_widget_uid;
         let thread_root_event_id = d.thread_root_event_id.clone();
 
+        // Claim state at our dispatch entry; any claim appearing after this came from within us.
+        let claim_before = event.pointer_claimed_area();
+
         // A right-click or long-press anywhere on a message widget should show its context menu,
         // so we have to handle the raw events instead of relying on the hit system.
         if let Event::MouseDown(mde) = event
@@ -5493,16 +5499,13 @@ impl Widget for Message {
             self.animator_play(cx, ids!(bg_hover.on));
             self.open_context_menu(cx, room_screen_widget_uid, details, mde.abs);
         }
-        else if let Event::LongPress(lpe) = event {
+        else if let Event::LongPress(lpe) = event
+            // the long press must've been claimed by us or a descendant on touch-down,
+            // which also rules out presses owned by an open context menu overlay.
+            && self.pressed_touch_uid == Some(lpe.uid)
+        {
             let msg_rect = self.view.area().clipped_rect(cx);
-            // the long press must've been captured by this message originally (on touch-down).
-            let capture_is_ours = cx.fingers.touch_capture_area(lpe.uid)
-                .is_none_or(|a| {
-                    let r = a.clipped_rect(cx);
-                    msg_rect.contains(r.pos) && msg_rect.contains(r.pos + r.size)
-                });
             if msg_rect.contains(lpe.abs)
-                && capture_is_ours
                 && !self.is_within_excluded_child(cx, lpe.abs, true)
             {
                 let details = d.clone();
@@ -5524,17 +5527,24 @@ impl Widget for Message {
             Hit::FingerDown(_) => {
                 self.animator_play(cx, ids!(bg_hover.on));
             }
-            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
-                // Tapping on a collapsed reply preview expands it.
-                // Tapping on an expanded reply preview jumps to the replied-to message.
-                let action = if reply.is_collapsed() {
-                    MessageAction::ToggleReplyPreviewExpanded(
-                        self.details.as_ref().unwrap().timeline_event_id.clone(), // guaranteed to be Some()
-                    )
-                } else {
-                    MessageAction::JumpToRelated(self.details.clone().unwrap()) // guaranteed to be Some()
-                };
-                cx.widget_action(room_screen_widget_uid, action);
+            Hit::FingerUp(fe) => {
+                if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
+                    // Tapping on a collapsed reply preview expands it.
+                    // Tapping on an expanded reply preview jumps to the replied-to message.
+                    let action = if reply.is_collapsed() {
+                        MessageAction::ToggleReplyPreviewExpanded(
+                            self.details.as_ref().unwrap().timeline_event_id.clone(), // guaranteed to be Some()
+                        )
+                    } else {
+                        MessageAction::JumpToRelated(self.details.clone().unwrap()) // guaranteed to be Some()
+                    };
+                    cx.widget_action(room_screen_widget_uid, action);
+                }
+                // We captured this press, so the body's hit test below won't see the
+                // release; settle here or a touch tap would leave us lit forever.
+                if !self.is_context_menu_open {
+                    self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(bg_hover.on), ids!(bg_hover.off));
+                }
             }
             _ => { }
         }
@@ -5570,6 +5580,11 @@ impl Widget for Message {
                 Hit::FingerUp(fe) => {
                     let still_hovered = fe.device.has_hovers() && fe.is_over;
                     apply_hover(cx, if still_hovered { COLOR_THREAD_SUMMARY_BG_HOVER } else { COLOR_THREAD_SUMMARY_BG });
+                    // Same as the reply preview: this press never reaches the body's
+                    // hit test, so settle the message highlight here too.
+                    if !self.is_context_menu_open {
+                        self.animator_toggle(cx, still_hovered, Animate::Yes, ids!(bg_hover.on), ids!(bg_hover.off));
+                    }
                     if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
                         cx.widget_action(
                             room_screen_widget_uid,
@@ -5590,7 +5605,7 @@ impl Widget for Message {
 
         // Finally, handle any hits on the rest of the message body itself.
         let message_view_area = self.view.area();
-        let body_hit = handle_hover_hit(self, cx, event, message_view_area, self.is_context_menu_open);
+        let body_hit = handle_hover_hit(self, cx, event, message_view_area, claim_before, self.is_context_menu_open);
         match body_hit {
             Hit::FingerDown(_) => {
                 cx.set_key_focus(message_view_area);
@@ -5604,22 +5619,40 @@ impl Widget for Message {
             _ => { }
         }
 
+        // All of our claim sites have run by now, so a press claimed since our
+        // entry snapshot came from within us; remember it for the LongPress guard.
+        if let Event::TouchUpdate(tue) = event {
+            for touch in &tue.touches {
+                match touch.state {
+                    TouchState::Start => {
+                        self.pressed_touch_uid = (claim_before.is_empty()
+                            && !touch.handled.get().is_empty())
+                            .then_some(touch.uid);
+                    }
+                    TouchState::Stop if self.pressed_touch_uid == Some(touch.uid) => {
+                        self.pressed_touch_uid = None;
+                    }
+                    _ => { }
+                }
+            }
+        }
+
+        // Everything else resets itself on ClearHover; the thread summary's color
+        // is set imperatively, so it's ours to reset.
+        if let Event::ClearHover = event
+            && thread_root_event_id.is_some()
+        {
+            let mut summary = self.thread_root_summary_view(cx);
+            script_apply_eval!(cx, summary, {
+                draw_bg.color: #(COLOR_THREAD_SUMMARY_BG)
+            });
+        }
+
         if let Event::Actions(actions) = event {
-            // when the context menu overlay is closed, clear all hovers.
             if self.is_context_menu_open
                 && actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some())
             {
                 self.is_context_menu_open = false;
-                self.animator_play(cx, ids!(bg_hover.off));
-                self.button(cx, ids!(replied_to_message.reply_expand_button)).reset_hover(cx);
-                self.button(cx, ids!(replied_to_message.reply_collapse_button)).reset_hover(cx);
-                self.link_preview(cx, ids!(content.link_preview_view)).reset_hovers(cx);
-                self.html_or_plaintext(cx, ids!(content.message)).reset_link_hovers(cx);
-                let mut summary = self.thread_root_summary_view(cx);
-                script_apply_eval!(cx, summary, {
-                    draw_bg.color: #(COLOR_THREAD_SUMMARY_BG)
-                });
-                self.redraw(cx);
             }
 
             for action in actions {
@@ -5700,7 +5733,7 @@ impl Message {
     /// This currently includes: reactions, download/share buttons, the read receipts row.
     /// On long-presses specifically, it also excludes timestamps, edited indicators, and TSP sign indicators.
     fn is_within_excluded_child(&self, cx: &mut Cx, abs: DVec2, is_long_press: bool) -> bool {
-        self.view.widget(cx, ids!(reaction_list)).area().clipped_rect(cx).contains(abs)
+        self.view.widget(cx, ids!(reaction_list)).as_reaction_list().contains_button(cx, abs)
             || self.view.widget(cx, ids!(avatar_row)).area().clipped_rect(cx).contains(abs)
             || self.view.widget(cx, ids!(content.download_section)).area().clipped_rect(cx).contains(abs)
             || (is_long_press && (
@@ -5742,6 +5775,16 @@ impl Message {
     ) {
         let prev_section_visible = self.download_info.is_some();
         let prev_state = self.download_state;
+
+        // A reused widget may be given a different message while it holds hover
+        // state, the menu-open latch, or an in-flight press; none belong to the new message.
+        if self.details.as_ref()
+            .is_none_or(|d| d.timeline_event_id != details.timeline_event_id)
+        {
+            self.is_context_menu_open = false;
+            self.pressed_touch_uid = None;
+            self.animator_cut(cx, ids!(bg_hover.off));
+        }
 
         self.details = Some(details);
         self.download_info = download_info;

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -1,5 +1,5 @@
 use makepad_widgets::*;
-use matrix_sdk::ruma::OwnedRoomId;
+use matrix_sdk::ruma::{OwnedRoomId, RoomId};
 
 use crate::{
     room::FetchedRoomAvatar,
@@ -316,8 +316,10 @@ pub struct RoomsListEntryContent {
 
     #[rust] room_id: Option<OwnedRoomId>,
 
-    /// `True` while a context menu that we opened is being shown.
+    /// `true` while a context menu that we opened is being shown.
     #[rust] is_context_menu_open: bool,
+    /// Whether this entry currently shows an invited (not joined) room.
+    #[rust] is_invited: bool,
 
     /// The preview colors that were last drawn for this entry.
     /// * Some(true): this entry was last drawn as selected.
@@ -340,36 +342,38 @@ impl Widget for RoomsListEntryContent {
             && actions.iter().any(|a| a.downcast_ref::<ContextMenuClosed>().is_some())
         {
             self.is_context_menu_open = false;
-            self.animator_play(cx, ids!(bg_hover.off));
         }
 
         // We handle hits on this widget first to ensure that any clicks on it
         // will just select the room, rather than resulting in a click on any child view
         // within the RoomsListEntry content itself, such as links or avatars.
-        if self.room_id.is_some() {
+        if let Some(room_id) = self.room_id.clone() {
             let uid = self.widget_uid();
             let area = self.view.area();
-            let hit = handle_hover_hit(self, cx, event, area, self.is_context_menu_open);
+            let claim_before = event.pointer_claimed_area();
+            let hit = handle_hover_hit(self, cx, event, area, claim_before, self.is_context_menu_open);
+            // Invited rooms have no context menu, so don't emit secondary clicks
+            // (nothing would consume them) or latch `is_context_menu_open`.
             match hit {
                 Hit::FingerDown(fe) => {
                     cx.set_key_focus(area);
-                    if fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
+                    if !self.is_invited && fe.device.mouse_button().is_some_and(|b| b.is_secondary()) {
                         self.is_context_menu_open = true;
                         cx.widget_action(
                             uid,
-                            RoomsListEntryAction::SecondaryClicked(self.room_id.clone().unwrap(), fe.abs),
+                            RoomsListEntryAction::SecondaryClicked(room_id, fe.abs),
                         );
                     }
                 }
-                Hit::FingerLongPress(fe) => {
+                Hit::FingerLongPress(fe) if !self.is_invited => {
                     self.is_context_menu_open = true;
                     cx.widget_action(
                         uid,
-                        RoomsListEntryAction::SecondaryClicked(self.room_id.clone().unwrap(), fe.abs),
+                        RoomsListEntryAction::SecondaryClicked(room_id, fe.abs),
                     );
                 }
                 Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
-                    cx.widget_action(uid, RoomsListEntryAction::PrimaryClicked(self.room_id.clone().unwrap()));
+                    cx.widget_action(uid, RoomsListEntryAction::PrimaryClicked(room_id));
                 }
                 _ => { }
             }
@@ -380,10 +384,10 @@ impl Widget for RoomsListEntryContent {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         if let Some(joined_room_info) = scope.props.get::<JoinedRoomInfo>() {
-            self.room_id = Some(joined_room_info.room_name_id.room_id().clone());
+            self.set_room(cx, joined_room_info.room_name_id.room_id(), false);
             self.draw_joined_room(cx, joined_room_info);
         } else if let Some(invited_room_info) = scope.props.get::<InvitedRoomInfo>() {
-            self.room_id = Some(invited_room_info.room_name_id.room_id().clone());
+            self.set_room(cx, invited_room_info.room_name_id.room_id(), true);
             self.draw_invited_room(cx, invited_room_info);
         }
 
@@ -392,6 +396,17 @@ impl Widget for RoomsListEntryContent {
 }
 
 impl RoomsListEntryContent {
+    /// A reused widget may be given a different room while it holds hover state
+    /// or the menu-open latch; neither belongs to the new room.
+    fn set_room(&mut self, cx: &mut Cx, room_id: &RoomId, is_invited: bool) {
+        if self.room_id.as_deref() != Some(room_id) {
+            self.is_context_menu_open = false;
+            self.animator_cut(cx, ids!(bg_hover.off));
+            self.room_id = Some(room_id.to_owned());
+        }
+        self.is_invited = is_invited;
+    }
+
     /// Populates this RoomsListEntry with info about a joined room.
     pub fn draw_joined_room(
         &mut self,

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -352,8 +352,8 @@ impl Widget for RoomsListEntryContent {
             let area = self.view.area();
             let claim_before = event.pointer_claimed_area();
             let hit = handle_hover_hit(self, cx, event, area, claim_before, self.is_context_menu_open);
-            // Invited rooms have no context menu, so don't emit secondary clicks
-            // (nothing would consume them) or latch `is_context_menu_open`.
+            // TODO: Invited rooms have no context menu, so don't emit secondary clicks.
+            //       We should add a context menu for invited rooms.
             match hit {
                 Hit::FingerDown(fe) => {
                     cx.set_key_focus(area);
@@ -396,9 +396,8 @@ impl Widget for RoomsListEntryContent {
 }
 
 impl RoomsListEntryContent {
-    /// A reused widget may be given a different room while it holds hover state
-    /// or the menu-open latch; neither belongs to the new room.
     fn set_room(&mut self, cx: &mut Cx, room_id: &RoomId, is_invited: bool) {
+        // If the room ID changed, reset any UI state that belongs to the previous room.
         if self.room_id.as_deref() != Some(room_id) {
             self.is_context_menu_open = false;
             self.animator_cut(cx, ids!(bg_hover.off));

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -162,7 +162,7 @@ script_mod! {
         }
 
         animator: Animator{
-            hover: {
+            bg_hover: {
                 default: @off
                 off: AnimatorState{
                     from: {all: Forward {duration: 0.15}}
@@ -270,7 +270,7 @@ script_mod! {
         draw_bg +: {
             hover: instance(0.0)
             color: instance(#fff)
-            color_hover: instance(#f5f5f5)
+            color_hover: instance(COLOR_LIST_ITEM_BG_HOVER)
             pixel: fn() {
                 return mix(self.color, self.color_hover, self.hover);
             }
@@ -399,7 +399,7 @@ script_mod! {
         tree_lines := mod.widgets.TreeLines {}
 
         animator: Animator{
-            hover: {
+            bg_hover: {
                 default: @off
                 off: AnimatorState{ from: {all: Forward {duration: 0.1}}, apply: { draw_bg: {hover: 0.0} } }
                 on: AnimatorState{ from: {all: Snap}, apply: { draw_bg: {hover: 1.0} } }
@@ -633,28 +633,34 @@ impl Widget for SpaceLobbyEntry {
             self.redraw(cx);
         }
 
+        if let Event::ClearHover = event {
+            self.animator_play(cx, ids!(bg_hover.off));
+        }
+
         let area = self.draw_bg.area();
         match event.hits(cx, area) {
             Hit::FingerHoverIn(_) => {
-                self.animator_play(cx, ids!(hover.on));
+                self.animator_play(cx, ids!(bg_hover.on));
             }
             Hit::FingerHoverOut(_) => {
-                self.animator_play(cx, ids!(hover.off));
+                self.animator_play(cx, ids!(bg_hover.off));
             }
             Hit::FingerDown(_fe) => {
-                self.animator_play(cx, ids!(hover.down));
+                self.animator_play(cx, ids!(bg_hover.down));
             }
             Hit::FingerLongPress(_lp) => {
-                self.animator_play(cx, ids!(hover.down));
+                self.animator_play(cx, ids!(bg_hover.down));
             }
-            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
-                self.animator_play(cx, ids!(hover.on));
-                cx.action(SpaceLobbyAction::SpaceLobbyEntryClicked);
+            Hit::FingerMove(fe) if !fe.is_over => {
+                self.animator_play(cx, ids!(bg_hover.off));
             }
-            Hit::FingerUp(fe) if !fe.is_over => {
-                self.animator_play(cx, ids!(hover.off));
+            Hit::FingerUp(fe) => {
+                if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
+                    cx.action(SpaceLobbyAction::SpaceLobbyEntryClicked);
+                }
+                // A released hit clears all hovers, unless the mouse is still hovering over us.
+                self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(bg_hover.on), ids!(bg_hover.off));
             }
-            Hit::FingerMove(_fe) => { }
             _ => {}
         }
     }
@@ -754,6 +760,12 @@ impl Widget for SubspaceEntry {
             self.redraw(cx);
         }
 
+        if let Event::ClearHover = event
+            && !self.buttons_shown_by_tap
+        {
+            self.animator_play(cx, ids!(bg_hover.off));
+        }
+
         // NOTE: Use child_by_path instead of widget tree-based lookups
         //       (e.g., self.view.view(), self.view.button()) because these
         //       fail for portal list items.
@@ -764,7 +776,7 @@ impl Widget for SubspaceEntry {
             rect.contains(abs) && !(are_buttons_visible && buttons_view_rect.contains(abs))
         }) {
             Hit::FingerHoverIn(_) => {
-                self.animator_play(cx, ids!(hover.on));
+                self.animator_play(cx, ids!(bg_hover.on));
                 if !self.show_buttons_view {
                     self.show_buttons_view = true;
                     self.buttons_shown_by_tap = false;
@@ -775,7 +787,7 @@ impl Widget for SubspaceEntry {
             // Occasionally there's an issue with Makepad hover events where hover in/out
             // doesn't work as expected, so we double-check here.
             Hit::FingerHoverOver(_) if !self.show_buttons_view => {
-                self.animator_play(cx, ids!(hover.on));
+                self.animator_play(cx, ids!(bg_hover.on));
                 self.show_buttons_view = true;
                 self.buttons_shown_by_tap = false;
                 self.view.child_by_path(ids!(buttons_view)).set_visible(cx, true);
@@ -788,7 +800,7 @@ impl Widget for SubspaceEntry {
                 let entry_rect = self.view.area().rect(cx);
                 let is_over_buttons_view = self.show_buttons_view && buttons_view_rect.contains(fe.abs);
                 if !entry_rect.contains(fe.abs) && !is_over_buttons_view {
-                    self.animator_play(cx, ids!(hover.off));
+                    self.animator_play(cx, ids!(bg_hover.off));
                     self.show_buttons_view = false;
                     self.buttons_shown_by_tap = false;
                     self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
@@ -796,12 +808,20 @@ impl Widget for SubspaceEntry {
                 }
             }
             Hit::FingerDown(_) => {
+                self.animator_play(cx, ids!(bg_hover.on));
                 cx.set_key_focus(self.view.area());
             }
-            Hit::FingerUp(fe) if fe.is_over && fe.is_primary_hit() && fe.was_tap() => {
+            Hit::FingerMove(fe) if !fe.is_over && !self.buttons_shown_by_tap => {
+                self.animator_play(cx, ids!(bg_hover.off));
+            }
+            Hit::FingerUp(fe) => {
+                let is_tap = fe.is_over && fe.is_primary_hit() && fe.was_tap();
                 let is_within_buttons_view = self.show_buttons_view
                     && self.view.child_by_path(ids!(buttons_view)).area().rect(cx).contains(fe.abs);
-                if is_within_buttons_view {
+                if !is_tap {
+                    // Not a tap: nothing to activate, just settle the hover below.
+                }
+                else if is_within_buttons_view {
                     // Let individual button handlers deal with taps on the buttons.
                 }
                 // On touch devices, tapping on the avatar or to its left
@@ -847,6 +867,13 @@ impl Widget for SubspaceEntry {
                             SubspaceEntryAction::RoomClicked { room_id: room_id.clone() },
                         );
                     }
+                }
+                // A released hit clears all hovers, unless the mouse is still over
+                // us (the buttons_view counts, though our hit test excludes it)
+                // or the buttons were just toggled visible by this tap.
+                if !self.buttons_shown_by_tap {
+                    let still_over = fe.is_over || is_within_buttons_view;
+                    self.animator_toggle(cx, fe.device.has_hovers() && still_over, Animate::Yes, ids!(bg_hover.on), ids!(bg_hover.off));
                 }
             }
             _ => {}
@@ -898,12 +925,12 @@ impl SubspaceEntry {
     /// Toggles the buttons_view visibility for a touch tap.
     fn toggle_buttons_for_tap(&mut self, cx: &mut Cx) {
         if self.show_buttons_view {
-            self.animator_play(cx, ids!(hover.off));
+            self.animator_play(cx, ids!(bg_hover.off));
             self.show_buttons_view = false;
             self.buttons_shown_by_tap = false;
             self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
         } else {
-            self.animator_play(cx, ids!(hover.on));
+            self.animator_play(cx, ids!(bg_hover.on));
             self.show_buttons_view = true;
             self.buttons_shown_by_tap = true;
             self.view.child_by_path(ids!(buttons_view)).set_visible(cx, true);

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -770,14 +770,14 @@ impl Widget for SubspaceEntry {
         //       (e.g., self.view.view(), self.view.button()) because these
         //       fail for portal list items.
         let buttons_view_ref = self.view.child_by_path(ids!(buttons_view));
-        let buttons_view_rect = buttons_view_ref.area().rect(cx);
+        // Clipped, to match the rect the hit system itself tests against.
+        let buttons_view_rect = buttons_view_ref.area().clipped_rect(cx);
 
         // While the pointer is over our buttons we aren't makepad's hover owner,
         // so it never tells us when the pointer leaves us for another entry.
         if let Event::MouseMove(mm) = event
-            && self.show_buttons_view
             && !self.buttons_shown_by_tap
-            && !self.view.area().rect(cx).contains(mm.abs)
+            && !self.view.area().clipped_rect(cx).contains(mm.abs)
             && !buttons_view_rect.contains(mm.abs)
         {
             self.unhover(cx);
@@ -933,6 +933,10 @@ impl SubspaceEntry {
     /// Clears the hover highlight and hides the buttons.
     fn unhover(&mut self, cx: &mut Cx) {
         self.animator_play(cx, ids!(bg_hover.off));
+        // The highlight can be on without the buttons, so only tear those down once.
+        if !self.show_buttons_view {
+            return;
+        }
         self.show_buttons_view = false;
         self.buttons_shown_by_tap = false;
         self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
@@ -1267,6 +1271,7 @@ impl Widget for SpaceLobbyScreen {
                                     if id_changed {
                                         inner.show_buttons_view = false;
                                         inner.buttons_shown_by_tap = false;
+                                        inner.animator_cut(cx, ids!(bg_hover.off));
                                     }
                                     show_buttons_view = inner.show_buttons_view;
                                 }
@@ -1289,6 +1294,7 @@ impl Widget for SpaceLobbyScreen {
                                     if id_changed {
                                         inner.show_buttons_view = false;
                                         inner.buttons_shown_by_tap = false;
+                                        inner.animator_cut(cx, ids!(bg_hover.off));
                                     }
                                     show_buttons_view = inner.show_buttons_view;
                                 }

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -18,6 +18,7 @@ use ruma::{OwnedRoomAliasId, room::JoinRuleSummary};
 use tokio::sync::mpsc::UnboundedSender;
 use crate::shared::avatar::{AvatarImage, AvatarState};
 use crate::shared::expand_arrow::ExpandArrow;
+use crate::shared::hover_highlight::handle_hover_hit_with_test;
 use crate::utils::replace_linebreaks_separators;
 /// The horizontal indent width (in pixels) per tree level.
 const TREE_INDENT_WIDTH: f64 = 44.0;
@@ -760,67 +761,41 @@ impl Widget for SubspaceEntry {
             self.redraw(cx);
         }
 
-        if let Event::ClearHover = event
-            && !self.buttons_shown_by_tap
-        {
-            self.animator_play(cx, ids!(bg_hover.off));
-        }
-
         // NOTE: Use child_by_path instead of widget tree-based lookups
         //       (e.g., self.view.view(), self.view.button()) because these
         //       fail for portal list items.
-        let buttons_view_ref = self.view.child_by_path(ids!(buttons_view));
-        // Clipped, to match the rect the hit system itself tests against.
-        let buttons_view_rect = buttons_view_ref.area().clipped_rect(cx);
-
-        // While the pointer is over our buttons we aren't makepad's hover owner,
-        // so it never tells us when the pointer leaves us for another entry.
-        if let Event::MouseMove(mm) = event
-            && !self.buttons_shown_by_tap
-            && !self.view.area().clipped_rect(cx).contains(mm.abs)
-            && !buttons_view_rect.contains(mm.abs)
-        {
-            self.unhover(cx);
-        }
-
+        let buttons_view_rect = self.view.child_by_path(ids!(buttons_view)).area().clipped_rect(cx);
         let are_buttons_visible = self.show_buttons_view;
-        match event.hits_with_test(cx, self.view.area(), |abs, rect, _| {
-            rect.contains(abs) && !(are_buttons_visible && buttons_view_rect.contains(abs))
-        }) {
-            Hit::FingerHoverIn(_) => {
-                self.animator_play(cx, ids!(bg_hover.on));
-                if !self.show_buttons_view {
-                    self.show_buttons_view = true;
-                    self.buttons_shown_by_tap = false;
-                    self.view.child_by_path(ids!(buttons_view)).set_visible(cx, true);
-                    self.redraw(cx);
-                }
-            }
-            // Occasionally there's an issue with Makepad hover events where hover in/out
-            // doesn't work as expected, so we double-check here.
-            Hit::FingerHoverOver(_) if !self.show_buttons_view => {
-                self.animator_play(cx, ids!(bg_hover.on));
-                self.show_buttons_view = true;
-                self.buttons_shown_by_tap = false;
-                self.view.child_by_path(ids!(buttons_view)).set_visible(cx, true);
+        let claim_before = event.pointer_claimed_area();
+
+        // Excluding the buttons from the hit test leaves them free to claim their
+        // own hover and presses; our highlight comes from the positional pass.
+        let hit = handle_hover_hit_with_test(
+            self,
+            cx,
+            event,
+            self.view.area(),
+            claim_before,
+            self.buttons_shown_by_tap,
+            |abs, rect, _| rect.contains(abs) && !(are_buttons_visible && buttons_view_rect.contains(abs)),
+        );
+
+        // The buttons follow the mouse highlight. Touch drives them through
+        // `buttons_shown_by_tap` instead, so a touch-down must not show them.
+        if matches!(event, Event::MouseMove(_) | Event::ClearHover)
+            && !self.buttons_shown_by_tap
+        {
+            let lit = self.animator_in_state(cx, ids!(bg_hover.on));
+            if lit != self.show_buttons_view {
+                self.show_buttons_view = lit;
+                self.view.child_by_path(ids!(buttons_view)).set_visible(cx, lit);
                 self.redraw(cx);
             }
-            Hit::FingerHoverOut(fe) => {
-                // When the mouse moves from the main SubspaceEntry area into the buttons_view,
-                // Makepad emits a HoverOut hit, but we don't want that to actually count as a hover-out
-                // because the mouse is still hovering over the buttons_view.
-                let entry_rect = self.view.area().rect(cx);
-                let is_over_buttons_view = self.show_buttons_view && buttons_view_rect.contains(fe.abs);
-                if !entry_rect.contains(fe.abs) && !is_over_buttons_view {
-                    self.unhover(cx);
-                }
-            }
+        }
+
+        match hit {
             Hit::FingerDown(_) => {
-                self.animator_play(cx, ids!(bg_hover.on));
                 cx.set_key_focus(self.view.area());
-            }
-            Hit::FingerMove(fe) if !fe.is_over && !self.buttons_shown_by_tap => {
-                self.animator_play(cx, ids!(bg_hover.off));
             }
             Hit::FingerUp(fe) => {
                 let is_tap = fe.is_over && fe.is_primary_hit() && fe.was_tap();
@@ -931,22 +906,14 @@ impl Widget for SubspaceEntry {
 
 impl SubspaceEntry {
     /// Clears the hover highlight and hides the buttons.
-    fn unhover(&mut self, cx: &mut Cx) {
-        self.animator_play(cx, ids!(bg_hover.off));
-        // The highlight can be on without the buttons, so only tear those down once.
-        if !self.show_buttons_view {
-            return;
-        }
-        self.show_buttons_view = false;
-        self.buttons_shown_by_tap = false;
-        self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
-        self.redraw(cx);
-    }
-
     /// Toggles the buttons_view visibility for a touch tap.
     fn toggle_buttons_for_tap(&mut self, cx: &mut Cx) {
         if self.show_buttons_view {
-            self.unhover(cx);
+            self.animator_play(cx, ids!(bg_hover.off));
+            self.show_buttons_view = false;
+            self.buttons_shown_by_tap = false;
+            self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
+            self.redraw(cx);
         } else {
             self.animator_play(cx, ids!(bg_hover.on));
             self.show_buttons_view = true;

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -659,7 +659,7 @@ impl Widget for SpaceLobbyEntry {
                 if fe.is_over && fe.is_primary_hit() && fe.was_tap() {
                     cx.action(SpaceLobbyAction::SpaceLobbyEntryClicked);
                 }
-                // A released hit clears all hovers, unless the mouse is still hovering over us.
+                // A finger-up clears all hovers unless the mouse is still over us.
                 self.animator_toggle(cx, fe.device.has_hovers() && fe.is_over, Animate::Yes, ids!(bg_hover.on), ids!(bg_hover.off));
             }
             _ => {}
@@ -768,8 +768,7 @@ impl Widget for SubspaceEntry {
         let are_buttons_visible = self.show_buttons_view;
         let claim_before = event.pointer_claimed_area();
 
-        // Excluding the buttons from the hit test leaves them free to claim their
-        // own hover and presses; our highlight comes from the positional pass.
+        // We exclude the buttons from the hit test so that they can handle their own hits.
         let hit = handle_hover_hit_with_test(
             self,
             cx,
@@ -780,15 +779,14 @@ impl Widget for SubspaceEntry {
             |abs, rect, _| rect.contains(abs) && !(are_buttons_visible && buttons_view_rect.contains(abs)),
         );
 
-        // The buttons follow the mouse highlight. Touch drives them through
-        // `buttons_shown_by_tap` instead, so a touch-down must not show them.
+        // Show buttons based on the mouse hover (if they're not shown via a prior touch tap).
         if matches!(event, Event::MouseMove(_) | Event::ClearHover)
             && !self.buttons_shown_by_tap
         {
-            let lit = self.animator_in_state(cx, ids!(bg_hover.on));
-            if lit != self.show_buttons_view {
-                self.show_buttons_view = lit;
-                self.view.child_by_path(ids!(buttons_view)).set_visible(cx, lit);
+            let is_hovered = self.animator_in_state(cx, ids!(bg_hover.on));
+            if is_hovered != self.show_buttons_view {
+                self.show_buttons_view = is_hovered;
+                self.view.child_by_path(ids!(buttons_view)).set_visible(cx, is_hovered);
                 self.redraw(cx);
             }
         }
@@ -802,7 +800,7 @@ impl Widget for SubspaceEntry {
                 let is_within_buttons_view = self.show_buttons_view
                     && self.view.child_by_path(ids!(buttons_view)).area().rect(cx).contains(fe.abs);
                 if !is_tap {
-                    // Not a tap: nothing to activate, just settle the hover below.
+                    // if it's not a tap, do nothing.
                 }
                 else if is_within_buttons_view {
                     // Let individual button handlers deal with taps on the buttons.
@@ -851,9 +849,7 @@ impl Widget for SubspaceEntry {
                         );
                     }
                 }
-                // A released hit clears all hovers, unless the mouse is still over
-                // us (the buttons_view counts, though our hit test excludes it)
-                // or the buttons were just toggled visible by this tap.
+                // A finger-up clears all hovers, unless the mouse is still over us (including the button view).
                 if !self.buttons_shown_by_tap {
                     let still_over = fe.is_over || is_within_buttons_view;
                     self.animator_toggle(cx, fe.device.has_hovers() && still_over, Animate::Yes, ids!(bg_hover.on), ids!(bg_hover.off));

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -771,6 +771,18 @@ impl Widget for SubspaceEntry {
         //       fail for portal list items.
         let buttons_view_ref = self.view.child_by_path(ids!(buttons_view));
         let buttons_view_rect = buttons_view_ref.area().rect(cx);
+
+        // While the pointer is over our buttons we aren't makepad's hover owner,
+        // so it never tells us when the pointer leaves us for another entry.
+        if let Event::MouseMove(mm) = event
+            && self.show_buttons_view
+            && !self.buttons_shown_by_tap
+            && !self.view.area().rect(cx).contains(mm.abs)
+            && !buttons_view_rect.contains(mm.abs)
+        {
+            self.unhover(cx);
+        }
+
         let are_buttons_visible = self.show_buttons_view;
         match event.hits_with_test(cx, self.view.area(), |abs, rect, _| {
             rect.contains(abs) && !(are_buttons_visible && buttons_view_rect.contains(abs))
@@ -800,11 +812,7 @@ impl Widget for SubspaceEntry {
                 let entry_rect = self.view.area().rect(cx);
                 let is_over_buttons_view = self.show_buttons_view && buttons_view_rect.contains(fe.abs);
                 if !entry_rect.contains(fe.abs) && !is_over_buttons_view {
-                    self.animator_play(cx, ids!(bg_hover.off));
-                    self.show_buttons_view = false;
-                    self.buttons_shown_by_tap = false;
-                    self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
-                    self.redraw(cx);
+                    self.unhover(cx);
                 }
             }
             Hit::FingerDown(_) => {
@@ -922,20 +930,26 @@ impl Widget for SubspaceEntry {
 }
 
 impl SubspaceEntry {
+    /// Clears the hover highlight and hides the buttons.
+    fn unhover(&mut self, cx: &mut Cx) {
+        self.animator_play(cx, ids!(bg_hover.off));
+        self.show_buttons_view = false;
+        self.buttons_shown_by_tap = false;
+        self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
+        self.redraw(cx);
+    }
+
     /// Toggles the buttons_view visibility for a touch tap.
     fn toggle_buttons_for_tap(&mut self, cx: &mut Cx) {
         if self.show_buttons_view {
-            self.animator_play(cx, ids!(bg_hover.off));
-            self.show_buttons_view = false;
-            self.buttons_shown_by_tap = false;
-            self.view.child_by_path(ids!(buttons_view)).set_visible(cx, false);
+            self.unhover(cx);
         } else {
             self.animator_play(cx, ids!(bg_hover.on));
             self.show_buttons_view = true;
             self.buttons_shown_by_tap = true;
             self.view.child_by_path(ids!(buttons_view)).set_visible(cx, true);
+            self.redraw(cx);
         }
-        self.redraw(cx);
     }
 }
 

--- a/src/shared/hover_highlight.rs
+++ b/src/shared/hover_highlight.rs
@@ -2,9 +2,12 @@
 
 use makepad_widgets::*;
 
-/// Hit-tests `area`, drives the widget's `bg_hover` animator, and returns the hit.
-/// `claim_before` is `event.pointer_claimed_area()` snapshotted at the widget's handle_event entry.
-/// Pass `true` for `keep_hovered` to leave the hover on even if it should be off.
+/// Hit-tests the given `area`, drives the widget's `bg_hover` animator, and returns the hit.
+///
+/// The `claim_before` area should come from `event.pointer_claimed_area()`, which should've been
+/// obtained *before* the widget forwarded the event to its children (e.g., at the start of `handle_event()`).
+///
+/// If `keep_hovered` is `true`, the hover will be left on even if the hit-test says it should be off.
 pub fn handle_hover_hit<W: AnimatorImpl>(
     widget: &mut W,
     cx: &mut Cx,
@@ -26,8 +29,8 @@ pub fn handle_hover_hit<W: AnimatorImpl>(
 
 /// Same as [`handle_hover_hit()`], but with a custom hit test.
 ///
-/// The test only narrows the returned hit; the highlight still covers the whole
-/// `area`, so a child that owns the pointer can't darken us.
+/// The `hit_test` fn only narrows the returned hit, it doesn't affect
+/// the area that may be hovered.
 pub fn handle_hover_hit_with_test<W: AnimatorImpl, F>(
     widget: &mut W,
     cx: &mut Cx,
@@ -40,9 +43,10 @@ pub fn handle_hover_hit_with_test<W: AnimatorImpl, F>(
 where
     F: Fn(Vec2d, &Rect, &Option<Inset>) -> bool,
 {
-    // Hover hits go to exactly one widget, so a child claiming them would leave
-    // us dark (or stuck lit). Instead, light up whenever the pointer rests inside
-    // us and any claim on it appeared during our own dispatch (us or a child).
+    // A hover hit can only be delivered to exactly one widget, so if a child claimed it
+    // then that would leave the given `widget` not hovered.
+    // Here, we want to activate the hover for the widget even if a child claimed it,
+    // but not if an ancestor widget claimed it.
     if let Event::MouseMove(mm) = event {
         let rect = area.clipped_rect(cx);
         if !rect.contains(mm.abs) {
@@ -53,15 +57,12 @@ where
             if claim_before.is_empty() {
                 widget.animator_play(cx, ids!(bg_hover.on));
             } else if !keep_hovered {
-                // A claim predating our dispatch means an overlay above us owns the pointer.
                 widget.animator_play(cx, ids!(bg_hover.off));
             }
         }
     }
 
-    if let Event::ClearHover = event
-        && !keep_hovered
-    {
+    if let Event::ClearHover = event && !keep_hovered {
         widget.animator_play(cx, ids!(bg_hover.off));
     }
 
@@ -70,7 +71,6 @@ where
         Hit::FingerHoverIn(_) | Hit::FingerDown(_) | Hit::FingerLongPress(_) => {
             widget.animator_play(cx, ids!(bg_hover.on));
         }
-        // Touch sends no mouse moves, so a drag off of us is handled here.
         Hit::FingerMove(fe) if !keep_hovered && !fe.is_over => {
             widget.animator_play(cx, ids!(bg_hover.off));
         }

--- a/src/shared/hover_highlight.rs
+++ b/src/shared/hover_highlight.rs
@@ -13,6 +13,27 @@ pub fn handle_hover_hit<W: AnimatorImpl>(
     claim_before: Area,
     keep_hovered: bool,
 ) -> Hit {
+    handle_hover_hit_with_test(widget, cx, event, area, claim_before, keep_hovered,
+        |abs, rect, inset| Inset::rect_contains_with_inset(abs, rect, inset),
+    )
+}
+
+/// Same as [`handle_hover_hit()`], but with a custom hit test.
+///
+/// The test only narrows the returned hit; the highlight still covers the whole
+/// `area`, so a child that owns the pointer can't darken us.
+pub fn handle_hover_hit_with_test<W: AnimatorImpl, F>(
+    widget: &mut W,
+    cx: &mut Cx,
+    event: &Event,
+    area: Area,
+    claim_before: Area,
+    keep_hovered: bool,
+    hit_test: F,
+) -> Hit
+where
+    F: Fn(Vec2d, &Rect, &Option<Inset>) -> bool,
+{
     // Hover hits go to exactly one widget, so a child claiming them would leave
     // us dark (or stuck lit). Instead, light up whenever the pointer rests inside
     // us and any claim on it appeared during our own dispatch (us or a child).
@@ -38,7 +59,7 @@ pub fn handle_hover_hit<W: AnimatorImpl>(
         widget.animator_play(cx, ids!(bg_hover.off));
     }
 
-    let hit = event.hits(cx, area);
+    let hit = event.hits_with_test(cx, area, hit_test);
     match &hit {
         Hit::FingerHoverIn(_) | Hit::FingerDown(_) | Hit::FingerLongPress(_) => {
             widget.animator_play(cx, ids!(bg_hover.on));

--- a/src/shared/hover_highlight.rs
+++ b/src/shared/hover_highlight.rs
@@ -13,8 +13,14 @@ pub fn handle_hover_hit<W: AnimatorImpl>(
     claim_before: Area,
     keep_hovered: bool,
 ) -> Hit {
-    handle_hover_hit_with_test(widget, cx, event, area, claim_before, keep_hovered,
-        |abs, rect, inset| Inset::rect_contains_with_inset(abs, rect, inset),
+    handle_hover_hit_with_test(
+        widget,
+        cx,
+        event,
+        area,
+        claim_before,
+        keep_hovered,
+        Inset::rect_contains_with_inset
     )
 }
 

--- a/src/shared/hover_highlight.rs
+++ b/src/shared/hover_highlight.rs
@@ -1,45 +1,39 @@
 //! Shared logic for handling gray hover/press highlights for list items.
 
 use makepad_widgets::*;
-use makepad_widgets::makepad_platform::event::finger::TouchState;
 
-/// Hit-tests `area`, drives the widget's `hover` animator, and returns the hit.
-///
+/// Hit-tests `area`, drives the widget's `bg_hover` animator, and returns the hit.
+/// `claim_before` is `event.pointer_claimed_area()` snapshotted at the widget's handle_event entry.
 /// Pass `true` for `keep_hovered` to leave the hover on even if it should be off.
-///
-/// Note the animator group is `bg_hover`, not `hover`: `View` drives its own
-/// `hover` group off any hit a child steals, which would fight us.
 pub fn handle_hover_hit<W: AnimatorImpl>(
     widget: &mut W,
     cx: &mut Cx,
     event: &Event,
     area: Area,
+    claim_before: Area,
     keep_hovered: bool,
 ) -> Hit {
-    // Drive from the mouse position, not from hover hits: a child widget steals those,
-    // and scrolling slides us off the area the hover was recorded against.
+    // Hover hits go to exactly one widget, so a child claiming them would leave
+    // us dark (or stuck lit). Instead, light up whenever the pointer rests inside
+    // us and any claim on it appeared during our own dispatch (us or a child).
     if let Event::MouseMove(mm) = event {
         let rect = area.clipped_rect(cx);
         if !rect.contains(mm.abs) {
             if !keep_hovered {
                 widget.animator_play(cx, ids!(bg_hover.off));
             }
-        }
-        // Whatever claimed a move inside our rect is us or a child, unless it's
-        // layered on top, which is always bigger. Stay dark under a menu or modal.
-        else {
-            let claimed = mm.handled.get().rect(cx).size;
-            if claimed.x <= rect.size.x && claimed.y <= rect.size.y {
+        } else if cx.fingers.first_mouse_button.is_none() {
+            if claim_before.is_empty() {
                 widget.animator_play(cx, ids!(bg_hover.on));
+            } else if !keep_hovered {
+                // A claim predating our dispatch means an overlay above us owns the pointer.
+                widget.animator_play(cx, ids!(bg_hover.off));
             }
         }
     }
 
-    // Touch has no mouse moves, and a child may have captured the press, so our own
-    // FingerUp below can't be relied on. Any release ends the hover.
-    if !keep_hovered
-        && let Event::TouchUpdate(tu) = event
-        && tu.touches.iter().any(|t| t.state == TouchState::Stop)
+    if let Event::ClearHover = event
+        && !keep_hovered
     {
         widget.animator_play(cx, ids!(bg_hover.off));
     }
@@ -49,7 +43,7 @@ pub fn handle_hover_hit<W: AnimatorImpl>(
         Hit::FingerHoverIn(_) | Hit::FingerDown(_) | Hit::FingerLongPress(_) => {
             widget.animator_play(cx, ids!(bg_hover.on));
         }
-        // Touch sends no mouse moves, so it needs the drag-off case handled here.
+        // Touch sends no mouse moves, so a drag off of us is handled here.
         Hit::FingerMove(fe) if !keep_hovered && !fe.is_over => {
             widget.animator_play(cx, ids!(bg_hover.off));
         }

--- a/src/shared/html_or_plaintext.rs
+++ b/src/shared/html_or_plaintext.rs
@@ -786,17 +786,6 @@ impl HtmlOrPlaintext {
         });
     }
 
-    /// Clears the hover highlight on every link, for when an overlay ate the hover-out.
-    pub fn reset_link_hovers(&mut self, cx: &mut Cx) {
-        let html_ref = self.html(cx, ids!(html_view.html));
-        let Some(html) = html_ref.borrow() else { return };
-        html.text_flow.children(&mut |_id, item| {
-            let Some(link) = item.borrow_mut::<RobrixHtmlLink>() else { return };
-            if let Some(mut html_link) = link.html_link(cx, ids!(html_link)).borrow_mut() {
-                html_link.animator_cut(cx, ids!(hover.off));
-            }
-        });
-    }
 }
 
 impl HtmlOrPlaintextRef {
@@ -821,10 +810,4 @@ impl HtmlOrPlaintextRef {
         }
     }
 
-    /// See [`HtmlOrPlaintext::reset_link_hovers()`].
-    pub fn reset_link_hovers(&self, cx: &mut Cx) {
-        if let Some(mut inner) = self.borrow_mut() {
-            inner.reset_link_hovers(cx);
-        }
-    }
 }


### PR DESCRIPTION
We've moved a lot of hover tracking code into makepad now, so we can remove it from robrix as a custom hack.

* Closing a context menu calls `cx.clear_all_hovers()`, dispatching `Event::ClearHover` to every widget. Buttons, `HtmlLink` and `CalloutTooltip` reset themselves in makepad, so `reset_link_hovers()` and `LinkPreviewRef::reset_hovers()` are gone now
* Hover is now decided by "claim bracketing", which is a fancy way of saying that a widget with lots of child widgets checks to see if a hover event has been claimed by another widget (meaning a parent/ancestor widget already handled the event), which tells that widget that it shouldn't handle that event. It then checks *again* after forwarding the event to its children to see if any of them handled the hover event, meaning that it should keep itself highlighted. 
   * This is only used for cases in which a "parent" widget wants to keep itself hovered even while its inner child widgets hover in or out themselves, e.g., messages, space lobby entries, etc.
   * Fix area functions for `ReactionList` and `AvatarRow` so that they can utilize this new hover behavior properly. 
* Rooms list entries reset hover and menu state when reused for a different room

tested to fully work on both desktop and mobile (touch) 
