### PR TITLE
ci(release): minor packaging changes for iOS and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,7 +586,9 @@ jobs:
           IOS_SIGNING_IDENTITY: Apple Distribution
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          IOS_UPLOAD_TESTFLIGHT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.upload_testflight == 'true' }}
+          ## Tagging a release always sends the build to TestFlight. A manual run only
+          ## does when asked, so test builds don't burn a TestFlight build number.
+          IOS_UPLOAD_TESTFLIGHT: ${{ github.event_name == 'push' || github.event.inputs.upload_testflight == 'true' }}
         run: |
           chmod +x ./packaging/build-ios-testflight.sh
           ./packaging/build-ios-testflight.sh

--- a/packaging/Info.plist
+++ b/packaging/Info.plist
@@ -18,10 +18,12 @@
 	<string>Robrix</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<!-- Both are overwritten from Cargo.toml at build time by build-macos-dmg.sh.
+	     Keep them roughly current anyway, so the committed file isn't misleading. -->
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1-pre-alpha</string>
+	<string>1.0.0-alpha.2</string>
 	<key>CFBundleVersion</key>
-	<string>20241009.225157</string>
+	<string>20260812.1415</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
now that testflight builds created by CI are fully verified and tested, we go ahead and include that as a default build target.