### PR TITLE
RoomInputBar: further improve/refactor the multi-mode/view handling

### DIFF
--- a/src/home/editing_pane.rs
+++ b/src/home/editing_pane.rs
@@ -662,6 +662,9 @@ impl EditingPaneRef {
     /// This function *DOES NOT* emit an [`EditingPaneAction::Hidden`] action.
     pub fn force_reset_hide(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
+        if inner.visible {
+            cx.revert_key_focus();
+        }
         inner.visible = false;
         inner.animator_cut(cx, ids!(panel.hide));
         inner.is_animating_out = false;

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -884,6 +884,13 @@ impl ScriptHook for RoomScreen {
                 // Clear the timeline's drawn items caches and redraw it.
                 tl_state.content_drawn_since_last_update.clear();
                 tl_state.profile_drawn_since_last_update.clear();
+                // The reapply also resets the RoomInputBar, so we need to re-update its state.
+                self.view.room_input_bar(cx, ids!(room_input_bar)).update_room_state(
+                    cx,
+                    tl_state.kind.room_id(),
+                    tl_state.tombstone_info.as_ref(),
+                    tl_state.user_power,
+                );
                 self.view.redraw(cx);
             }
         });
@@ -1965,16 +1972,16 @@ impl RoomScreen {
                 TimelineUpdate::UserPowerLevels(user_power_levels) => {
                     tl.user_power = user_power_levels;
                     self.view.room_input_bar(cx, ids!(room_input_bar))
-                        .update_user_power_levels(cx, user_power_levels);
+                        .update_room_state(cx, tl.kind.room_id(), tl.tombstone_info.as_ref(), user_power_levels);
                     // We need to redraw all events in order to reflect the new power levels,
                     // e.g., for the message context menu to be correctly populated.
                     tl.content_drawn_since_last_update.clear();
                     tl.profile_drawn_since_last_update.clear();
                 }
                 TimelineUpdate::Tombstoned(successor_room_details) => {
-                    self.view.room_input_bar(cx, ids!(room_input_bar))
-                        .update_tombstone_footer(cx, tl.kind.room_id(), Some(&successor_room_details));
                     tl.tombstone_info = Some(successor_room_details);
+                    self.view.room_input_bar(cx, ids!(room_input_bar))
+                        .update_room_state(cx, tl.kind.room_id(), tl.tombstone_info.as_ref(), tl.user_power);
                 }
                 TimelineUpdate::RoomEncrypted => {
                     tl.is_encrypted = true;

--- a/src/home/tombstone_footer.rs
+++ b/src/home/tombstone_footer.rs
@@ -97,6 +97,21 @@ pub enum SuccessorRoomDetails {
         reason: Option<String>,
     }
 }
+impl Clone for SuccessorRoomDetails {
+    fn clone(&self) -> Self {
+        match self {
+            Self::None => Self::None,
+            Self::Basic(sr) => Self::Basic(SuccessorRoom {
+                room_id: sr.room_id.clone(),
+                reason: sr.reason.clone(),
+            }),
+            Self::Full { room_preview, reason } => Self::Full {
+                room_preview: room_preview.clone(),
+                reason: reason.clone(),
+            },
+        }
+    }
+}
 
 
 /// A view that shows information about a tombstoned room and its successor.

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -160,7 +160,23 @@ script_mod! {
     }
 }
 
-/// Main component for message input with @mention support
+/// Which view the `RoomInputBar` should show, based on room state.
+enum RoomInputBarMode<'a> {
+    /// The user can send messages, so show the regular message input bar.
+    Input,
+    /// The user cannot send messages, so show a notice saying so.
+    CannotSend,
+    /// This room was replaced, so show the tombstone footer.
+    Tombstoned {
+        room_id: &'a OwnedRoomId,
+        successor: &'a SuccessorRoomDetails,
+    },
+}
+
+/// The input bar at the bottom of a RoomScreen that allows the user to send messages, upload files, etc.
+///
+/// It also shows the tombstone footer for rooms that have been tombstoned,
+/// or a notice that the user cannot send messages to this room.
 #[derive(Script, Widget)]
 pub struct RoomInputBar {
     #[source] source: ScriptObjectRef,
@@ -178,10 +194,6 @@ pub struct RoomInputBar {
     #[rust] is_encrypted: bool,
     /// Whether the send button is currently enabled (the message input is non-empty).
     #[rust] is_send_enabled: bool,
-    /// Whether the user has permission to send messages to the current room.
-    #[rust] can_send_message: bool,
-    /// Whether the current room has been tombstoned (replaced by a successor room).
-    #[rust] is_tombstoned: bool,
     /// The room or thread that this RoomInputBar is currently within.
     #[rust] timeline_kind: Option<TimelineKind>,
     /// The widget UID of the RoomScreen containing this RoomInputBar.
@@ -363,11 +375,16 @@ impl RoomInputBar {
             }
         }
 
+        // Keyboard events still reach a hidden input bar (like the send msg shortcut),
+        // so we have to ignore them unless the user is allowed to send a message.
+        let can_post = self.view.view(cx, ids!(input_bar)).visible();
+
         // Handle the send message button being clicked, or a `Returned` action
         // from the message text input, which already respects the user's app setting.
-        if self.button(cx, ids!(send_message_button)).clicked(actions)
+        if can_post && (
+            self.button(cx, ids!(send_message_button)).clicked(actions)
             || text_input.returned(actions).is_some()
-        {
+        ) {
             let entered_text = mentionable_text_input.text().trim().to_string();
             if !entered_text.is_empty() {
                 let message = mentionable_text_input.create_message_with_mentions(&entered_text);
@@ -411,10 +428,12 @@ impl RoomInputBar {
         // send a typing notice to the room and update the send_message_button state.
         let is_text_input_empty = if let Some(new_text) = text_input.changed(actions) {
             let is_empty = new_text.is_empty();
-            submit_async_request(MatrixRequest::SendTypingNotice {
-                room_id: timeline_kind.room_id().clone(),
-                typing: !is_empty,
-            });
+            if can_post {
+                submit_async_request(MatrixRequest::SendTypingNotice {
+                    room_id: timeline_kind.room_id().clone(),
+                    typing: !is_empty,
+                });
+            }
             is_empty
         } else {
             text_input.text().is_empty()
@@ -428,7 +447,7 @@ impl RoomInputBar {
 
         // Handle the user pressing the up arrow in an empty message input box
         // to edit their latest sent message.
-        if is_text_input_empty {
+        if can_post && is_text_input_empty {
             if let Some(KeyEvent {
                 key_code: KeyCode::ArrowUp,
                 modifiers: KeyModifiers { shift: false, control: false, alt: false, logo: false },
@@ -572,31 +591,45 @@ impl RoomInputBar {
         // because it has already been hidden by the time this function gets called.
     } 
 
-    /// Updates (populates and shows or hides) this room's tombstone footer
-    /// based on the given successor room details.
-    fn update_tombstone_footer(
+    /// Updates the room state to set which mode and views are shown in the RoomInputBar.
+    fn update_room_state(
         &mut self,
         cx: &mut Cx,
-        tombstoned_room_id: &OwnedRoomId,
-        successor_room_details: Option<&SuccessorRoomDetails>,
+        room_id: &OwnedRoomId,
+        tombstone_info: Option<&SuccessorRoomDetails>,
+        user_power_levels: UserPowerLevels,
     ) {
+        // If the room is tombstoned, that takes precedence over anything else.
+        let mode = match tombstone_info {
+            Some(successor) => RoomInputBarMode::Tombstoned { room_id, successor },
+            None if user_power_levels.can_send_message() => RoomInputBarMode::Input,
+            None => RoomInputBarMode::CannotSend,
+        };
+        self.view.view(cx, ids!(input_bar))
+            .set_visible(cx, matches!(mode, RoomInputBarMode::Input));
+        self.view.view(cx, ids!(can_not_send_message_notice))
+            .set_visible(cx, matches!(mode, RoomInputBarMode::CannotSend));
+
         let tombstone_footer = self.tombstone_footer(cx, ids!(tombstone_footer));
-        if let Some(srd) = successor_room_details {
-            tombstone_footer.show(cx, tombstoned_room_id, srd);
+        if let RoomInputBarMode::Tombstoned { room_id, successor } = mode {
+            tombstone_footer.show(cx, room_id, successor);
         } else {
             tombstone_footer.hide(cx);
         }
-        self.is_tombstoned = successor_room_details.is_some();
-        self.update_input_bar_visibility(cx);
-    }
 
-    /// Shows either the `input_bar` or the `can_not_send_message_notice`,
-    /// or neither of them if the tombstone footer is covering them both.
-    fn update_input_bar_visibility(&mut self, cx: &mut Cx) {
-        let can_send = !self.is_tombstoned && self.can_send_message;
-        let cannot_send = !self.is_tombstoned && !self.can_send_message;
-        self.view.view(cx, ids!(input_bar)).set_visible(cx, can_send);
-        self.view.view(cx, ids!(can_not_send_message_notice)).set_visible(cx, cannot_send);
+        // The user can't post here anymore, so cancel any in-progress edit, reply, input, etc.
+        if !matches!(mode, RoomInputBarMode::Input) {
+            self.editing_pane(cx, ids!(editing_pane)).force_reset_hide(cx);
+            self.was_replying_preview_visible = false;
+            self.clear_replying_to(cx);
+            self.view.location_preview(cx, ids!(location_preview)).clear();
+        }
+
+        let can_notify = user_power_levels.can_notify_room();
+        self.mentionable_text_input(cx, ids!(mentionable_text_input))
+            .set_can_notify_room(cx, can_notify);
+        self.mentionable_text_input(cx, ids!(editing_pane.editing_content.edit_text_input))
+            .set_can_notify_room(cx, can_notify);
     }
 
     /// Enables or disables (grays out) the send_message_button.
@@ -617,25 +650,6 @@ impl RoomInputBar {
             draw_icon.color: #(fg_color),
             draw_bg.color: #(bg_color),
         });
-    }
-
-    /// Updates the visibility of select views based on the user's new power levels.
-    ///
-    /// This will show/hide the `input_bar` and the `can_not_send_message_notice` views.
-    fn update_user_power_levels(
-        &mut self,
-        cx: &mut Cx,
-        user_power_levels: UserPowerLevels,
-    ) {
-        self.can_send_message = user_power_levels.can_send_message();
-        self.update_input_bar_visibility(cx);
-
-        // Forward the updated power levels to the two mentionable text inputs within this widget.
-        let can_notify = user_power_levels.can_notify_room();
-        self.mentionable_text_input(cx, ids!(mentionable_text_input))
-            .set_can_notify_room(cx, can_notify);
-        self.mentionable_text_input(cx, ids!(editing_pane.editing_content.edit_text_input))
-            .set_can_notify_room(cx, can_notify);
     }
 
     /// Updates the send button (icon + color style) and empty message text
@@ -821,27 +835,16 @@ impl RoomInputBarRef {
         );
     }
 
-    /// Updates the visibility of select views based on the user's new power levels.
-    ///
-    /// This will show/hide the `input_bar` and the `can_not_send_message_notice` views.
-    pub fn update_user_power_levels(
+    /// See [`RoomInputBar::update_room_state()`].
+    pub fn update_room_state(
         &self,
         cx: &mut Cx,
+        room_id: &OwnedRoomId,
+        tombstone_info: Option<&SuccessorRoomDetails>,
         user_power_levels: UserPowerLevels,
     ) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.update_user_power_levels(cx, user_power_levels);
-    }
-
-    /// Updates this room's tombstone footer based on the given `tombstone_state`.
-    pub fn update_tombstone_footer(
-        &self,
-        cx: &mut Cx,
-        tombstoned_room_id: &OwnedRoomId,
-        successor_room_details: Option<&SuccessorRoomDetails>,
-    ) {
-        let Some(mut inner) = self.borrow_mut() else { return };
-        inner.update_tombstone_footer(cx, tombstoned_room_id, successor_room_details);
+        inner.update_room_state(cx, room_id, tombstone_info, user_power_levels);
     }
 
     /// Updates the message input's placeholder based on this room's encryption status.
@@ -941,10 +944,7 @@ impl RoomInputBarRef {
 
         // Note: we do *not* restore the location preview state here; see `save_state()`.
 
-        // 0. Update select views based on user power levels from the RoomScreen (the `TimelineUiState`).
-        //    This must happen before we restore the state of the `EditingPane`,
-        //    because the call to `show_editing_pane()` might re-update the `input_bar`'s visibility.
-        inner.update_user_power_levels(cx, user_power_levels);
+        // 0. Apply this room's encryption state.
         inner.update_encryption_state(cx, is_encrypted);
 
         // 1. Restore the state of the MentionableTextInput.
@@ -971,9 +971,8 @@ impl RoomInputBarRef {
             inner.on_editing_pane_hidden(cx);
         }
 
-        // 4. Restore the state of the tombstone footer.
-        //    This depends on the `EditingPane` state, so it must be done after Step 3.
-        inner.update_tombstone_footer(cx, timeline_kind.room_id(), tombstone_info);
+        // 4. Apply this room's tombstone state and the user's power levels.
+        inner.update_room_state(cx, timeline_kind.room_id(), tombstone_info, user_power_levels);
     }
 
     /// Hides the upload progress view for the given upload attempt.

--- a/src/settings/app_settings.rs
+++ b/src/settings/app_settings.rs
@@ -336,7 +336,6 @@ script_mod! {
         }
 
         send_shortcut_soft_keyboard_warning := mod.widgets.SettingsSectionDescription {
-            visible: false // shown only on iOS/Android, see `populate_safe()``
             font_color: (COLOR_TEXT_WARNING_NOT_FOUND)
             body: "<ul><li>Note: this only applies to physical (hardware) keyboards.</li></ul>"
         }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2497,7 +2497,7 @@ impl JoinedRoomDetails {
     fn all_timeline_update_senders(&self) -> Vec<crossbeam_channel::Sender<TimelineUpdate>> {
         std::iter::once(&self.main_timeline)
             .chain(self.thread_timelines.values())
-            .map(|ptd| ptd.timeline_update_sender.clone())
+            .map(|d| d.timeline_update_sender.clone())
             .collect()
     }
 }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1247,14 +1247,14 @@ async fn matrix_worker_task(
 
             MatrixRequest::GetSuccessorRoomDetails { tombstoned_room_id } => {
                 let Some(client) = get_client() else { continue };
-                let (sender, successor_room) = {
+                let (senders, successor_room) = {
                     let all_joined_rooms = ALL_JOINED_ROOMS.lock().unwrap();
                     let Some(room_info) = all_joined_rooms.get(&tombstoned_room_id) else {
                         error!("BUG: tombstoned room {tombstoned_room_id} info not found for get successor room details request");
                         continue;
                     };
                     (
-                        room_info.main_timeline.timeline_update_sender.clone(),
+                        room_info.all_timeline_update_senders(),
                         room_info.main_timeline.timeline.room().successor_room(),
                     )
                 };
@@ -1262,7 +1262,7 @@ async fn matrix_worker_task(
                     client,
                     successor_room,
                     tombstoned_room_id,
-                    sender,
+                    senders,
                 );
             }
 
@@ -2492,6 +2492,15 @@ impl Drop for JoinedRoomDetails {
         drop(self.pinned_events_subscriber.take());
     }
 }
+impl JoinedRoomDetails {
+    /// Returns the update senders for this room's main timeline and all of its thread timelines.
+    fn all_timeline_update_senders(&self) -> Vec<crossbeam_channel::Sender<TimelineUpdate>> {
+        std::iter::once(&self.main_timeline)
+            .chain(self.thread_timelines.values())
+            .map(|ptd| ptd.timeline_update_sender.clone())
+            .collect()
+    }
+}
 
 
 /// A const-compatible hasher, used for `static` items containing `HashMap`s or `HashSet`s.
@@ -3555,26 +3564,26 @@ async fn update_room(
                 });
             }
 
-            let mut __timeline_update_sender_opt = None;
-            let mut get_timeline_update_sender = |room_id| {
-                if __timeline_update_sender_opt.is_none() {
-                    if let Some(jrd) = ALL_JOINED_ROOMS.lock().unwrap().get(room_id) {
-                        __timeline_update_sender_opt = Some(jrd.main_timeline.timeline_update_sender.clone());
-                    }
-                }
-                __timeline_update_sender_opt.clone()
+            let mut __timeline_update_senders_opt = None;
+            let mut get_timeline_update_senders = |room_id: &RoomId| -> Vec<crossbeam_channel::Sender<TimelineUpdate>> {
+                __timeline_update_senders_opt.get_or_insert_with(||
+                    ALL_JOINED_ROOMS.lock().unwrap().get(room_id)
+                        .map(JoinedRoomDetails::all_timeline_update_senders)
+                        .unwrap_or_default()
+                ).clone()
             };
 
             if !old_room.is_tombstoned && new_room.is_tombstoned {
                 let successor_room = new_room.room.successor_room();
                 log!("Updating room {new_room_id} to be tombstoned, {successor_room:?}");
                 enqueue_rooms_list_update(RoomsListUpdate::TombstonedRoom { room_id: new_room_id.clone() });
-                if let Some(timeline_update_sender) = get_timeline_update_sender(&new_room_id) {
+                let timeline_update_senders = get_timeline_update_senders(&new_room_id);
+                if !timeline_update_senders.is_empty() {
                     spawn_fetch_successor_room_preview(
                         room_list_service.client().clone(),
                         successor_room,
                         new_room_id.clone(),
-                        timeline_update_sender,
+                        timeline_update_senders,
                     );
                 } else {
                     error!("BUG: could not find JoinedRoomDetails for newly-tombstoned room {new_room_id}");
@@ -3584,24 +3593,26 @@ async fn update_room(
             if let Some(nupl) = new_room.user_power_levels
                 && old_room.user_power_levels.is_none_or(|oupl| oupl != nupl)
             {
-                if let Some(timeline_update_sender) = get_timeline_update_sender(&new_room_id) {
+                let timeline_update_senders = get_timeline_update_senders(&new_room_id);
+                if !timeline_update_senders.is_empty() {
                     log!("Updating room {new_room_id} user power levels.");
-                    match timeline_update_sender.send(TimelineUpdate::UserPowerLevels(nupl)) {
-                        Ok(_) => SignalToUI::set_ui_signal(),
-                        Err(_) => error!("Failed to send the UserPowerLevels update to room {new_room_id}"),
+                    for sender in &timeline_update_senders {
+                        let _ = sender.send(TimelineUpdate::UserPowerLevels(nupl));
                     }
+                    SignalToUI::set_ui_signal();
                 } else {
                     error!("BUG: could not find JoinedRoomDetails for room {new_room_id} where power levels changed.");
                 }
             }
 
             if !old_room.is_encrypted && new_room.is_encrypted {
-                if let Some(timeline_update_sender) = get_timeline_update_sender(&new_room_id) {
+                let timeline_update_senders = get_timeline_update_senders(&new_room_id);
+                if !timeline_update_senders.is_empty() {
                     log!("Room {new_room_id} is now encrypted.");
-                    match timeline_update_sender.send(TimelineUpdate::RoomEncrypted) {
-                        Ok(_) => SignalToUI::set_ui_signal(),
-                        Err(_) => error!("Failed to send the RoomEncrypted update to room {new_room_id}"),
+                    for sender in &timeline_update_senders {
+                        let _ = sender.send(TimelineUpdate::RoomEncrypted);
                     }
+                    SignalToUI::set_ui_signal();
                 } else {
                     error!("BUG: could not find JoinedRoomDetails for room {new_room_id} that became encrypted.");
                 }
@@ -4020,7 +4031,7 @@ fn spawn_fetch_successor_room_preview(
     client: Client,
     successor_room: Option<SuccessorRoom>,
     tombstoned_room_id: OwnedRoomId,
-    timeline_update_sender: crossbeam_channel::Sender<TimelineUpdate>,
+    timeline_update_senders: Vec<crossbeam_channel::Sender<TimelineUpdate>>,
 ) {
     Handle::current().spawn(async move {
         log!("Updating room {tombstoned_room_id} to be tombstoned, {successor_room:?}");
@@ -4041,10 +4052,10 @@ fn spawn_fetch_successor_room_preview(
             SuccessorRoomDetails::None
         };
 
-        match timeline_update_sender.send(TimelineUpdate::Tombstoned(srd)) {
-            Ok(_) => SignalToUI::set_ui_signal(),
-            Err(_) => error!("Failed to send the Tombstoned update to room {tombstoned_room_id}"),
+        for sender in &timeline_update_senders {
+            let _ = sender.send(TimelineUpdate::Tombstoned(srd.clone()));
         }
+        SignalToUI::set_ui_signal();
     });
 }
 


### PR DESCRIPTION
The input bar, the can't-send notice, and the `TombstoneFooter` are all separate overlays that can be shown at the same time. Now we make sure that can't happen with a simple single function that always sets the right view to visible and hides the others.

* Replace `update_user_power_levels` & `update_tombstone_footer` with a single `update_room_state()` that determines the `RoomInputBarMode`. As a bonus, there's no need to hold duplicate room state in the room input bar struct itself.
* Send updates to thread timelines too, such that an open thread will now hide its input view if that room gets tombstones or the user is no longer allowed to post to it.