### PR TITLE
fix verification modal confusing msg. Allow only one verification at a time

### DIFF
--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -177,9 +177,14 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
         if cancel_clicked ||
             actions.iter().any(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)))
         {
-            // Inform other widgets that this modal has been closed.
-            cx.action(JoinLeaveRoomModalAction::Close { successful: false, was_internal: cancel_clicked });
-            self.reset_state();
+            if self.kind.is_some() {
+                // Inform other widgets that this modal has been closed.
+                cx.action(JoinLeaveRoomModalAction::Close {
+                    successful: self.final_success.unwrap_or(false),
+                    was_internal: cancel_clicked,
+                });
+                self.reset_state();
+            }
             return;
         }
 

--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -173,6 +173,8 @@ impl WidgetMatchEvent for ConfirmationModal {
 
         // If the accept button was clicked, emit the action and call the on_accept callback.
         if accept_button.clicked(actions) {
+            // The user made their choice, so the cancel callback must never run ever again.
+            self.content.on_cancel_clicked = None;
             if let Some(on_accept_clicked) = self.content.on_accept_clicked.take() {
                 on_accept_clicked(cx);
             }

--- a/src/tsp/tsp_verification_modal.rs
+++ b/src/tsp/tsp_verification_modal.rs
@@ -2,7 +2,7 @@
 use makepad_widgets::*;
 use tsp_sdk::AsyncSecureStore;
 
-use crate::{sliding_sync::current_user_id, tsp::{submit_tsp_request, TspRequest, TspVerificationDetails}};
+use crate::{shared::styles::apply_positive_button_style, sliding_sync::current_user_id, tsp::{submit_tsp_request, TspRequest, TspVerificationDetails}};
 
 script_mod! {
     link tsp_enabled
@@ -108,12 +108,13 @@ impl WidgetMatchEvent for TspVerificationModal {
             .any(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)));
 
         if cancel_button_clicked || modal_dismissed {
-            match &self.state {
+            // Take the state now to avoid declining/dismissing this modal twice.
+            match std::mem::take(&mut self.state) {
                 TspVerificationModalState::ReceivedRequest { details, wallet_db }
                 | TspVerificationModalState::RequestAccepted { details, wallet_db } => {
                     submit_tsp_request(TspRequest::RespondToDidAssociationRequest {
-                        details: details.clone(),
-                        wallet_db: wallet_db.clone(),
+                        details,
+                        wallet_db,
                         accepted: false,
                     });
                 }
@@ -271,8 +272,9 @@ impl TspVerificationModal {
         );
         self.label(cx, ids!(body)).set_text(cx, &prompt_text);
 
-        let accept_button = self.button(cx, ids!(accept_button));
+        let mut accept_button = self.button(cx, ids!(accept_button));
         let cancel_button = self.button(cx, ids!(cancel_button));
+        apply_positive_button_style(cx, &mut accept_button);
         accept_button.set_text(cx, "Accept Request");
         accept_button.set_enabled(cx, true);
         accept_button.set_visible(cx, true);

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use futures_util::StreamExt;
 use makepad_widgets::{error, log, Cx};
@@ -16,6 +17,26 @@ use matrix_sdk::{
 use tokio::{runtime::Handle, sync::mpsc::{UnboundedReceiver, UnboundedSender}};
 
 use crate::shared::popup_list::{enqueue_popup_notification, PopupKind};
+
+/// Whether a verification flow is currently in progress. See [`VerificationInProgress`].
+static VERIFICATION_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// A guard type to prevent multiple simultaneous verifications.
+struct VerificationInProgress;
+impl VerificationInProgress {
+    /// Returns `None` if another verification flow is already in progress.
+    fn start() -> Option<Self> {
+        VERIFICATION_IN_PROGRESS
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+            .then_some(Self)
+    }
+}
+impl Drop for VerificationInProgress {
+    fn drop(&mut self) {
+        VERIFICATION_IN_PROGRESS.store(false, Ordering::Release);
+    }
+}
 
 #[derive(Clone, Debug, Default)]
 pub enum VerificationStateAction {
@@ -100,6 +121,7 @@ async fn sas_verification_handler(
     client: Client,
     sas: SasVerification,
     response_receiver: UnboundedReceiver<VerificationUserResponse>,
+    _in_progress: VerificationInProgress,
 ) {
     log!(
         "Starting verification with {} {}",
@@ -192,12 +214,20 @@ async fn sas_verification_handler(
 
 async fn request_verification_handler(client: Client, request: VerificationRequest) {
     log!("Received a verification request in room {:?}: {:?}", request.room_id(), request.state());
+    let Some(in_progress) = VerificationInProgress::start() else {
+        log!("Declining verification request: another verification is already in progress.");
+        let _ = request.cancel().await;
+        return;
+    };
     let (sender, mut response_receiver) = tokio::sync::mpsc::unbounded_channel::<VerificationUserResponse>();
     Cx::post_action(
         VerificationAction::RequestReceived(
             VerificationRequestActionState {
                 request: request.clone(),
-                response_sender: sender.clone(),
+                // Moved, not cloned: the modal dropping its copy is how we find out that the
+                // user walked away from this request, which wakes the `recv()` below with
+                // `None` so we can cancel. Keeping a copy alive here would park us forever.
+                response_sender: sender,
             }
         )
     );
@@ -235,7 +265,7 @@ async fn request_verification_handler(client: Client, request: VerificationReque
                 // We only support SAS verification.
                 Verification::SasV1(sas) => {
                     log!("Verification request transitioned to SAS V1.");
-                    Handle::current().spawn(sas_verification_handler(client, sas, response_receiver));
+                    Handle::current().spawn(sas_verification_handler(client, sas, response_receiver, in_progress));
                     return;
                 }
                 unsupported => {
@@ -260,6 +290,14 @@ async fn request_verification_handler(client: Client, request: VerificationReque
 
 /// Sends a self-verification request to the user's other logged-in sessions,
 pub async fn request_self_verification_handler(client: Client) {
+    let Some(in_progress) = VerificationInProgress::start() else {
+        enqueue_popup_notification(
+            "A verification request is already in progress. Finish or cancel it first.",
+            PopupKind::Error,
+            Some(6.0),
+        );
+        return;
+    };
     let Some(user_id) = client.user_id() else {
         enqueue_popup_notification("Can't verify this device: you are not logged in.", PopupKind::Error, Some(5.0));
         return;
@@ -349,12 +387,12 @@ pub async fn request_self_verification_handler(client: Client) {
         }
     };
 
-    sas_verification_handler(client, sas, response_receiver).await;
+    sas_verification_handler(client, sas, response_receiver, in_progress).await;
 }
 
 
 /// Actions related to verification that should be handled by the top-level app context.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub enum VerificationAction {
     /// Informs the main UI thread that a verification request has been received.
     RequestReceived(VerificationRequestActionState),
@@ -390,8 +428,6 @@ pub enum VerificationAction {
     SasConfirmationError(Arc<matrix_sdk::Error>),
     /// Informs the main UI thread that a verification request has been fully completed.
     RequestCompleted,
-    #[default]
-    None,
 }
 
 /// The state included in a verification request action.

--- a/src/verification_modal.rs
+++ b/src/verification_modal.rs
@@ -335,7 +335,7 @@ impl VerificationModal {
         let we_started = request.we_started();
         let prompt_text = if we_started {
             Cow::from("We just sent a verification request to your other logged-in devices.\n\n\
-                Accept the request to continue verifying this device.")
+                Accept the request on another device to continue…")
         } else if request.is_self_verification() {
             Cow::from("Do you wish to verify your own device?")
         } else if let Some(room_id) = request.room_id() {

--- a/src/verification_modal.rs
+++ b/src/verification_modal.rs
@@ -140,21 +140,20 @@ impl WidgetMatchEvent for VerificationModal {
             if self.is_final {
                 cx.action(VerificationModalAction::Close);
                 self.reset_state();
-            } else {
-                if let Some(state) = self.state.as_ref() {
-                    let _ = state.response_sender.send(VerificationUserResponse::Accept);
-                }
+            } else if let Some(state) = self.state.as_ref() {
+                let _ = state.response_sender.send(VerificationUserResponse::Accept);
+                accept_button.set_enabled(cx, false);
             }
         }
 
         let mut needs_redraw = false;
         for action in actions {
             // `VerificationAction`s come from a background thread, so they are NOT widget actions.
-            // Therefore, we cannot use `as_widget_action().cast()` to match them.
             if let Some(verification_action) = action.downcast_ref::<VerificationAction>() {
-                // Outgoing verification requests start with the accept button hidden
-                // since we're still in the waiting state then, so show it now
-                accept_button.set_visible(cx, true);
+                // `RequestReceived` is handled by the top-level app.
+                if matches!(verification_action, VerificationAction::RequestReceived(_)) {
+                    continue;
+                }
                 // The emoji grid is hidden by default and only shown during emoji verification.
                 self.view.view(cx, ids!(emojis_view)).set_visible(cx, false);
                 match verification_action {
@@ -163,37 +162,27 @@ impl WidgetMatchEvent for VerificationModal {
                             cx,
                             &format!("Verification request was cancelled: {}", cancel_info.reason())
                         );
-                        accept_button.set_enabled(cx, true);
-                        accept_button.set_text(cx, "Ok");
-                        cancel_button.set_visible(cx, false);
-                        self.is_final = true;
+                        self.transition_to_final_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::RequestAccepted => {
                         self.label(cx, ids!(body)).set_text(
                             cx,
                             "You successfully accepted the verification request.\n\n\
-                            Waiting for the other device to agree on verification methods..."
+                            Waiting for the other device to agree on verification methods…"
                         );
-                        accept_button.set_enabled(cx, false);
-                        accept_button.set_text(cx, "Waiting...");
-                        cancel_button.set_text(cx, "Cancel");
-                        cancel_button.set_enabled(cx, true);
-                        cancel_button.set_visible(cx, true);
+                        Self::transition_to_waiting_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::RequestAcceptError(error) => {
-                        self.label(cx, ids!(body)).set_text(cx, 
+                        self.label(cx, ids!(body)).set_text(cx,
                             &format!(
                                 "Error accepting verification request: {}\n\n\
                                 Please try the verification process again.",
                                 error,
                             ),
                         );
-                        accept_button.set_enabled(cx, true);
-                        accept_button.set_text(cx, "Ok");
-                        cancel_button.set_visible(cx, false);
-                        self.is_final = true;
+                        self.transition_to_final_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::RequestCancelError(error) => {
@@ -201,10 +190,7 @@ impl WidgetMatchEvent for VerificationModal {
                             cx,
                             &format!("Error cancelling verification request: {}.", error)
                         );
-                        accept_button.set_enabled(cx, true);
-                        accept_button.set_text(cx, "Ok");
-                        cancel_button.set_visible(cx, false);
-                        self.is_final = true;
+                        self.transition_to_final_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::RequestTransitionedToUnsupportedMethod(method) => {
@@ -219,23 +205,16 @@ impl WidgetMatchEvent for VerificationModal {
                                 },
                             )
                         );
-                        accept_button.set_enabled(cx, true);
-                        accept_button.set_text(cx, "Ok");
-                        cancel_button.set_visible(cx, false);
-                        self.is_final = true;
+                        self.transition_to_final_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::SasAccepted(_accepted_protocols) => {
                         self.label(cx, ids!(body)).set_text(
                             cx,
                             "Both sides have accepted the same verification method(s).\n\n\
-                            Waiting for both devices to exchange keys..."
+                            Waiting for both devices to exchange keys…"
                         );
-                        accept_button.set_enabled(cx, false);
-                        accept_button.set_text(cx, "Waiting...");
-                        cancel_button.set_text(cx, "Cancel");
-                        cancel_button.set_enabled(cx, true);
-                        cancel_button.set_visible(cx, true);
+                        Self::transition_to_waiting_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::KeysExchanged { emojis, decimals } => {
@@ -270,6 +249,7 @@ impl WidgetMatchEvent for VerificationModal {
                             );
                             self.label(cx, ids!(body)).set_text(cx, &text);
                         }
+                        accept_button.set_visible(cx, true);
                         accept_button.set_enabled(cx, true);
                         accept_button.set_text(cx, "Yes");
                         cancel_button.set_text(cx, "No");
@@ -281,13 +261,9 @@ impl WidgetMatchEvent for VerificationModal {
                         self.label(cx, ids!(body)).set_text(
                             cx,
                             "You successfully confirmed the Short Auth String keys.\n\n\
-                            Waiting for the other device to confirm..."
+                            Waiting for the other device to confirm…"
                         );
-                        accept_button.set_enabled(cx, false);
-                        accept_button.set_text(cx, "Waiting...");
-                        cancel_button.set_text(cx, "Cancel");
-                        cancel_button.set_enabled(cx, true);
-                        cancel_button.set_visible(cx, true);
+                        Self::transition_to_waiting_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::SasConfirmationError(error) => {
@@ -295,10 +271,7 @@ impl WidgetMatchEvent for VerificationModal {
                             cx,
                             &format!("Error confirming keys: {}\n\nPlease retry the verification process.", error)
                         );
-                        accept_button.set_text(cx, "Ok");
-                        accept_button.set_enabled(cx, true);
-                        cancel_button.set_visible(cx, false);
-                        self.is_final = true;
+                        self.transition_to_final_state(cx, &accept_button, &cancel_button);
                     }
 
                     VerificationAction::RequestCompleted => {
@@ -308,12 +281,12 @@ impl WidgetMatchEvent for VerificationModal {
                             Now you can send and receive encrypted messages,\
                             and everyone you chat with can trust this device is yours.",
                         );
-                        accept_button.set_text(cx, "Ok");
-                        accept_button.set_enabled(cx, true);
-                        cancel_button.set_visible(cx, false);
-                        self.is_final = true;
+                        self.transition_to_final_state(cx, &accept_button, &cancel_button);
                     }
-                    _ => { }
+
+                    // Skipped above. Listed explicitly instead of a `_` catch-all so that a
+                    // new action variant is a compile error here rather than a silent no-op.
+                    VerificationAction::RequestReceived(_) => { }
                 }
                 // If we received a `VerificationAction`, we need to redraw the modal content.
                 needs_redraw = true;
@@ -332,6 +305,24 @@ impl VerificationModal {
         self.is_final = false;
     }
 
+    /// The verification flow is waiting on another device.
+    fn transition_to_waiting_state(cx: &mut Cx, accept_button: &ButtonRef, cancel_button: &ButtonRef) {
+        accept_button.set_enabled(cx, false);
+        accept_button.set_text(cx, "Waiting…");
+        cancel_button.set_text(cx, "Cancel");
+        cancel_button.set_enabled(cx, true);
+        cancel_button.set_visible(cx, true);
+    }
+
+    /// The verification flow is in its final state.
+    fn transition_to_final_state(&mut self, cx: &mut Cx, accept_button: &ButtonRef, cancel_button: &ButtonRef) {
+        accept_button.set_visible(cx, true);
+        accept_button.set_enabled(cx, true);
+        accept_button.set_text(cx, "Okay");
+        cancel_button.set_visible(cx, false);
+        self.is_final = true;
+    }
+
     fn initialize_with_data(
         &mut self,
         cx: &mut Cx,
@@ -343,8 +334,8 @@ impl VerificationModal {
         // to accept it, but rather just wait for another device to accept & respond.
         let we_started = request.we_started();
         let prompt_text = if we_started {
-            Cow::from("Send a verification request to your other logged-in devices.\n\n\
-                Accept it on one of those devices to continue verifying this device.")
+            Cow::from("We just sent a verification request to your other logged-in devices.\n\n\
+                Accept the request to continue verifying this device.")
         } else if request.is_self_verification() {
             Cow::from("Do you wish to verify your own device?")
         } else if let Some(room_id) = request.room_id() {


### PR DESCRIPTION
The accept button stayed visible on outgoing requests and the message shown in the modal wasn't particularly clear that the request had ALREADY been sent to the other clients.

Verification actions are broadcast app-wide with no flow ID, so two at once could potentially be confused. Only one can run at a time now.

Also fixes modals running their cancel path twice, since `Modal::close()` re-enters the modal's `content` widget with a `Dismissed` action