### PR TITLE
clearly show errors/warnings on verification problems/cancellation

### DIFF
--- a/src/verification.rs
+++ b/src/verification.rs
@@ -51,9 +51,6 @@ pub fn add_verification_event_handlers_and_sync_client(client: Client) -> tokio:
         while let Some(state) = verification_state_subscriber.next().await {
             log!("Received a verification state update: {state:?}");
             Cx::post_action(VerificationStateAction::Update(state));
-            if let VerificationState::Verified = state {
-                break;
-            }
         }
     });
 
@@ -98,8 +95,12 @@ pub fn add_verification_event_handlers_and_sync_client(client: Client) -> tokio:
 
 
 async fn dump_devices(user_id: &UserId, client: &Client) -> String {
+    let our_devices = match client.encryption().get_user_devices(user_id).await {
+        Ok(d) => d,
+        Err(e) => return format!("Couldn't get the list of devices for user {user_id}: {e}"),
+    };
     let mut devices = String::new();
-    for device in client.encryption().get_user_devices(user_id).await.unwrap().devices() {
+    for device in our_devices.devices() {
         let current = client.device_id().is_some_and(|id| id == device.device_id());
         let _ = writeln!(&mut devices,
             "    {:<10} {:<30} {:<}{}",
@@ -164,6 +165,13 @@ async fn sas_verification_handler(
                     }
                     // An old or duplicate `Accept` shouldn't be treated as us confirming the keys match.
                     Some(VerificationUserResponse::Accept) => { }
+                    Some(VerificationUserResponse::Mismatch) => {
+                        log!("User reported that the SAS keys did not match");
+                        if !sas.is_done() {
+                            let _ = sas.mismatch().await;
+                        }
+                        return;
+                    }
                     // `None` means the modal was dismissed, meaning that verification was cancelled.
                     Some(VerificationUserResponse::Cancel) | None => {
                         log!("User cancelled the SAS verification");
@@ -235,7 +243,17 @@ async fn sas_verification_handler(
 }
 
 async fn request_verification_handler(client: Client, request: VerificationRequest) {
-    log!("Received a verification request in room {:?}: {:?}", request.room_id(), request.state());
+    // A self-verification request we just sent can get delivered to us via homeserver sync,
+    // so we must ignore that instead of treating it as a new request.
+    if request.we_started() {
+        return;
+    }
+    let mut stream = request.changes();
+    let state = request.state();
+    log!("Received a verification request; {state:?}, room {:?}", request.room_id());
+    if matches!(state, VerificationRequestState::Cancelled(_) | VerificationRequestState::Done) {
+        return;
+    }
     let Some(in_progress) = VerificationInProgress::start() else {
         log!("Declining verification request: another verification is already in progress.");
         let _ = request.cancel().await;
@@ -251,8 +269,6 @@ async fn request_verification_handler(client: Client, request: VerificationReque
             }
         )
     );
-
-    let mut stream = request.changes();
 
     let mut accepted = false;
     // If the other side starts SAS before the user clicks Yes,
@@ -279,7 +295,7 @@ async fn request_verification_handler(client: Client, request: VerificationReque
                 }
                 Some(VerificationUserResponse::Accept) => { }
                 // `None` means the modal went away, which we treat as a cancel too.
-                Some(VerificationUserResponse::Cancel) | None => {
+                Some(VerificationUserResponse::Cancel | VerificationUserResponse::Mismatch) | None => {
                     log!("User cancelled the verification request.");
                     if let Err(e) = request.cancel().await {
                         Cx::post_action(VerificationAction::RequestCancelError(Arc::new(e)));
@@ -329,20 +345,13 @@ async fn request_verification_handler(client: Client, request: VerificationReque
 
 /// Sends a self-verification request to the user's other logged-in sessions,
 pub async fn request_self_verification_handler(client: Client) {
-    let Some(in_progress) = VerificationInProgress::start() else {
-        enqueue_popup_notification(
-            "A verification request is already in progress. Finish or cancel it first.",
-            PopupKind::Error,
-            Some(6.0),
-        );
-        return;
-    };
     let Some(user_id) = client.user_id() else {
         enqueue_popup_notification("Can't verify this device: you are not logged in.", PopupKind::Error, Some(5.0));
         return;
     };
 
-    let identity = match client.encryption().get_user_identity(user_id).await {
+    // Get a fresh copy of the user's device list, don't rely on a cached one
+    let identity = match client.encryption().request_user_identity(user_id).await {
         Ok(Some(identity)) => identity,
         Ok(None) => {
             enqueue_popup_notification(
@@ -358,6 +367,46 @@ pub async fn request_self_verification_handler(client: Client) {
             enqueue_popup_notification(format!("Couldn't start verification: {e}"), PopupKind::Error, Some(6.0));
             return;
         }
+    };
+
+    // If there's no other signed device to verify against, show an appropriate error or warning.
+    match client.encryption().get_user_devices(user_id).await {
+        Ok(devices) => {
+            let mut other_devices = devices.devices()
+                .filter(|d| Some(d.device_id()) != client.device_id() && !d.is_dehydrated())
+                .peekable();
+            if other_devices.peek().is_none() {
+                enqueue_popup_notification(
+                    "Cannot verify this device because it's the only one logged into this account.\n\n\
+                    Sign in to this account on another device or Matrix client, and then unlock it \
+                    with your recovery key or security phrase, then use that to verify this device.",
+                    PopupKind::Error,
+                    None,
+                );
+                return;
+            }
+            // Signing this device needs cross-signing keys, so only a cross-signed session can do it.
+            if !other_devices.any(|d| d.is_cross_signed_by_owner()) {
+                enqueue_popup_notification(
+                    "You don't have any other devices/sessions with cross-signing keys. \
+                    Verification might succeed, but this device will stay unverified.\n\n\
+                    Unlock another session with your recovery key or security phrase, then try again.",
+                    PopupKind::Warning,
+                    Some(20.0),
+                );
+            }
+        }
+        Err(e) => error!("Couldn't list our own devices before self-verification: {e:?}"),
+    }
+
+    // Now we try to start the verification flow.
+    let Some(in_progress) = VerificationInProgress::start() else {
+        enqueue_popup_notification(
+            "A verification request is already in progress. Finish or cancel it first.",
+            PopupKind::Error,
+            Some(6.0),
+        );
+        return;
     };
 
     let request = match identity.request_verification_with_methods(vec![VerificationMethod::SasV1]).await {
@@ -486,4 +535,5 @@ pub struct VerificationRequestActionState {
 pub enum VerificationUserResponse {
     Accept,
     Cancel,
+    Mismatch,
 }

--- a/src/verification_modal.rs
+++ b/src/verification_modal.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use makepad_widgets::*;
-use matrix_sdk::encryption::verification::Verification;
+use matrix_sdk::{encryption::verification::Verification, ruma::events::key::verification::cancel::CancelCode};
 
 use crate::verification::{VerificationAction, VerificationRequestActionState, VerificationUserResponse};
 
@@ -93,6 +93,9 @@ pub struct VerificationModal {
     /// meaning that the verification process has ended
     /// and that any further interaction with it should close the modal.
     #[rust(false)] is_final: bool,
+    /// Whether the emoji/decimal comparison is currently being shown,
+    /// which deetermines what the cancel button text shows.
+    #[rust(false)] is_comparing_keys: bool,
 }
 
 /// Actions emitted by the `VerificationModal`.
@@ -124,7 +127,14 @@ impl WidgetMatchEvent for VerificationModal {
 
         if cancel_button_clicked || modal_dismissed {
             if let Some(state) = self.state.as_ref() {
-                let _ = state.response_sender.send(VerificationUserResponse::Cancel);
+                // Clicking "no" should send a key mismatch response,
+                // but dismissing the modal should just cancel the verification.
+                let response = if self.is_comparing_keys && cancel_button_clicked {
+                    VerificationUserResponse::Mismatch
+                } else {
+                    VerificationUserResponse::Cancel
+                };
+                let _ = state.response_sender.send(response);
             }
             self.reset_state();
 
@@ -142,6 +152,7 @@ impl WidgetMatchEvent for VerificationModal {
                 self.reset_state();
             } else if let Some(state) = self.state.as_ref() {
                 let _ = state.response_sender.send(VerificationUserResponse::Accept);
+                self.is_comparing_keys = false;
                 accept_button.set_enabled(cx, false);
             }
         }
@@ -158,10 +169,33 @@ impl WidgetMatchEvent for VerificationModal {
                 self.view.view(cx, ids!(emojis_view)).set_visible(cx, false);
                 match verification_action {
                     VerificationAction::RequestCancelled(cancel_info) => {
-                        self.label(cx, ids!(body)).set_text(
-                            cx,
-                            &format!("Verification request was cancelled: {}", cancel_info.reason())
-                        );
+                        let text: Cow<'static, str> = match cancel_info.cancel_code() {
+                            CancelCode::Timeout => Cow::from(
+                                "The verification process timed out.\n\n\
+                                Each step must be completed fairly quickly. Try again."
+                            ),
+                            CancelCode::Accepted => Cow::from(
+                                "You handled this request on a different device."
+                            ),
+                            CancelCode::MismatchedSas => Cow::from(
+                                "The emoji did not match, so nothing was verified.\n\n\
+                                If you're sure you compared them correctly, your connection may be compromised."
+                            ),
+                            CancelCode::User if cancel_info.cancelled_by_us() => Cow::from(
+                                "Verification was cancelled on this device.\n\n\
+                                You might have started another verification request jointly, \
+                                or there was a different Matrix error. Please try again."
+                            ),
+                            CancelCode::User => Cow::from(
+                                "Verification was cancelled on the other device."
+                            ),
+                            _ => Cow::from(format!(
+                                "Verification was cancelled by {}: {}",
+                                if cancel_info.cancelled_by_us() { "this device" } else { "another device" },
+                                cancel_info.reason(),
+                            )),
+                        };
+                        self.label(cx, ids!(body)).set_text(cx, &text);
                         self.transition_to_final_state(cx, &accept_button, &cancel_button);
                     }
 
@@ -250,6 +284,7 @@ impl WidgetMatchEvent for VerificationModal {
                             self.label(cx, ids!(body)).set_text(cx, &text);
                         }
                         self.is_final = false;
+                        self.is_comparing_keys = true;
                         accept_button.set_visible(cx, true);
                         accept_button.set_enabled(cx, true);
                         accept_button.set_text(cx, "Yes");
@@ -279,7 +314,7 @@ impl WidgetMatchEvent for VerificationModal {
                         self.label(cx, ids!(body)).set_text(
                             cx,
                             "Verification completed successfully!\n\n\
-                            Now you can send and receive encrypted messages,\
+                            Now you can send and receive encrypted messages, \
                             and everyone you chat with can trust this device is yours.",
                         );
                         self.transition_to_final_state(cx, &accept_button, &cancel_button);
@@ -304,11 +339,13 @@ impl VerificationModal {
     fn reset_state(&mut self) {
         self.state = None;
         self.is_final = false;
+        self.is_comparing_keys = false;
     }
 
     /// The verification flow is waiting on another device.
     fn transition_to_waiting_state(&mut self, cx: &mut Cx, accept_button: &ButtonRef, cancel_button: &ButtonRef) {
         self.is_final = false;
+        self.is_comparing_keys = false;
         accept_button.set_enabled(cx, false);
         accept_button.set_text(cx, "Waiting…");
         cancel_button.set_text(cx, "Cancel");
@@ -323,6 +360,7 @@ impl VerificationModal {
         accept_button.set_text(cx, "Okay");
         cancel_button.set_visible(cx, false);
         self.is_final = true;
+        self.is_comparing_keys = false;
     }
 
     fn initialize_with_data(
@@ -364,6 +402,7 @@ impl VerificationModal {
 
         self.state = Some(state);
         self.is_final = false;
+        self.is_comparing_keys = false;
     }
 }
 


### PR DESCRIPTION
If a user tries to verify with no cross-signed devices on their account, the homeserver will send our own impossible request back to us, so we now handle that explicitly.

We also do a check before accepting the verification request to see if it's even possible to succeed. This just amoutns to checking the account's list of devices so we can determine if there are any others and if any of them are cross-signed.
If not, we emit a clear error or warning, respectively.

We also differentiate between the user canceling a request and stating that the emoji keys are mismatched. The matrix sdk now offers more cancel codes, so we dispaly those as well.