### PR TITLE
ci(release): enable LTO and 1 compilation unit for android release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,7 +555,11 @@ jobs:
         env:
           AWS_LC_SYS_CMAKE_BUILDER: 1
           MAKEPAD_ANDROID_FULL_NDK: true
+          ## Fat LTO takes ~7 MB off the apk and ~35 MB off the installed size.
+          ## Android release only, so desktop build times are unaffected.
           MAKEPAD_MOBILE_CARGO_EXTRA_ARGS: >-
+            --config profile.release.lto=true
+            --config profile.release.codegen-units=1
             --config profile.dev.opt-level=0
             --config profile.dev.debug=false
             --config profile.dev.lto=false


### PR DESCRIPTION
just like iOS. Makes the build smaller and faster at execution time