### PR TITLE
Ensure that all room/space names are always updated upon change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "bit-vec",
 ]
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "bitflags"
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "bitmaps"
@@ -834,7 +834,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "byteorder"
@@ -845,7 +845,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "bytes"
@@ -904,7 +904,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "cfg_aliases"
@@ -915,7 +915,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "chacha20"
@@ -1252,7 +1252,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "crypto-bigint"
@@ -1632,7 +1632,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "dunce"
@@ -1767,7 +1767,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "errno"
@@ -1945,7 +1945,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "foreign-types"
@@ -2102,9 +2102,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
@@ -2300,9 +2300,9 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
@@ -2335,7 +2335,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "hilog-sys"
@@ -2774,10 +2774,10 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
@@ -2969,9 +2969,9 @@ dependencies = [
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "windows-link 0.2.1",
 ]
 
@@ -3043,7 +3043,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "loom"
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -3132,12 +3132,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3179,15 +3179,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3195,27 +3195,27 @@ dependencies = [
 [[package]]
 name = "makepad-fast-inflate"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "weezl",
 ]
@@ -3223,10 +3223,10 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
- "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "num-traits 0.2.20",
  "zerocopy 0.8.39",
 ]
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3248,7 +3248,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "ttf-parser",
 ]
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3289,12 +3289,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3325,15 +3325,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3356,7 +3356,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3368,12 +3368,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3381,13 +3381,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3404,14 +3404,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "makepad-video"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-apple-sys",
  "makepad-objc-sys",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3475,13 +3475,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "simd-adler32",
 ]
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-fast-inflate",
  "makepad-zune-core",
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3906,7 +3906,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "memoffset"
@@ -3978,23 +3978,23 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "bit-set",
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
- "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "hexf-parse",
- "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "makepad-error-log",
  "makepad-half",
  "num-traits 0.2.20",
- "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "unicode-ident",
 ]
 
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "num_cpus"
@@ -4326,7 +4326,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4636,7 +4636,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "polling"
@@ -4795,10 +4795,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "unicase 2.9.0",
 ]
 
@@ -5580,7 +5580,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "rustc-hash"
@@ -5705,12 +5705,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5799,7 +5799,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "scopeguard"
@@ -5810,7 +5810,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "sealed"
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "siphasher"
@@ -6146,7 +6146,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "socket2"
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6541,9 +6541,9 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
- "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
@@ -6571,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "tungstenite"
@@ -7016,7 +7016,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-bidi"
@@ -7027,17 +7027,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-ident"
@@ -7048,7 +7048,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-normalization"
@@ -7068,12 +7068,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7084,7 +7084,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "unicode-xid"
@@ -7410,11 +7410,11 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "downcast-rs",
  "libc",
- "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
  "smallvec 1.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys",
 ]
@@ -7422,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7451,10 +7451,10 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "log 0.4.29",
- "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured)",
+ "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
 ]
 
 [[package]]
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "whoami"
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7607,7 +7607,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7692,7 +7692,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "windows-numerics"
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8316,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=second_touch_stays_captured#697bf7016aae9c07afe425e9e4be9227b79d8cba"
+source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "bit-vec",
 ]
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "bitflags"
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "bitmaps"
@@ -834,7 +834,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "byteorder"
@@ -845,7 +845,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "bytes"
@@ -904,7 +904,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "cfg_aliases"
@@ -915,7 +915,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "chacha20"
@@ -1252,7 +1252,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "crypto-bigint"
@@ -1632,7 +1632,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "dunce"
@@ -1767,7 +1767,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "errno"
@@ -1945,7 +1945,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "foreign-types"
@@ -2102,9 +2102,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -2300,9 +2300,9 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "foldhash 0.2.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -2335,7 +2335,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "hilog-sys"
@@ -2774,10 +2774,10 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "equivalent 1.0.2 (git+https://github.com/makepad/makepad?branch=dev)",
+ "hashbrown 0.16.1 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -2963,15 +2963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "cfg-if 1.0.4 (git+https://github.com/makepad/makepad?branch=dev)",
  "windows-link 0.2.1",
 ]
 
@@ -3043,7 +3043,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "loom"
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -3132,12 +3132,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3179,15 +3179,15 @@ dependencies = [
  "rustybuzz",
  "sdfer",
  "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3195,27 +3195,27 @@ dependencies = [
 [[package]]
 name = "makepad-fast-inflate"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "weezl",
 ]
@@ -3223,10 +3223,10 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
- "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "cfg-if 1.0.4 (git+https://github.com/makepad/makepad?branch=dev)",
+ "crunchy 0.2.4 (git+https://github.com/makepad/makepad?branch=dev)",
  "num-traits 0.2.20",
  "zerocopy 0.8.39",
 ]
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3248,7 +3248,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "ttf-parser",
 ]
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-live-id-macros",
  "serde",
@@ -3265,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3273,7 +3273,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3289,12 +3289,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3325,15 +3325,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3356,7 +3356,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3368,12 +3368,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3381,13 +3381,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3404,14 +3404,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3421,7 +3421,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "makepad-video"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-apple-sys",
  "makepad-objc-sys",
@@ -3449,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -3475,13 +3475,13 @@ dependencies = [
  "pulldown-cmark 0.12.2",
  "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "simd-adler32",
 ]
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-fast-inflate",
  "makepad-zune-core",
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3906,7 +3906,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "memoffset"
@@ -3978,23 +3978,23 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "arrayvec 0.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
  "bit-set",
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
- "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
- "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "cfg-if 1.0.4 (git+https://github.com/makepad/makepad?branch=dev)",
+ "cfg_aliases 0.2.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "hashbrown 0.16.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "hexf-parse",
- "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "indexmap 2.13.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "makepad-error-log",
  "makepad-half",
  "num-traits 0.2.20",
- "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "once_cell 1.21.3 (git+https://github.com/makepad/makepad?branch=dev)",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "thiserror 2.0.18 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicode-ident",
 ]
 
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "num_cpus"
@@ -4326,7 +4326,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4636,7 +4636,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "polling"
@@ -4795,10 +4795,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
- "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
  "unicase 2.9.0",
 ]
 
@@ -5580,7 +5580,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "rustc-hash"
@@ -5705,12 +5705,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5799,7 +5799,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "scopeguard"
@@ -5810,7 +5810,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "sealed"
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "siphasher"
@@ -6146,7 +6146,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "socket2"
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6541,9 +6541,9 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
- "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "thiserror-impl 2.0.18 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -6571,7 +6571,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "tungstenite"
@@ -7016,7 +7016,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-bidi"
@@ -7027,17 +7027,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-ident"
@@ -7048,7 +7048,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-normalization"
@@ -7068,12 +7068,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7084,7 +7084,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "unicode-xid"
@@ -7410,11 +7410,11 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "downcast-rs",
  "libc",
- "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "scoped-tls 1.0.1 (git+https://github.com/makepad/makepad?branch=dev)",
  "smallvec 1.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys",
 ]
@@ -7422,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7441,7 +7441,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7451,10 +7451,10 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "log 0.4.29",
- "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view)",
+ "pkg-config 0.3.32 (git+https://github.com/makepad/makepad?branch=dev)",
 ]
 
 [[package]]
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "whoami"
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7607,7 +7607,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7692,7 +7692,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "windows-numerics"
@@ -7736,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8316,7 +8316,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/kevinaboos/makepad?branch=stack_nav_destination_view#50aedcf075d16008ff57978abffc99a72f589ce0"
+source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ version = "1.0.0-alpha.2"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "stack_nav_destination_view", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "stack_nav_destination_view" }
+makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
 
 robius-directories = { git = "https://github.com/project-robius/robius" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ version = "1.0.0-alpha.2"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "second_touch_stays_captured", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "second_touch_stays_captured" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "stack_nav_destination_view", features = ["serde"] }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "stack_nav_destination_view" }
 
 
 robius-directories = { git = "https://github.com/project-robius/robius" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -350,6 +350,32 @@ impl MatchEvent for App {
                 continue;
             }
 
+            // Handle room name changes by updating all cached instances.
+            if let Some(
+                AppStateAction::RoomNameUpdated(new_room_name)
+                | AppStateAction::RoomLoadedSuccessfully { room_name_id: new_room_name, .. }
+            ) = action.downcast_ref() {
+                if let Some(selected_room) = self.app_state.selected_room.as_mut() {
+                    selected_room.update_room_name(new_room_name);
+                }
+                for saved in std::iter::once(&mut self.app_state.saved_dock_state_home)
+                    .chain(self.app_state.saved_dock_state_per_space.values_mut())
+                {
+                    for room in saved.selected_room.iter_mut().chain(saved.room_order.iter_mut()) {
+                        room.update_room_name(new_room_name);
+                    }
+                    // The tab's name is what actually gets rendered when a saved dock
+                    // is loaded, so it has to be updated alongside the `SelectedRoom`.
+                    for (tab_id, room) in saved.open_rooms.iter_mut() {
+                        if room.update_room_name(new_room_name)
+                            && let Some(DockItem::Tab { name, .. }) = saved.dock_items.get_mut(tab_id)
+                        {
+                            *name = room.display_name();
+                        }
+                    }
+                }
+            }
+
             // Handle actions that instruct us to update the top-level app state.
             match action.downcast_ref() {
                 Some(AppStateAction::RoomFocused(selected_room)) => {
@@ -1077,6 +1103,23 @@ impl SelectedRoom {
         }
     }
 
+    /// Updates this room's name if it refers to the same room (same room ID).
+    ///
+    /// Returns `true` if the name was replaced.
+    pub fn update_room_name(&mut self, new_room_name: &RoomNameId) -> bool {
+        let (SelectedRoom::JoinedRoom { room_name_id }
+            | SelectedRoom::Thread { room_name_id, .. }
+            | SelectedRoom::InvitedRoom { room_name_id }
+            | SelectedRoom::Space { space_name_id: room_name_id }) = self;
+        if room_name_id.room_id() != new_room_name.room_id()
+            || room_name_id.display_name() == new_room_name.display_name()
+        {
+            return false;
+        }
+        *room_name_id = new_room_name.clone();
+        true
+    }
+
     /// Returns the `LiveId` of the room tab corresponding to this `SelectedRoom`.
     pub fn tab_id(&self) -> LiveId {
         match self {
@@ -1167,6 +1210,10 @@ pub enum AppStateAction {
     /// The given room has successfully been upgraded from being displayed
     /// as an InviteScreen to a RoomScreen.
     UpgradedInviteToJoinedRoom(OwnedRoomId),
+    /// The given room or space has a new name.
+    ///
+    /// This triggers an update to every cached copy of that room/space name.
+    RoomNameUpdated(RoomNameId),
     /// The given app state was loaded from persistent storage
     /// and is ready to be restored.
     RestoreAppStateFromPersistentState(AppState),

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -598,6 +598,22 @@ impl Widget for HomeScreen {
                 if let StackNavigationAction::Pop = action.as_widget_action().cast() {
                     self.pop_selected_screen_view(cx, app_state);
                 }
+
+                if let Some(
+                    AppStateAction::RoomNameUpdated(new_room_name)
+                    | AppStateAction::RoomLoadedSuccessfully { room_name_id: new_room_name, .. }
+                ) = action.downcast_ref() {
+                    for room in &mut self.mobile_screen_history {
+                        room.update_room_name(new_room_name);
+                    }
+                    let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
+                    if let Some(view_id) = stack_navigation.destination_view()
+                        && let Some(room) = app_state.selected_room.as_ref()
+                        && room.room_id() == new_room_name.room_id()
+                    {
+                        stack_navigation.set_title(cx, view_id, &room.display_name());
+                    }
+                }
             }
         }
 

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -599,6 +599,26 @@ impl WidgetMatchEvent for MainDesktopUI {
                 RoomsListAction::None => { }
             }
 
+            // Handle potential changes to room names.
+            if let Some(
+                AppStateAction::RoomNameUpdated(new_room_name)
+                | AppStateAction::RoomLoadedSuccessfully { room_name_id: new_room_name, .. }
+            ) = action.downcast_ref() {
+                let dock = self.view.dock(cx, ids!(dock));
+                for (tab_id, room) in self.open_rooms.iter_mut() {
+                    if room.update_room_name(new_room_name) {
+                        dock.set_tab_title(cx, *tab_id, room.display_name());
+                    }
+                }
+                for room in self.most_recently_selected_room
+                    .iter_mut()
+                    .chain(self.room_order.iter_mut())
+                {
+                    room.update_room_name(new_room_name);
+                }
+                continue;
+            }
+
             // Handle our own actions related to dock updates that we have previously emitted.
             match action.downcast_ref() {
                 Some(MainDesktopUiAction::LoadDockFromAppState) => {

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1064,6 +1064,14 @@ impl Widget for RoomScreen {
             self.handle_message_actions(cx, actions, &portal_list, &loading_pane);
 
             for action in actions {
+                if let Some(AppStateAction::RoomNameUpdated(new_room_name)) = action.downcast_ref()
+                    && let Some(room_name_id) = self.room_name_id.as_mut()
+                    && room_name_id.room_id() == new_room_name.room_id()
+                {
+                    *room_name_id = new_room_name.clone();
+                    continue;
+                }
+
                 // Handle actions related to restoring the previously-saved state of rooms.
                 if let Some(AppStateAction::RoomLoadedSuccessfully { room_name_id, ..}) = action.downcast_ref() {
                     if self.room_name_id.as_ref().is_some_and(|rn| rn.room_id() == room_name_id.room_id()) {

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -757,10 +757,8 @@ impl RoomsList {
                     }
                 }
                 RoomsListUpdate::UpdateRoomName { new_room_name } => {
-
-                    // TODO: broadcast a new AppState action to ensure that this room's or space's new name
-                    //       gets updated in all of the `SelectedRoom` instances throughout Robrix,
-                    //       e.g., the name of the room in the Dock Tab or the StackNav header.
+                    // Broadcast this room name change to the rest of Robrix's UI elements.
+                    cx.action(AppStateAction::RoomNameUpdated(new_room_name.clone()));
 
                     let room_id = new_room_name.room_id().clone();
                     // Try to update joined room first
@@ -1512,6 +1510,15 @@ impl Widget for RoomsList {
                 if let Some(MainFilterAction::Changed(keywords)) = action.downcast_ref() {
                     self.regenerate_display_filter_and_sort_fn(keywords);
                     self.update_displayed_rooms(cx, true);
+                    continue;
+                }
+
+                // Update the selected space name too, if that's what changed.
+                if let Some(AppStateAction::RoomNameUpdated(new_room_name)) = action.downcast_ref()
+                    && let Some(selected_space) = self.selected_space.as_mut()
+                    && selected_space.room_id() == new_room_name.room_id()
+                {
+                    *selected_space = new_room_name.clone();
                     continue;
                 }
 

--- a/src/home/rooms_list_header.rs
+++ b/src/home/rooms_list_header.rs
@@ -7,8 +7,10 @@ use std::mem::discriminant;
 
 use makepad_widgets::*;
 use matrix_sdk_ui::sync_service::State;
+use ruma::OwnedRoomId;
 
 use crate::{
+    app::AppStateAction,
     avatar_cache,
     home::navigation_tab_bar::{NavigationBarAction, SelectedTab},
     profile::user_profile_cache,
@@ -93,6 +95,9 @@ pub struct RoomsListHeader {
     #[deref] view: View,
 
     #[rust(State::Idle)] sync_state: State,
+
+    /// Used for updating the name of the currently-selected space.
+    #[rust] displayed_space: Option<OwnedRoomId>,
 }
 
 impl Widget for RoomsListHeader {
@@ -158,9 +163,21 @@ impl Widget for RoomsListHeader {
                     match tab {
                         SelectedTab::Space { space_name_id } => {
                             header_title.set_text(cx, &space_name_id.display());
+                            self.displayed_space = Some(space_name_id.room_id().clone());
                         }
-                        _ => header_title.set_text(cx, "All Rooms"),
+                        _ => {
+                            header_title.set_text(cx, "All Rooms");
+                            self.displayed_space = None;
+                        }
                     }
+                    continue;
+                }
+
+                // If the name of the currently-selected space was changed, update the header title.
+                if let Some(AppStateAction::RoomNameUpdated(new_room_name)) = action.downcast_ref()
+                    && self.displayed_space.as_ref().is_some_and(|id| id == new_room_name.room_id())
+                {
+                    self.view.label(cx, ids!(header_title)).set_text(cx, &new_room_name.display());
                     continue;
                 }
             }

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -1054,6 +1054,15 @@ impl Widget for SpaceLobbyScreen {
 
         if let Event::Actions(actions) = event {
             for action in actions {
+                // Just like the rooms list header, handle updates to a space's name.
+                if let Some(AppStateAction::RoomNameUpdated(new_room_name)) = action.downcast_ref()
+                    && self.space_name_id.as_ref().is_some_and(|sni| sni.room_id() == new_room_name.room_id())
+                {
+                    self.set_displayed_space(cx, new_room_name);
+                    self.redraw(cx);
+                    continue;
+                }
+
                 match action.downcast_ref() {
                     Some(SpaceRoomListAction::DetailedChildren { space_id, children, .. }) => {
                         self.update_children_in_space(cx, space_id, children);
@@ -1752,9 +1761,9 @@ impl SpaceLobbyScreen {
         let parent_name = self.view.label(cx, ids!(header.parent_space_row.parent_name));
         parent_name.set_text(cx, &space_name);
 
-        // If this space is already being displayed, then the only thing we may need to do
-        // is update its name in the top-level header (already done above).
+        // If this space is already being displayed, then update its name here in case it changed.
         if self.space_name_id.as_ref().is_some_and(|sni| sni.room_id() == space_name_id.room_id()) {
+            self.space_name_id = Some(space_name_id.clone());
             return;
         }
 

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -13,7 +13,7 @@ use matrix_sdk::{RoomDisplayName, RoomState};
 use ruma::{OwnedRoomAliasId, OwnedRoomId, room::JoinRuleSummary};
 
 use crate::{
-    home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction}, utils::{self, RoomNameId}
+    app::AppStateAction, home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction}, utils::{self, RoomNameId}
 };
 
 script_mod! {
@@ -596,6 +596,7 @@ impl SpacesBar {
                             RoomDisplayName::Named(new_space_name),
                             space_id.clone(),
                         );
+                        cx.action(AppStateAction::RoomNameUpdated(space.space_name_id.clone()));
                         let should_display = (self.display_filter)(space);
                         adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
                     } else {

--- a/src/space_service_sync.rs
+++ b/src/space_service_sync.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{Client, RoomState, media::MediaRequestParameters};
 use matrix_sdk_ui::spaces::{SpaceRoom, SpaceRoomList, SpaceService, room_list::SpaceRoomListPaginationState};
 use ruma::{OwnedMxcUri, OwnedRoomId, events::room::MediaSource, room::RoomType};
 use tokio::{runtime::Handle, sync::mpsc::{UnboundedReceiver, UnboundedSender}, task::JoinHandle};
-use crate::{home::{rooms_list::{RoomsListUpdate, enqueue_rooms_list_update}, spaces_bar::{JoinedSpaceInfo, SpacesListUpdate, enqueue_spaces_list_update}}, room::FetchedRoomAvatar, utils::{self, RoomNameId}};
+use crate::{app::AppStateAction, home::{rooms_list::{RoomsListUpdate, enqueue_rooms_list_update}, spaces_bar::{JoinedSpaceInfo, SpacesListUpdate, enqueue_spaces_list_update}}, room::FetchedRoomAvatar, utils::{self, RoomNameId}};
 
 /// Whether to enable verbose logging of all spaces service diff updates.
 const LOG_SPACE_SERVICE_DIFFS: bool = cfg!(feature = "log_space_service_diffs");
@@ -359,6 +359,9 @@ async fn add_new_space(space: &SpaceRoom, client: &Client) {
         guest_can_join: space.guest_can_join,
         children_count: space.children_count,
     };
+    // If this space was renamed since the last time we received it,
+    // Robrix might be showing an out-of-date name, so broadcast the new name.
+    Cx::post_action(AppStateAction::RoomNameUpdated(jsi.space_name_id.clone()));
     enqueue_spaces_list_update(SpacesListUpdate::AddJoinedSpace(jsi));
 }
 


### PR DESCRIPTION
e.g., dock tab titles, stack nav headers, rooms list header title, etc

lots of this was a to-do, but now it's all done. Dont' think we missed any cases where the room name was cached and we weren't changing it

Also, update makepad with our change to make it easier to access which view is currently being shown by the stack nav widget