### PR TITLE
Implement "Jump to Read Receipt" button; improve searching for events

### DIFF
--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -91,11 +91,13 @@ script_mod! {
 
 
 /// The state of a LoadingPane: the possible tasks that it may be performing.
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub enum LoadingPaneState {
     /// The room is being backwards paginated until the target event is reached.
     BackwardsPaginateUntilEvent {
         target_event_id: OwnedEventId,
+        /// A human-friendly description of what message/event we're searching for.
+        description: String,
         /// The number of events paginated so far, which is only used to display progress.
         events_paginated: usize,
         /// The sender for timeline requests for the room that is showing this modal.
@@ -109,26 +111,24 @@ pub enum LoadingPaneState {
     #[default]
     None,
 }
+impl Drop for LoadingPaneState {
+    fn drop(&mut self) {
+        // upon drop, tell the background async task to stop looking for the target event,
+        // because the UI side no longer cares about it (the user closed the room, thread, or loading pane).
+        let Self::BackwardsPaginateUntilEvent { target_event_id, request_sender, .. } = self else { return };
+        request_sender.send_if_modified(|req| {
+            let initial_len = req.backwards_paginate.len();
+            req.backwards_paginate.retain(|r| &r.target_event_id != target_event_id);
+            req.backwards_paginate.len() != initial_len
+        });
+    }
+}
 
 
 #[derive(Script, ScriptHook, Widget)]
 pub struct LoadingPane {
     #[deref] view: View,
     #[rust] state: LoadingPaneState,
-}
-impl Drop for LoadingPane {
-    fn drop(&mut self) {
-        if let LoadingPaneState::BackwardsPaginateUntilEvent { target_event_id, request_sender, .. } = &self.state {
-            warning!("Dropping LoadingPane with target_event_id: {}", target_event_id);
-            request_sender.send_if_modified(|req| {
-                let initial_len = req.backwards_paginate.len();
-                req.backwards_paginate.retain(|r| &r.target_event_id != target_event_id);
-                // if we actually cancelled this request, notify the receivers
-                // such that they can stop looking for the target event.
-                req.backwards_paginate.len() != initial_len
-            });
-        }
-    }
 }
 
 
@@ -175,21 +175,7 @@ impl Widget for LoadingPane {
             }
         };
         if close_pane {
-            if let LoadingPaneState::BackwardsPaginateUntilEvent { target_event_id, request_sender, .. } = &self.state {
-                let _did_send = request_sender.send_if_modified(|req| {
-                    let initial_len = req.backwards_paginate.len();
-                    req.backwards_paginate.retain(|r| &r.target_event_id != target_event_id);
-                    // if we actually cancelled this request, notify the receivers
-                    // such that they can stop looking for the target event.
-                    req.backwards_paginate.len() != initial_len
-                });
-                log!("LoadingPane: {} cancel request for target_event_id: {target_event_id}",
-                    if _did_send { "Sent" } else { "Did not send" },
-                );
-            }
-            self.set_state(cx, LoadingPaneState::None);
-            cx.revert_key_focus();
-            self.visible = false;
+            self.hide(cx);
         }
     }
 }
@@ -199,6 +185,16 @@ impl LoadingPane {
     /// Returns `true` if this pane is currently being shown.
     pub fn is_currently_shown(&self, _cx: &mut Cx) -> bool {
         self.visible
+    }
+
+    /// Hides this pane, which also cancels any search it was showing.
+    pub fn hide(&mut self, cx: &mut Cx) {
+        self.set_state(cx, LoadingPaneState::None);
+        // Only give back key focus if we still had it; something else may have taken it.
+        if cx.has_key_focus(self.view.area()) {
+            cx.revert_key_focus();
+        }
+        self.visible = false;
     }
 
     pub fn show(&mut self, cx: &mut Cx) {
@@ -211,13 +207,13 @@ impl LoadingPane {
         let cancel_button = self.button(cx, ids!(cancel_button));
         match &state {
             LoadingPaneState::BackwardsPaginateUntilEvent {
-                target_event_id,
+                description,
                 events_paginated,
                 ..
             } => {
                 self.set_title(cx, "Searching older messages...");
                 self.set_status(cx, &format!(
-                    "Looking for event {target_event_id}\n\n\
+                    "Looking for {description}...\n\n\
                     Fetched {events_paginated} messages so far...",
                 ));
                 cancel_button.set_text(cx, "Cancel");
@@ -254,6 +250,27 @@ impl LoadingPaneRef {
     pub fn show(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.show(cx);
+    }
+
+    /// See [`LoadingPane::hide()`]
+    pub fn hide(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.hide(cx);
+    }
+
+    /// Returns `true` if this pane is currently searching for any event.
+    pub fn is_searching(&self) -> bool {
+        self.borrow().is_some_and(|inner|
+            matches!(inner.state, LoadingPaneState::BackwardsPaginateUntilEvent { .. })
+        )
+    }
+
+    /// Returns the target event ID this pane is currently searching for, if any.
+    pub fn searching_for(&self) -> Option<OwnedEventId> {
+        self.borrow().and_then(|inner| match &inner.state {
+            LoadingPaneState::BackwardsPaginateUntilEvent { target_event_id, .. } => Some(target_event_id.clone()),
+            _ => None,
+        })
     }
 
     pub fn take_state(&self) -> LoadingPaneState {

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -28,7 +28,7 @@ use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, e
 use matrix_sdk_ui::sync_service::State;
 use crate::{
     app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
-        user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
+        user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneAction, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     },
     room::{BasicRoomDetails, reply_preview::{CollapsiblePreviewRef, CollapsiblePreviewWidgetRefExt}, room_input_bar::{RoomInputBarState, RoomInputBarWidgetRefExt}, typing_notice::TypingNoticeWidgetExt},
@@ -63,6 +63,17 @@ const BLURHASH_IMAGE_MAX_SIZE: u32 = 32;
 
 /// How long after scrolling/interaction stops before we send read receipts.
 const READ_RECEIPT_SEND_DELAY: f64 = 0.5;
+
+/// The timeout/delay between pagination finishing and us showing an error.
+const JUMP_SEARCH_NOT_FOUND_DELAY: f64 = 2.0;
+
+/// The error shown when a jumped-to event can't be found.
+/// `noun` is what the search covered, i.e. "room" or "thread".
+fn jump_target_not_found_msg(noun: &str) -> String {
+    format!("Couldn't find that message in this {noun}'s history.\n\n\
+        It may have been deleted, it may be a kind of event that Robrix doesn't display, \
+        or the server may not be able to return it.")
+}
 
 static UNNAMED_ROOM: &str = "Unnamed Room";
 
@@ -827,6 +838,35 @@ impl ReadReceiptState {
     }
 }
 
+
+/// Returns the user's display name in the given room, falling back to their user ID.
+fn display_name_or_user_id(cx: &mut Cx, room_id: &OwnedRoomId, user_id: OwnedUserId) -> String {
+    user_profile_cache::get_user_display_name_for_room(cx, user_id.clone(), Some(room_id), false)
+        .into_option()
+        .unwrap_or_else(|| user_id.to_string())
+}
+
+/// Searches backwards from `max_idx` through at most `limit` items
+/// for the item with the given event ID.
+pub(crate) fn index_of_event(
+    items: &Vector<Arc<TimelineItem>>,
+    event_id: &EventId,
+    max_idx: usize,
+    limit: usize,
+) -> Option<usize> {
+    items
+        .focus()
+        .narrow(..max_idx)
+        .into_iter()
+        .rev()
+        .take(limit)
+        .position(|i| i.as_event()
+            .and_then(|e| e.event_id())
+            .is_some_and(|ev_id| ev_id == event_id)
+        )
+        .map(|position| max_idx.saturating_sub(position).saturating_sub(1))
+}
+
 /// The main widget that displays a single Matrix room.
 #[derive(Script, Widget)]
 pub struct RoomScreen {
@@ -853,6 +893,11 @@ pub struct RoomScreen {
     #[rust] cached_refs: Option<RoomScreenWidgetRefs>,
     /// Decides when to send read receipts; see [`ReadReceiptState`].
     #[rust] read_receipt_state: ReadReceiptState,
+    /// The user whose read receipt we're currently waiting to jump to, if any.
+    /// This lets us ignore a response that arrives after the user gave up on it.
+    #[rust] pending_read_receipt_jump: Option<OwnedUserId>,
+    /// Fires when a background search for a jumped-to event has gone quiet.
+    #[rust] jump_search_timer: Timer,
 }
 
 /// Cached references to RoomScreen child widgets used in every event handler.
@@ -943,6 +988,29 @@ impl Widget for RoomScreen {
             && !loading_pane.is_currently_shown(cx)
         {
             self.send_read_receipts_for_visible_events(cx, &portal_list);
+        }
+
+        // If pagination has completed, we wait for a bit to ensure that the new events get delivered to this timeline.
+        if self.jump_search_timer.is_event(event).is_some() {
+            self.jump_search_timer = Timer::empty();
+            let search_target = loading_pane.searching_for();
+            // Process pending timeline updates, since they might include the event we're looking for.
+            self.process_timeline_updates(cx, &portal_list);
+            // If we didn't find it and nothing else changed, we have to assume the search is over (unsuccessfully).
+            let is_search_over = search_target.is_some()
+                && loading_pane.searching_for() == search_target
+                && self.jump_search_timer.is_empty()
+                && !self.tl_state.as_ref().is_some_and(|tl| tl.is_paginating);
+            if is_search_over && let Some(target_event_id) = search_target {
+                warning!("Couldn't find event {target_event_id} in room {:?}", self.room_id());
+                // Dropping the taken state cancels the search request.
+                drop(loading_pane.take_state());
+                loading_pane.set_state(cx, LoadingPaneState::Error(
+                    jump_target_not_found_msg(
+                        self.tl_state.as_ref().map_or("room", |tl| tl.kind.desc())
+                    )
+                ));
+            }
         }
 
         // Handle actions here before processing timeline updates.
@@ -1252,6 +1320,20 @@ impl Widget for RoomScreen {
                         room_member: None,
                     },
                 );
+            }
+
+            // Handle a request to jump to a given user's latest read receipt (last-seen event).
+            if let UserProfilePaneAction::JumpToReadReceipt(user_id) = action.as_widget_action().cast() {
+                let Some(timeline_kind) = self.tl_state.as_ref().map(|tl| tl.kind.clone()) else {
+                    error!("BUG: can't jump to {user_id}'s read receipt with no timeline kind.");
+                    return false;
+                };
+                submit_async_request(MatrixRequest::GetUserReadReceipt {
+                    timeline_kind,
+                    user_id: user_id.clone(),
+                });
+                self.pending_read_receipt_jump = Some(user_id);
+                return false;
             }
 
             /*
@@ -1594,6 +1676,7 @@ impl RoomScreen {
     fn process_timeline_updates(&mut self, cx: &mut Cx, portal_list: &PortalListRef) {
         let top_space = self.view(cx, ids!(top_space));
         let jump_to_bottom_button = self.jump_to_bottom_button(cx, ids!(jump_to_bottom_button));
+        let loading_pane = self.view.loading_pane(cx, ids!(loading_pane));
         let curr_first_id = portal_list.first_id();
         let ui = self.widget_uid();
         let Some(tl) = self.tl_state.as_mut() else { return };
@@ -1601,6 +1684,7 @@ impl RoomScreen {
         let mut done_loading = false;
         let mut should_continue_backwards_pagination = false;
         let mut typing_users = None;
+        let mut jump_to_read_receipt = None;
         let mut num_updates = 0;
         while let Ok(update) = tl.update_receiver.try_recv() {
             num_updates += 1;
@@ -1709,23 +1793,14 @@ impl RoomScreen {
 
                     if prior_items_changed {
                         // If this RoomScreen is showing the loading pane and has an ongoing backwards pagination request,
-                        // then we should update the status message in that loading pane
-                        // and then continue paginating backwards until we find the target event.
+                        // then we should update the status message in that loading pane.
                         // Note that we do this here because `clear_cache` will always be true if backwards pagination occurred.
-                        let loading_pane = self.view.loading_pane(cx, ids!(loading_pane));
                         let mut loading_pane_state = loading_pane.take_state();
                         if let LoadingPaneState::BackwardsPaginateUntilEvent {
                             events_paginated, target_event_id, ..
                         } = &mut loading_pane_state {
                             *events_paginated += new_items.len().saturating_sub(tl.items.len());
                             log!("While finding target event {target_event_id}, we have now loaded {events_paginated} messages...");
-                            // Here, we assume that we have not yet found the target event,
-                            // so we need to continue paginating backwards.
-                            // If the target event has already been found, it will be handled
-                            // in the `TargetEventFound` match arm below, which will set
-                            // `should_continue_backwards_pagination` to `false`.
-                            // So either way, it's okay to set this to `true` here.
-                            should_continue_backwards_pagination = true;
                         }
                         loading_pane.set_state(cx, loading_pane_state);
                     }
@@ -1759,11 +1834,13 @@ impl RoomScreen {
                 }
                 TimelineUpdate::TargetEventFound { target_event_id, index } => {
                     // log!("Target event found in room {}: {target_event_id}, index: {index}", tl.kind.room_id());
-                    tl.request_sender.send_if_modified(|req| {
-                        req.backwards_paginate.retain(|r| &r.room_id != tl.kind.room_id());
-                        // no need to notify/wake-up all receivers for a completed request
-                        false
-                    });
+                    // Ignore a target-event-found result if we're no longer waiting on it.
+                    if loading_pane.searching_for().as_ref() != Some(&target_event_id) {
+                        continue;
+                    }
+                    // Stop & reset the timeout timer now that we've found it.
+                    cx.stop_timer(self.jump_search_timer);
+                    self.jump_search_timer = Timer::empty();
 
                     // sanity check: ensure the target event is in the timeline at the given `index`.
                     let item = tl.items.get(index);
@@ -1771,14 +1848,13 @@ impl RoomScreen {
                         item.as_event()
                             .is_some_and(|ev| ev.event_id() == Some(&target_event_id))
                     );
-                    let loading_pane = self.view.loading_pane(cx, ids!(loading_pane));
 
                     // log!("TargetEventFound: is_valid? {is_valid}. room {}, event {target_event_id}, index {index} of {}\n  --> item: {item:?}", tl.kind.room_id(), tl.items.len());
                     if is_valid {
                         // We successfully found the target event, so we can close the loading pane,
                         // reset the loading panestate to `None`, and stop issuing backwards pagination requests.
-                        loading_pane.set_status(cx, "Successfully found replied-to message!");
-                        loading_pane.set_state(cx, LoadingPaneState::None);
+                        loading_pane.set_status(cx, "Successfully found the target message!");
+                        loading_pane.hide(cx);
 
                         // NOTE: this code was copied from the `MessageAction::JumpToRelated` handler;
                         //       we should deduplicate them at some point.
@@ -1796,7 +1872,7 @@ impl RoomScreen {
                         error!("Target event index {index} of {} is out of bounds for room {}", tl.items.len(), tl.kind.room_id());
                         // Show this error in the loading pane, which should already be open.
                         loading_pane.set_state(cx, LoadingPaneState::Error(
-                            String::from("Unable to find related message; it may have been deleted.")
+                            jump_target_not_found_msg(tl.kind.desc())
                         ));
                     }
 
@@ -1810,6 +1886,9 @@ impl RoomScreen {
                         tl.is_paginating = true;
                         top_space.set_visible(cx, true);
                         done_loading = false;
+                        // if we started another round of backwards pagination, reset the timeout timer.
+                        cx.stop_timer(self.jump_search_timer);
+                        self.jump_search_timer = Timer::empty();
                     } else {
                         error!("Unexpected PaginationRunning update in the Forwards direction");
                     }
@@ -1827,6 +1906,10 @@ impl RoomScreen {
                     // really that valuable when the user can just try to scroll again.
                     tl.pending_reached_start = false;
                     done_loading = true;
+                    // Start the timeout timer upon a failure to back-paginate more.
+                    if direction == PaginationDirection::Backwards && loading_pane.is_searching() {
+                        self.jump_search_timer = cx.start_timeout(JUMP_SEARCH_NOT_FOUND_DELAY);
+                    }
                 }
                 TimelineUpdate::PaginationIdle { fully_paginated, direction } => {
                     if direction == PaginationDirection::Backwards {
@@ -1837,9 +1920,21 @@ impl RoomScreen {
                         if fully_paginated {
                             tl.pending_reached_start = false;
                             done_loading = true;
-                        } else if tl.pending_reached_start || portal_list.first_id() <= 2 {
-                            tl.pending_reached_start = false;
-                            should_continue_backwards_pagination = true;
+                            if loading_pane.is_searching() {
+                                self.jump_search_timer = cx.start_timeout(JUMP_SEARCH_NOT_FOUND_DELAY);
+                            }
+                        } else {
+                            if tl.pending_reached_start || portal_list.first_id() <= 2 {
+                                tl.pending_reached_start = false;
+                                should_continue_backwards_pagination = true;
+                            }
+                            // A search keeps paginating wherever the user is scrolled, since a
+                            // round can add no items at all if the timeline filters them all out.
+                            if loading_pane.is_searching() {
+                                should_continue_backwards_pagination = true;
+                                cx.stop_timer(self.jump_search_timer);
+                                self.jump_search_timer = Timer::empty();
+                            }
                         }
                     } else {
                         error!("Unexpected PaginationIdle update in the Forwards direction");
@@ -1965,6 +2060,21 @@ impl RoomScreen {
                         *last_sent = None; // allow this receipt to be re-sent later
                     }
                 }
+                TimelineUpdate::UserReadReceiptFetched { user_id, event_id } => {
+                    if self.pending_read_receipt_jump.take_if(|u| *u == user_id).is_none() {
+                        continue;
+                    }
+                    let name = display_name_or_user_id(cx, tl.kind.room_id(), user_id);
+                    if let Some(event_id) = event_id {
+                        jump_to_read_receipt = Some((event_id, format!("the latest event seen by {name}")));
+                    } else {
+                        enqueue_popup_notification(
+                            format!("Couldn't find the last-seen event of {name} in this {}.", tl.kind.desc()),
+                            PopupKind::Error,
+                            Some(6.0),
+                        );
+                    }
+                }
                 TimelineUpdate::LinkPreviewFetched => {
                     // fall through to this item being redrawn
                 }
@@ -2017,6 +2127,12 @@ impl RoomScreen {
             self.view
                 .typing_notice(cx, ids!(typing_notice))
                 .show_or_hide(cx, &users);
+        }
+
+        if let Some((event_id, searching_for)) = jump_to_read_receipt {
+            // This jump supersedes any search already showing, so close that one out first.
+            loading_pane.hide(cx);
+            self.jump_to_event(cx, &event_id, None, searching_for, portal_list, &loading_pane);
         }
 
         if num_updates > 0 {
@@ -2505,10 +2621,31 @@ impl RoomScreen {
                         );
                         continue;
                     };
+                    // Get the sender of the replied-to event so we can show it in the loading pane.
+                    let replied_to_sender_and_room = self.tl_state.as_ref().and_then(|tl| {
+                        let sender = tl.items.get(details.item_id)
+                            .and_then(|item| item.as_event())
+                            .and_then(|ev| match ev.content() {
+                                TimelineItemContent::MsgLike(msg_like) => msg_like.in_reply_to.as_ref(),
+                                _ => None,
+                            })
+                            .and_then(|reply| match &reply.event {
+                                TimelineDetails::Ready(replied_to) => Some(replied_to.sender.clone()),
+                                _ => None,
+                            })?;
+                        Some((sender, tl.kind.room_id().clone()))
+                    });
+                    let searching_for = match replied_to_sender_and_room {
+                        Some((sender, room_id)) => format!(
+                            "the message from {}", display_name_or_user_id(cx, &room_id, sender),
+                        ),
+                        None => String::from("the replied-to message"),
+                    };
                     self.jump_to_event(
                         cx,
                         related_event_id,
                         Some(details.item_id),
+                        searching_for,
                         portal_list,
                         loading_pane
                     );
@@ -2530,6 +2667,7 @@ impl RoomScreen {
                         cx,
                         event_id,
                         None,
+                        String::from("the message you're replying to"),
                         portal_list,
                         loading_pane
                     );
@@ -2609,6 +2747,7 @@ impl RoomScreen {
         cx: &mut Cx,
         target_event_id: &OwnedEventId,
         max_tl_idx: Option<usize>,
+        searching_for: String,
         portal_list: &PortalListRef,
         loading_pane: &LoadingPaneRef,
     ) {
@@ -2618,20 +2757,7 @@ impl RoomScreen {
         // Attempt to find the index of replied-to message in the timeline.
         // Start from the current item's index (`tl_idx`) and search backwards,
         // since we know the related message must come before the current item.
-        let mut num_items_searched = 0;
-        let related_msg_tl_index = tl.items
-            .focus()
-            .narrow(..max_tl_idx)
-            .into_iter()
-            .rev()
-            .take(MAX_ITEMS_TO_SEARCH_THROUGH)
-            .position(|i| {
-                num_items_searched += 1;
-                i.as_event()
-                    .and_then(|e| e.event_id())
-                    .is_some_and(|ev_id| ev_id == target_event_id)
-            })
-            .map(|position| max_tl_idx.saturating_sub(position).saturating_sub(1));
+        let related_msg_tl_index = index_of_event(&tl.items, target_event_id, max_tl_idx, MAX_ITEMS_TO_SEARCH_THROUGH);
 
         if let Some(index) = related_msg_tl_index {
             // log!("The related message {replied_to_event} was immediately found in room {}, scrolling to from index {reply_message_item_id} --> {index} (first ID {}).", tl.kind.room_id(), portal_list.first_id());
@@ -2643,6 +2769,8 @@ impl RoomScreen {
             };
         } else {
             log!("The related event {target_event_id} wasn't immediately available in room {}, searching for it in the background...", tl.kind.room_id());
+            cx.stop_timer(self.jump_search_timer);
+            self.jump_search_timer = Timer::empty();
             // Here, we set the state of the loading pane and display it to the user.
             // The main logic will be handled in `process_timeline_updates()`, which is the only
             // place where we can receive updates to the timeline from the background tasks.
@@ -2650,6 +2778,7 @@ impl RoomScreen {
                 cx,
                 LoadingPaneState::BackwardsPaginateUntilEvent {
                     target_event_id: target_event_id.clone(),
+                    description: searching_for,
                     events_paginated: 0,
                     request_sender: tl.request_sender.clone(),
                 },
@@ -2666,7 +2795,7 @@ impl RoomScreen {
                         room_id: tl.kind.room_id().clone(),
                         target_event_id: target_event_id.clone(),
                         // avoid re-searching through items we already searched through.
-                        starting_index: max_tl_idx.saturating_sub(num_items_searched),
+                        starting_index: max_tl_idx.saturating_sub(MAX_ITEMS_TO_SEARCH_THROUGH),
                         current_tl_len: tl.items.len(),
                     });
                 }
@@ -2896,6 +3025,9 @@ impl RoomScreen {
 
         // Don't send read receipts if we're hiding the timeline.
         self.read_receipt_state.clear();
+        // Closing/hiding the room should cancel any pending jump/search.
+        self.pending_read_receipt_jump = None;
+        self.jump_search_timer = Timer::empty();
 
         // Tell the background subscriber that this timeline is now closed.
         if let Some(tl) = self.tl_state.as_ref() {
@@ -3044,6 +3176,8 @@ impl RoomScreen {
         if self.tl_state.is_some() {
             self.hide_timeline();
         }
+        // Dropping the loading pane state cancels any in-progress event search.
+        drop(self.loading_pane(cx, ids!(loading_pane)).take_state());
         self.room_name_id = None;
         self.timeline_kind = None;
         self.pinned_events.clear();
@@ -3340,6 +3474,13 @@ pub enum TimelineUpdate {
     ReadReceiptSendFailed {
         receipt_type: ReceiptType,
         event_id: OwnedEventId,
+    },
+    /// The search for the given user's read receipt (last-seen event) finished.
+    UserReadReceiptFetched {
+        user_id: OwnedUserId,
+        /// Their last-seen event ID (which we should now jump to),
+        /// or `None` if we couldn't find it.
+        event_id: Option<OwnedEventId>,
     },
     /// A notice that the given room has been tombstoned (closed)
     /// and replaced by the given successor room.

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -198,7 +198,6 @@ script_mod! {
             }
 
             jump_to_read_receipt_button := RobrixNeutralIconButton {
-                enabled: false, // TODO: support this button
                 padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
                 margin: 0,
                 draw_icon.svg: (ICON_JUMP)
@@ -293,6 +292,15 @@ pub enum ShowUserProfileAction {
     None,
 }
 
+/// Actions emitted by the user profile sliding pane, handled by its parent RoomScreen.
+#[derive(Clone, Default, Debug)]
+pub enum UserProfilePaneAction {
+    /// A request to scroll the timeline to this user's latest read receipt.
+    JumpToReadReceipt(OwnedUserId),
+    #[default]
+    None,
+}
+
 /// Information needed to populate/display the user profile sliding pane.
 #[derive(Clone, Debug)]
 pub struct UserProfilePaneInfo {
@@ -375,7 +383,10 @@ impl Widget for UserProfileSlidingPane {
         if self.is_animating_out && !self.animator.is_track_animating(id!(panel)) {
             self.visible = false;
             self.is_animating_out = false;
-            cx.revert_key_focus();
+            // give up key focus if we still had it
+            if cx.has_key_focus(self.view.area()) {
+                cx.revert_key_focus();
+            }
             self.view(cx, ids!(bg_view)).set_visible(cx, false);
             self.redraw(cx);
             return;
@@ -481,9 +492,19 @@ impl Widget for UserProfileSlidingPane {
                 );
             }
 
-            // TODO: implement the third button: `jump_to_read_receipt_button`,
-            //       which involves calling `Timeline::latest_user_read_receipt()`
-            //       or `Room::load_user_receipt()`, which are async functions.
+            // Handle the jump to read receipt button being clicked, which is mostly handled by the room screen.
+            if !self.is_animating_out && self.button(cx, ids!(jump_to_read_receipt_button)).clicked(actions) {
+                cx.widget_action(
+                    self.widget_uid(),
+                    UserProfilePaneAction::JumpToReadReceipt(info.user_id.clone()),
+                );
+                // Close the sliding pane so it doesn't cover the event we're jumping to.
+                self.is_animating_out = true;
+                cx.revert_key_focus();
+                self.animator_play(cx, ids!(panel.hide));
+                self.redraw(cx);
+                return;
+            }
 
             // The `ignore_user_button` require room membership info.
             if let Some(room_member) = info.room_member.as_ref() {
@@ -547,7 +568,7 @@ impl Widget for UserProfileSlidingPane {
         // * `direct_message_button` is hidden if the user is the same as the account user,
         //    since you cannot direct message yourself.
         // * `copy_link_to_user_button` is always enabled with the same text.
-        // * `jump_to_read_receipt_button` is always enabled with the same text.
+        // * `jump_to_read_receipt_button` is always shown with the same text.
         // * `ignore_user_button` is hidden if the user is not a member of the room,
         //    or if the user is the same as the account user, since you cannot ignore yourself.
         //    * The button text changes to "Unignore" if the user is already ignored.

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -11,10 +11,11 @@ use matrix_sdk_base::crypto::{DecryptionSettings, TrustRequirement};
 use matrix_sdk::{
     authentication::oauth::error::OAuthDiscoveryError, config::RequestConfig, encryption::{identities::Device, EncryptionSettings}, event_handler::EventHandlerDropGuard, media::MediaRequestParameters, room::{edit::EditedContent, reply::Reply, IncludeRelations, Receipts, RelationsOptions, RoomMember}, ruma::{
         api::{Direction, client::{authenticated_media::get_media_preview, discovery::get_authorization_server_metadata::v1::{AccountManagementAction, AccountManagementActionData}, profile::{AvatarUrl, DisplayName}, receipt::create_receipt::v3::ReceiptType}}, events::{
+            receipt::{ReceiptThread, ReceiptType as ReceiptEventType},
             relation::RelationType,
             room::{
-                message::{RoomMessageEventContent, TextMessageEventContent}, power_levels::RoomPowerLevels, MediaSource
-            }, MessageLikeEventType, StateEventType
+                encrypted::Relation as EncryptedRelation, message::{RoomMessageEventContent, TextMessageEventContent}, power_levels::RoomPowerLevels, redaction::SyncRoomRedactionEvent, MediaSource
+            }, AnySyncMessageLikeEvent, AnySyncTimelineEvent, MessageLikeEventType, StateEventType
         }, EventId, MatrixToUri, MatrixUri, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomOrAliasId, UserId, uint
     }, sliding_sync::VersionBuilder, Client, ClientBuildError, OwnedServerName, Room, RoomDisplayName, RoomMemberships, RoomState, SessionChange, SuccessorRoom
 };
@@ -36,7 +37,7 @@ use std::io;
 use hashbrown::{HashMap, HashSet};
 use crate::{
     app::AppStateAction, app_data_dir, cache_dir, avatar_cache::AvatarUpdate, event_preview::{BeforeText, TextPreview, text_preview_of_raw_timeline_event, text_preview_of_timeline_item}, home::{
-        add_room::KnockResultAction, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::LinkPreviewData, room_screen::{InviteResultAction, TimelineUpdate}, rooms_list::{self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails
+        add_room::KnockResultAction, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::LinkPreviewData, room_screen::{InviteResultAction, TimelineUpdate, index_of_event}, rooms_list::{self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails
     }, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state}, profile::{
         user_profile::UserProfile,
         user_profile_cache::{UserProfileUpdate, enqueue_user_profile_update},
@@ -408,6 +409,13 @@ impl TimelineKind {
             TimelineKind::Thread { thread_root_event_id, .. } => Some(thread_root_event_id),
         }
     }
+    /// What to call this timeline in messages shown to the user.
+    pub fn desc(&self) -> &'static str {
+        match self {
+            TimelineKind::MainRoom { .. } => "room",
+            TimelineKind::Thread { .. } => "thread",
+        }
+    }
 }
 impl std::fmt::Display for TimelineKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -721,6 +729,13 @@ pub enum MatrixRequest {
         timeline_kind: TimelineKind,
         event_id: OwnedEventId,
         receipt_type: ReceiptType,
+    },
+    /// Requests the event ID of the given user's latest read receipt in this timeline.
+    ///
+    /// The response is delivered back to the main UI thread via [`TimelineUpdate::UserReadReceiptFetched`].
+    GetUserReadReceipt {
+        timeline_kind: TimelineKind,
+        user_id: OwnedUserId,
     },
     /// Sends a request to obtain the power levels for this room.
     ///
@@ -2175,6 +2190,51 @@ async fn matrix_worker_task(
                             }
                         }
                     }
+                });
+            },
+
+            MatrixRequest::GetUserReadReceipt { timeline_kind, user_id } => {
+                let Some((timeline, sender)) = get_timeline_and_sender(&timeline_kind) else {
+                    error!("BUG: {timeline_kind} not found when getting read receipt of user {user_id}");
+                    enqueue_popup_notification(
+                        format!("Couldn't look up read receipts in this {}.", timeline_kind.desc()),
+                        PopupKind::Error,
+                        Some(5.0),
+                    );
+                    continue;
+                };
+
+                let _get_rr_task = Handle::current().spawn(async move {
+                    let mut event_id = timeline.latest_user_read_receipt_timeline_event_id(&user_id).await;
+                    if event_id.is_none() {
+                        // Some timeline events aren't separately visible, like edits or reactions,
+                        // so we try to find the event that this receipt is shown *on*, e.g., the reacted-to event.
+                        let mut candidates = vec![timeline.latest_user_read_receipt(&user_id).await];
+                        if timeline_kind.thread_root_event_id().is_none() {
+                            let room = timeline.room();
+                            for receipt_type in [ReceiptEventType::Read, ReceiptEventType::ReadPrivate] {
+                                candidates.push(
+                                    room.load_user_receipt(receipt_type, ReceiptThread::Unthreaded, &user_id).await.ok().flatten()
+                                );
+                            }
+                        }
+                        // find the latest (newest) event from the list of candidates
+                        event_id = candidates.into_iter().flatten()
+                            .max_by_key(|(_, receipt)| receipt.ts)
+                            .map(|(ev_id, _)| ev_id);
+
+                        if let Some(ev_id) = event_id {
+                            event_id = Some(resolve_receipt_target(
+                                timeline.room(),
+                                ev_id,
+                                timeline_kind.thread_root_event_id().is_some(),
+                            ).await);
+                        }
+                    }
+                    if sender.send(TimelineUpdate::UserReadReceiptFetched { user_id, event_id }).is_err() {
+                        error!("Failed to send fetched user read receipt to UI for {timeline_kind}");
+                    }
+                    SignalToUI::set_ui_signal();
                 });
             },
 
@@ -4144,6 +4204,44 @@ async fn fetch_room_preview_with_avatar(
     Ok(FetchedRoomPreview::from(room_preview, room_avatar))
 }
 
+/// Resolves a receipt's target to the nearest event the timeline can display,
+/// since receipts can refer to non-visible events like reactions, edits, or redactions.
+async fn resolve_receipt_target(
+    room: &Room,
+    mut event_id: OwnedEventId,
+    is_thread_timeline: bool,
+) -> OwnedEventId {
+    let original = event_id.clone();
+    // we only need to iterate over a few links in the chain of reactions/edits, or threaded replies.
+    // i picked 5 randomly, but typically just 2 or 3 is sufficient.
+    for _ in 0..5 {
+        let Ok(event) = room.load_or_fetch_event(&event_id, None).await else { break };
+        let Ok(AnySyncTimelineEvent::MessageLike(message_like)) = event.raw().deserialize() else { break };
+        let next_target = if let AnySyncMessageLikeEvent::RoomRedaction(SyncRoomRedactionEvent::Original(ev)) = &message_like {
+            ev.content.redacts.clone().or_else(|| ev.redacts.clone())
+        } else {
+            message_like.original_content().and_then(|content| match content.relation() {
+                Some(EncryptedRelation::Annotation(annotation)) => Some(annotation.event_id),
+                Some(EncryptedRelation::Replacement(replacement)) => Some(replacement.event_id),
+                // Things like poll responses and verification steps are hidden as "references".
+                // Call notifications are the same, but we can actually jump to them since we display them as an event.
+                Some(EncryptedRelation::Reference(reference))
+                if !matches!(message_like, AnySyncMessageLikeEvent::RtcNotification(_))
+                    => Some(reference.event_id),
+                // Thread replies are only hidden in the main room timeline.
+                Some(EncryptedRelation::Thread(thread)) if !is_thread_timeline => Some(thread.event_id),
+                _ => None,
+            })
+        };
+        let Some(next) = next_target else { break };
+        event_id = next;
+    }
+    if event_id != original {
+        log!("Resolved read receipt target {original} to displayable event {event_id}");
+    }
+    event_id
+}
+
 /// Fetches key details about the given thread root event.
 ///
 /// Returns a tuple of:
@@ -4568,17 +4666,7 @@ async fn timeline_subscriber_handler(
                     };
                     // log!("Received new request to search for event {new_target_event_id} in room {room_id}, thread {thread_root_event_id:?} starting from index {starting_index} (tl len {}).", timeline_items.len());
                     // Search backwards for the target event in the timeline, starting from the given index.
-                    if let Some(target_event_tl_index) = timeline_items
-                        .focus()
-                        .narrow(..starting_index)
-                        .into_iter()
-                        .rev()
-                        .position(|i| i.as_event()
-                            .and_then(|e| e.event_id())
-                            .is_some_and(|ev_id| ev_id == new_target_event_id)
-                        )
-                        .map(|i| starting_index.saturating_sub(i).saturating_sub(1))
-                    {
+                    if let Some(target_event_tl_index) = index_of_event(&timeline_items, &new_target_event_id, starting_index, usize::MAX) {
                         // log!("Found existing target event {new_target_event_id} in room {room_id}, thread {thread_root_event_id:?} at index {target_event_tl_index}.");
 
                         // Nice! We found the target event in the current timeline items,
@@ -4740,6 +4828,11 @@ async fn timeline_subscriber_handler(
                     }
                     VectorDiff::Reset { values } => {
                         if LOG_TIMELINE_DIFFS { log!("timeline_subscriber: room {room_id}, thread {thread_root_event_id:?} diff Reset, new length {}", values.len()); }
+                        // Every item is replaced, so any index we already found is stale.
+                        if let Some((_i, ev)) = found_target_event_id.take() {
+                            target_event_id = Some(ev);
+                        }
+                        found_target_event_id = find_target_event(&mut target_event_id, values.iter());
                         clear_cache = true; // we must assume all items have changed.
                         timeline_items = values;
                     }


### PR DESCRIPTION
The user profile pane's "jump to read receipt" button is now fully implemented, it scrolls the timeline to the latest event that that user had seen/read.

This also fixes an older bug related to backwards searchign for a given event, e.g., a replied-to message that was much older than the timeline's current set of known events.
We now reliably terminate the search in all cases, based on pagination status, so there's no way the loading pane can get stuck or something.

The loading pane also now shows a human-friendly description of the event that we're searching for instead of just showing its event ID, which is basically meaningless to any user.