### PR TITLE
ImageViewer + RoomScreen: redesign input handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "bit-vec",
 ]
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "bitflags"
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "bitmaps"
@@ -834,7 +834,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "byteorder"
@@ -845,7 +845,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "bytes"
@@ -904,7 +904,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "cfg_aliases"
@@ -915,7 +915,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "chacha20"
@@ -1252,7 +1252,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "crypto-bigint"
@@ -1632,7 +1632,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "dunce"
@@ -1767,7 +1767,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "errno"
@@ -1945,7 +1945,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "foreign-types"
@@ -2102,9 +2102,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
@@ -2300,9 +2300,9 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
@@ -2335,7 +2335,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "hilog-sys"
@@ -2774,10 +2774,10 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
@@ -2969,9 +2969,9 @@ dependencies = [
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "windows-link 0.2.1",
 ]
 
@@ -3043,7 +3043,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "loom"
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -3132,12 +3132,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3179,15 +3179,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3195,27 +3195,27 @@ dependencies = [
 [[package]]
 name = "makepad-fast-inflate"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "weezl",
 ]
@@ -3223,10 +3223,10 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
- "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "num-traits 0.2.20",
  "zerocopy 0.8.39",
 ]
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3248,7 +3248,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "ttf-parser",
 ]
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3289,12 +3289,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3325,15 +3325,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3356,7 +3356,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3368,12 +3368,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3381,13 +3381,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3404,14 +3404,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "makepad-video"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-apple-sys",
  "makepad-objc-sys",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3475,13 +3475,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "simd-adler32",
 ]
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-fast-inflate",
  "makepad-zune-core",
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3906,7 +3906,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "memoffset"
@@ -3978,23 +3978,23 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "bit-set",
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
- "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "hexf-parse",
- "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "makepad-error-log",
  "makepad-half",
  "num-traits 0.2.20",
- "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "unicode-ident",
 ]
 
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "num_cpus"
@@ -4326,7 +4326,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4636,7 +4636,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "polling"
@@ -4795,10 +4795,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "unicase 2.9.0",
 ]
 
@@ -5580,7 +5580,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "rustc-hash"
@@ -5705,12 +5705,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5799,7 +5799,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "scopeguard"
@@ -5810,7 +5810,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "sealed"
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "siphasher"
@@ -6146,7 +6146,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "socket2"
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6541,9 +6541,9 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
- "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
@@ -6571,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "tungstenite"
@@ -7016,7 +7016,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-bidi"
@@ -7027,17 +7027,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-ident"
@@ -7048,7 +7048,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-normalization"
@@ -7068,12 +7068,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7084,7 +7084,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "unicode-xid"
@@ -7410,11 +7410,11 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "downcast-rs",
  "libc",
- "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
  "smallvec 1.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys",
 ]
@@ -7422,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7451,10 +7451,10 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "log 0.4.29",
- "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel)",
+ "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
 ]
 
 [[package]]
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "whoami"
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7607,7 +7607,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7692,7 +7692,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "windows-numerics"
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8316,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=portal_list_scroll_travel#b43172d99c37d975263c7df0e51bf839346e28ca"
+source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ version = "1.0.0-alpha.2"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "portal_list_scroll_travel", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "portal_list_scroll_travel" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "second_touch_stays_captured", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "second_touch_stays_captured" }
 
 
 robius-directories = { git = "https://github.com/project-robius/robius" }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -913,9 +913,9 @@ impl Widget for RoomScreen {
             room_input_popup_menu,
         } = self.cached_widget_refs(cx);
 
-        let is_pane_shown = room_input_popup_menu.is_open()
-            || loading_pane.is_currently_shown(cx)
+        let is_pane_shown = loading_pane.is_currently_shown(cx)
             || user_profile_sliding_pane.is_currently_shown(cx);
+        let is_popup_menu_open = room_input_popup_menu.is_open();
 
         // Only direct interaction with the timeline itself can send a read receipt;
         // the direction of any scrolling gets checked later via `user_scroll_travel()`.
@@ -931,6 +931,7 @@ impl Widget for RoomScreen {
             // Interactions aimed at one of our own panes don't count, nor do those aimed
             // at an app-level overlay (modals and menus block scrolling while open).
             && !is_pane_shown
+            && !is_popup_menu_open
             && cx.is_scrolling_allowed_within(&portal_list.area())
         {
             self.read_receipt_state.start_timer(cx, &portal_list);
@@ -1199,15 +1200,16 @@ impl Widget for RoomScreen {
         // such that we can handle the ones relevant to only THIS RoomScreen widget right here and now,
         // ensuring they are not mistakenly handled by other RoomScreen widget instances.
         // When an overlay pane is shown, all "interactive" user inputs are only forwarded to it.
+        // The popup menu allows events to fall through, but they do dismiss it.
         let mut actions_generated_within_this_room_screen = cx.capture_actions(|cx| {
             if is_pane_shown && utils::is_interactive_hit_event(event) {
-                if room_input_popup_menu.is_open() {
-                    room_input_popup_menu.handle_event(cx, event, &mut Scope::empty());
-                } else if loading_pane.is_currently_shown(cx) {
+                if loading_pane.is_currently_shown(cx) {
                     loading_pane.handle_event(cx, event, &mut Scope::empty());
                 } else {
                     user_profile_sliding_pane.handle_event(cx, event, &mut Scope::empty());
                 }
+            } else if is_popup_menu_open && room_input_popup_menu.is_event_within_popup_menu(cx, event) {
+                room_input_popup_menu.handle_event(cx, event, &mut Scope::empty());
             } else {
                 self.view.handle_event(cx, event, &mut Scope::empty());
             }

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -899,7 +899,7 @@ impl ScriptHook for RoomScreen {
 
 impl Widget for RoomScreen {
     // Handle events and actions for the RoomScreen widget and its inner Timeline view.
-    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, _scope: &mut Scope) {
         // Skip event handling if this RoomScreen is uninitialized (a background dock tab after dock restore).
         if self.tl_state.is_none() && self.room_name_id.is_none() {
             return;
@@ -913,6 +913,10 @@ impl Widget for RoomScreen {
             room_input_popup_menu,
         } = self.cached_widget_refs(cx);
 
+        let is_pane_shown = room_input_popup_menu.is_open()
+            || loading_pane.is_currently_shown(cx)
+            || user_profile_sliding_pane.is_currently_shown(cx);
+
         // Only direct interaction with the timeline itself can send a read receipt;
         // the direction of any scrolling gets checked later via `user_scroll_travel()`.
         let interaction_pos = match event {
@@ -924,10 +928,10 @@ impl Widget for RoomScreen {
             _ => None,
         };
         if interaction_pos.is_some_and(|pos| portal_list.area().rect(cx).contains(pos))
-            // Interactions aimed at an overlaying pane don't count.
-            && !room_input_popup_menu.is_open()
-            && !loading_pane.is_currently_shown(cx)
-            && !user_profile_sliding_pane.is_currently_shown(cx)
+            // Interactions aimed at one of our own panes don't count, nor do those aimed
+            // at an app-level overlay (modals and menus block scrolling while open).
+            && !is_pane_shown
+            && cx.is_scrolling_allowed_within(&portal_list.area())
         {
             self.read_receipt_state.start_timer(cx, &portal_list);
         }
@@ -1191,145 +1195,97 @@ impl Widget for RoomScreen {
             avatar_cache::process_avatar_updates(cx);
         }
 
-        // We only forward "interactive hit" events to the inner timeline view
-        // if none of the various overlay views are visible.
-        // We always forward "non-interactive hit" events to the inner timeline view.
-        // We check which overlay views are visible in the order of those views' z-ordering,
-        // such that the top-most views get a chance to handle the event first.
-        //
-        let is_interactive_hit = utils::is_interactive_hit_event(event);
-        let is_pane_shown: bool;
-        let mut close_room_input_popup_menu_after_forwarding = false;
-        if room_input_popup_menu.is_open() {
-            if event.back_pressed() || matches!(event, Event::KeyUp(KeyEvent { key_code: KeyCode::Escape, .. })) {
-                room_input_popup_menu.close(cx);
-                is_pane_shown = true;
-            }
-            else if is_interactive_hit {
-                if room_input_popup_menu.is_event_within_popup_menu(cx, event) {
-                    is_pane_shown = true;
-                    room_input_popup_menu.handle_event(cx, event, scope);
+        // Forward the event to the inner timeline view, but capture any actions it produces
+        // such that we can handle the ones relevant to only THIS RoomScreen widget right here and now,
+        // ensuring they are not mistakenly handled by other RoomScreen widget instances.
+        // When an overlay pane is shown, all "interactive" user inputs are only forwarded to it.
+        let mut actions_generated_within_this_room_screen = cx.capture_actions(|cx| {
+            if is_pane_shown && utils::is_interactive_hit_event(event) {
+                if room_input_popup_menu.is_open() {
+                    room_input_popup_menu.handle_event(cx, event, &mut Scope::empty());
+                } else if loading_pane.is_currently_shown(cx) {
+                    loading_pane.handle_event(cx, event, &mut Scope::empty());
                 } else {
-                    // Let outside clicks, hovers, and mouse moves fall through to the underlying UI.
-                    close_room_input_popup_menu_after_forwarding =
-                        room_input_popup_menu.should_dismiss_for_outside_event(cx, event);
-                    is_pane_shown = false;
+                    user_profile_sliding_pane.handle_event(cx, event, &mut Scope::empty());
                 }
             } else {
-                is_pane_shown = false;
+                self.view.handle_event(cx, event, &mut Scope::empty());
             }
-        }
-        else if loading_pane.is_currently_shown(cx) {
-            is_pane_shown = true;
-            if is_interactive_hit {
-                loading_pane.handle_event(cx, event, scope);
+        });
+        // Here, we handle and remove any general actions that are relevant to only this RoomScreen.
+        // Removing the handled actions ensures they are not mistakenly handled by other RoomScreen widget instances.
+        actions_generated_within_this_room_screen.retain(|action| {
+            if self.handle_link_clicked(cx, action, &user_profile_sliding_pane) {
+                return false;
             }
-        }
-        else if user_profile_sliding_pane.is_currently_shown(cx) {
-            is_pane_shown = true;
-            if is_interactive_hit {
-                user_profile_sliding_pane.handle_event(cx, event, scope);
-            }
-        }
-        else {
-            is_pane_shown = false;
-        }
 
-        // TODO: once we use the `hits()` API, should be able to remove the above conditionals
-        //       about whether the loading pane or user profile pane are shown, because
-        //       Makepad already delivers most events to all views regardless of visibility,
-        //       so the only thing we'd need here is the conditional below.
-
-        if !is_pane_shown || !is_interactive_hit {
-            // Forward the event to the inner timeline view, but capture any actions it produces
-            // such that we can handle the ones relevant to only THIS RoomScreen widget right here and now,
-            // ensuring they are not mistakenly handled by other RoomScreen widget instances.
-            let mut actions_generated_within_this_room_screen = cx.capture_actions(|cx|
-                self.view.handle_event(cx, event, &mut Scope::empty())
-            );
-            // Here, we handle and remove any general actions that are relevant to only this RoomScreen.
-            // Removing the handled actions ensures they are not mistakenly handled by other RoomScreen widget instances.
-            actions_generated_within_this_room_screen.retain(|action| {
-                if self.handle_link_clicked(cx, action, &user_profile_sliding_pane) {
+            // Handle actions related to the room input popup menu.
+            match action.as_widget_action().cast() {
+                RoomInputPopupMenuAction::None => {}
+                room_popup_menu_action => {
+                    self.handle_room_input_popup_menu_action(cx, room_popup_menu_action);
                     return false;
                 }
-
-                // Handle actions related to the room input popup menu.
-                match action.as_widget_action().cast() {
-                    RoomInputPopupMenuAction::None => {}
-                    room_popup_menu_action => {
-                        self.handle_room_input_popup_menu_action(cx, room_popup_menu_action);
-                        return false;
-                    }
-                }
-
-                // Handle the action that requests to show the user profile sliding pane.
-                if let ShowUserProfileAction::ShowUserProfile(profile_and_room_id) = action.as_widget_action().cast() {
-                    self.show_user_profile(
-                        cx,
-                        &user_profile_sliding_pane,
-                        UserProfilePaneInfo {
-                            profile_and_room_id,
-                            room_name: self.room_name_id.as_ref().map_or_else(
-                                || UNNAMED_ROOM.to_string(),
-                                |r| r.to_string(),
-                            ),
-                            room_member: None,
-                        },
-                    );
-                }
-
-                /*
-                match action.as_widget_action().widget_uid_eq(room_screen_widget_uid).cast() {
-                    MessageAction::ActionBarClose => {
-                        let message_action_bar_popup = self.popup_notification(cx, ids!(message_action_bar_popup));
-                        let message_action_bar = message_action_bar_popup.message_action_bar(cx, ids!(message_action_bar));
-
-                        // close only if the active message is requesting it to avoid double closes.
-                        if let Some(message_widget_uid) = message_action_bar.message_widget_uid() {
-                            if action.as_widget_action().widget_uid_eq(message_widget_uid).is_some() {
-                                message_action_bar_popup.close(cx);
-                            }
-                        }
-                    }
-                    MessageAction::ActionBarOpen { item_id, message_rect } => {
-                        let message_action_bar_popup = self.popup_notification(cx, ids!(message_action_bar_popup));
-                        let message_action_bar = message_action_bar_popup.message_action_bar(cx, ids!(message_action_bar));
-
-                        let margin_x = 50.;
-
-                        let coords = dvec2(
-                            (message_rect.pos.x + message_rect.size.x) - margin_x,
-                            message_rect.pos.y,
-                        );
-
-                        script_apply_eval!(cx, message_action_bar_popup, {
-                            content +: { margin +: { left: #(coords.x), top: #(coords.y) } }
-                        });
-
-                        if let Some(message_widget_uid) = action.as_widget_action().map(|a| a.widget_uid) {
-                            message_action_bar_popup.open(cx);
-                            message_action_bar.initialize_with_data(cx, widget_uid, message_widget_uid, item_id);
-                        }
-                    }
-                    _ => {}
-                }
-                */
-
-                // Keep all unhandled actions so we can add them back to the global action list below.
-                true
-            });
-            // Add back any unhandled actions to the global action list.
-            cx.extend_actions(actions_generated_within_this_room_screen);
-
-            if close_room_input_popup_menu_after_forwarding {
-                let room_input_popup_menu =
-                    self.room_input_popup_menu(cx, ids!(room_input_popup_menu));
-                if room_input_popup_menu.is_open() {
-                    room_input_popup_menu.close(cx);
-                }
             }
-        }
+
+            // Handle the action that requests to show the user profile sliding pane.
+            if let ShowUserProfileAction::ShowUserProfile(profile_and_room_id) = action.as_widget_action().cast() {
+                self.show_user_profile(
+                    cx,
+                    &user_profile_sliding_pane,
+                    UserProfilePaneInfo {
+                        profile_and_room_id,
+                        room_name: self.room_name_id.as_ref().map_or_else(
+                            || UNNAMED_ROOM.to_string(),
+                            |r| r.to_string(),
+                        ),
+                        room_member: None,
+                    },
+                );
+            }
+
+            /*
+            match action.as_widget_action().widget_uid_eq(room_screen_widget_uid).cast() {
+                MessageAction::ActionBarClose => {
+                    let message_action_bar_popup = self.popup_notification(cx, ids!(message_action_bar_popup));
+                    let message_action_bar = message_action_bar_popup.message_action_bar(cx, ids!(message_action_bar));
+
+                    // close only if the active message is requesting it to avoid double closes.
+                    if let Some(message_widget_uid) = message_action_bar.message_widget_uid() {
+                        if action.as_widget_action().widget_uid_eq(message_widget_uid).is_some() {
+                            message_action_bar_popup.close(cx);
+                        }
+                    }
+                }
+                MessageAction::ActionBarOpen { item_id, message_rect } => {
+                    let message_action_bar_popup = self.popup_notification(cx, ids!(message_action_bar_popup));
+                    let message_action_bar = message_action_bar_popup.message_action_bar(cx, ids!(message_action_bar));
+
+                    let margin_x = 50.;
+
+                    let coords = dvec2(
+                        (message_rect.pos.x + message_rect.size.x) - margin_x,
+                        message_rect.pos.y,
+                    );
+
+                    script_apply_eval!(cx, message_action_bar_popup, {
+                        content +: { margin +: { left: #(coords.x), top: #(coords.y) } }
+                    });
+
+                    if let Some(message_widget_uid) = action.as_widget_action().map(|a| a.widget_uid) {
+                        message_action_bar_popup.open(cx);
+                        message_action_bar.initialize_with_data(cx, widget_uid, message_widget_uid, item_id);
+                    }
+                }
+                _ => {}
+            }
+            */
+
+            // Keep all unhandled actions so we can add them back to the global action list below.
+            true
+        });
+        // Add back any unhandled actions to the global action list.
+        cx.extend_actions(actions_generated_within_this_room_screen);
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -8,7 +8,6 @@ use chrono::{DateTime, Local};
 use makepad_widgets::{
     event::TouchUpdateEvent,
     image_cache::{decode_image_from_data, looks_like_svg, ImageBuffer, ImageError},
-    makepad_platform::event::finger::TouchState,
     *,
 };
 use matrix_sdk_ui::timeline::EventTimelineItem;
@@ -582,13 +581,6 @@ impl Widget for ImageViewer {
         }
         if let Event::TouchUpdate(touch_event) = event {
             self.handle_pinch_to_zoom(cx, touch_event);
-            // makepad doesn't mark a second touch on our already-captured area as "handled",
-            // so we do it ourselves to ensure widgets behind us don't capture and handle it.
-            for t in &touch_event.touches {
-                if matches!(t.state, TouchState::Start) && t.handled.get().is_empty() {
-                    t.handled.set(self.view.area());
-                }
-            }
         }
 
         if let (Event::Signal, Some((_background_task_id, receiver))) = (event, &mut self.receiver) {

--- a/src/shared/image_viewer.rs
+++ b/src/shared/image_viewer.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Local};
 use makepad_widgets::{
     event::TouchUpdateEvent,
     image_cache::{decode_image_from_data, looks_like_svg, ImageBuffer, ImageError},
+    makepad_platform::event::finger::TouchState,
     *,
 };
 use matrix_sdk_ui::timeline::EventTimelineItem;
@@ -447,6 +448,8 @@ struct ImageViewer {
 
 impl Widget for ImageViewer {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        // Block all scrolling, as the image viewer modal is full-screen.
+        cx.block_scrolling_except_within(Area::Empty);
         self.view.handle_event(cx, event, scope);
         self.match_event(cx, event);
 
@@ -579,6 +582,13 @@ impl Widget for ImageViewer {
         }
         if let Event::TouchUpdate(touch_event) = event {
             self.handle_pinch_to_zoom(cx, touch_event);
+            // makepad doesn't mark a second touch on our already-captured area as "handled",
+            // so we do it ourselves to ensure widgets behind us don't capture and handle it.
+            for t in &touch_event.touches {
+                if matches!(t.state, TouchState::Start) && t.handled.get().is_empty() {
+                    t.handled.set(self.view.area());
+                }
+            }
         }
 
         if let (Event::Signal, Some((_background_task_id, receiver))) = (event, &mut self.receiver) {

--- a/src/shared/room_input_popup_menu.rs
+++ b/src/shared/room_input_popup_menu.rs
@@ -119,6 +119,12 @@ impl Widget for RoomInputPopupMenu {
             return;
         }
 
+        // Any user interaction outside of this menu dismisses it.
+        if self.should_dismiss_for_outside_event(cx, event) {
+            self.close(cx);
+            return;
+        }
+
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
     }
@@ -172,20 +178,7 @@ impl RoomInputPopupMenu {
         self.button(cx, ids!(send_location_button)).reset_hover(cx);
     }
 
-    pub fn is_event_within_popup_menu(&self, cx: &mut Cx, event: &Event) -> bool {
-        let main_rect = self.view(cx, ids!(main_content)).area().rect(cx);
-        match event {
-            Event::MouseDown(e) => main_rect.contains(e.abs),
-            Event::MouseUp(e) => main_rect.contains(e.abs),
-            Event::MouseMove(e) => main_rect.contains(e.abs),
-            Event::Scroll(e) => main_rect.contains(e.abs),
-            Event::LongPress(e) => main_rect.contains(e.abs),
-            Event::TouchUpdate(e) => e.touches.iter().any(|touch| main_rect.contains(touch.abs)),
-            _ => false,
-        }
-    }
-
-    pub fn should_dismiss_for_outside_event(&self, cx: &mut Cx, event: &Event) -> bool {
+    fn should_dismiss_for_outside_event(&self, cx: &mut Cx, event: &Event) -> bool {
         let main_rect = self.view(cx, ids!(main_content)).area().rect(cx);
         match event {
             Event::MouseDown(e) => !main_rect.contains(e.abs),
@@ -212,16 +205,6 @@ impl RoomInputPopupMenuRef {
     pub fn show(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.show(cx);
-    }
-
-    pub fn is_event_within_popup_menu(&self, cx: &mut Cx, event: &Event) -> bool {
-        let Some(inner) = self.borrow() else { return false };
-        inner.is_event_within_popup_menu(cx, event)
-    }
-
-    pub fn should_dismiss_for_outside_event(&self, cx: &mut Cx, event: &Event) -> bool {
-        let Some(inner) = self.borrow() else { return false };
-        inner.should_dismiss_for_outside_event(cx, event)
     }
 
     pub fn selected(&self, actions: &Actions) -> Option<RoomInputPopupMenuAction> {

--- a/src/shared/room_input_popup_menu.rs
+++ b/src/shared/room_input_popup_menu.rs
@@ -41,7 +41,7 @@ script_mod! {
         height: Fill
         flow: Overlay
         align: Align{x: 0, y: 1}
-        cursor: MouseCursor.Default
+        // No cursor here, since this is a Fill-Fill overlay pane.
 
         show_bg: false
         draw_bg +: {
@@ -119,7 +119,7 @@ impl Widget for RoomInputPopupMenu {
             return;
         }
 
-        // Any user interaction outside of this menu dismisses it.
+        // Clicks/taps outside the menu dismiss it, but do fall through to the widgets behind.
         if self.should_dismiss_for_outside_event(cx, event) {
             self.close(cx);
             return;
@@ -178,6 +178,19 @@ impl RoomInputPopupMenu {
         self.button(cx, ids!(send_location_button)).reset_hover(cx);
     }
 
+    pub fn is_event_within_popup_menu(&self, cx: &mut Cx, event: &Event) -> bool {
+        let main_rect = self.view(cx, ids!(main_content)).area().rect(cx);
+        match event {
+            Event::MouseDown(e) => main_rect.contains(e.abs),
+            Event::MouseUp(e) => main_rect.contains(e.abs),
+            Event::MouseMove(e) => main_rect.contains(e.abs),
+            Event::Scroll(e) => main_rect.contains(e.abs),
+            Event::LongPress(e) => main_rect.contains(e.abs),
+            Event::TouchUpdate(e) => e.touches.iter().any(|touch| main_rect.contains(touch.abs)),
+            _ => false,
+        }
+    }
+
     fn should_dismiss_for_outside_event(&self, cx: &mut Cx, event: &Event) -> bool {
         let main_rect = self.view(cx, ids!(main_content)).area().rect(cx);
         match event {
@@ -205,6 +218,11 @@ impl RoomInputPopupMenuRef {
     pub fn show(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.show(cx);
+    }
+
+    pub fn is_event_within_popup_menu(&self, cx: &mut Cx, event: &Event) -> bool {
+        let Some(inner) = self.borrow() else { return false };
+        inner.is_event_within_popup_menu(cx, event)
     }
 
     pub fn selected(&self, actions: &Actions) -> Option<RoomInputPopupMenuAction> {


### PR DESCRIPTION
* ImageViewer: prevent interactive user inputs from piercing through to widgets
  behind the image viewer; now it behaves like other modals.
* A pinch-to-zoom's second finger touch can no longer drag-scroll
  or press widgets behind the image viewer, fixed  in makepad/makepad#1187
* RoomScreen: hit system is used in more cases w.r.t. the overlay panes,
  so things are now a lot less complex to forward events to the right pane
  or to the roomscreen's children.