### PR TITLE
invites: always show who sent the invite, and remember its state

### DIFF
--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -8,9 +8,9 @@ use std::ops::Deref;
 use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
 
-use crate::{app::AppStateAction, home::rooms_list::RoomsListRef, join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, room::{BasicRoomDetails, FetchedRoomAvatar}, shared::{avatar::AvatarWidgetRefExt, popup_list::{enqueue_popup_notification, PopupKind}, restore_status_view::RestoreStatusViewWidgetExt}, sliding_sync::{submit_async_request, MatrixRequest}, utils::{self, RoomNameId}};
+use crate::{app::AppStateAction, avatar_cache::{self, AvatarCacheEntry}, home::rooms_list::RoomsListRef, join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, room::{BasicRoomDetails, FetchedRoomAvatar}, shared::{avatar::AvatarWidgetRefExt, popup_list::{enqueue_popup_notification, PopupKind}, restore_status_view::RestoreStatusViewWidgetExt}, sliding_sync::{submit_async_request, MatrixRequest}, utils::{self, RoomNameId}};
 
-use super::rooms_list::{InviteState, InviterInfo};
+use super::rooms_list::{InviteState, InviterInfo, get_invited_rooms, set_invite_state};
 
 
 script_mod! {
@@ -235,6 +235,17 @@ pub enum LeaveRoomResultAction {
 }
 
 
+/// Actions that tell an `InviteScreen` to refresh part of its content.
+#[derive(Debug)]
+pub enum InviteScreenAction {
+    /// We've fetched more info about who sent this invite.
+    InviterInfoUpdated {
+        room_id: OwnedRoomId,
+        inviter_info: InviterInfo,
+    },
+}
+
+
 /// A view that shows information about a room that the user has been invited to.
 #[derive(Script, ScriptHook, Widget)]
 pub struct InviteScreen {
@@ -255,9 +266,11 @@ pub struct InviteScreen {
 
 impl Widget for InviteScreen {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        // Currently, a Signal event is only used to tell this widget
-        // to check if the room has been loaded from the homeserver yet.
         if let Event::Signal = event {
+            // We use the avatar cache to populate the inviter's avatar.
+            avatar_cache::process_avatar_updates(cx);
+
+            // Otherwise, a Signal just means that the room might've been received from the homeserver.
             if let (false, Some(room_name_id), true) = (self.is_loaded, self.room_name_id.as_ref(), cx.has_global::<RoomsListRef>()) {
                 let rooms_list_ref = cx.get_global::<RoomsListRef>();
                 if !rooms_list_ref.is_room_loaded(room_name_id.room_id()) {
@@ -274,26 +287,36 @@ impl Widget for InviteScreen {
 
         let orig_state = self.invite_state;
 
-        // Handle button clicks to accept or decline the invite
+        // Handle any updates to this invite screen, e.g., it's been loaded or more inviter info has been fetched.
         if let Event::Actions(actions) = event {
-            // First, we quickly loop over the actions up front to handle the case
-            // where this room was restored and has now been successfully loaded from the homeserver.
             for action in actions {
                 if let Some(AppStateAction::RoomLoadedSuccessfully { room_name_id, .. }) = action.downcast_ref() {
                     if self.room_name_id.as_ref().is_some_and(|current| current.room_id() == room_name_id.room_id()) {
                         self.set_displayed_invite(cx, room_name_id);
                         break;
                     }
+                    continue;
+                }
+                if let Some(InviteScreenAction::InviterInfoUpdated { room_id, inviter_info }) = action.downcast_ref() {
+                    if self.room_name_id.as_ref().is_some_and(|r| r.room_id() == room_id) {
+                        if let Some(info) = self.info.as_mut() {
+                            info.inviter = Some(inviter_info.clone());
+                        }
+                        self.redraw(cx);
+                    }
+                    continue;
                 }
             }
 
             let Some(info) = self.info.as_ref() else { return; };
+            // Handle button clicks to accept or decline the invite
             if let Some(modifiers) = self.view.button(cx, ids!(cancel_button)).clicked_modifiers(actions) {
-                self.invite_state = InviteState::WaitingForLeaveResult;
                 if modifiers.shift {
                     submit_async_request(MatrixRequest::LeaveRoom {
                         room_id: info.room_id().clone(),
                     });
+                    self.invite_state = InviteState::WaitingForLeaveResult;
+                    set_invite_state(cx, info.room_id(), InviteState::WaitingForLeaveResult);
                     self.has_shown_confirmation = false;
                 } else {
                     cx.action(JoinLeaveRoomModalAction::Open {
@@ -304,11 +327,12 @@ impl Widget for InviteScreen {
                 }
             }
             if let Some(modifiers) = self.view.button(cx, ids!(accept_button)).clicked_modifiers(actions) {
-                self.invite_state = InviteState::WaitingForJoinResult;
                 if modifiers.shift {
                     submit_async_request(MatrixRequest::JoinRoom {
                         room_id: info.room_id().clone(),
                     });
+                    self.invite_state = InviteState::WaitingForJoinResult;
+                    set_invite_state(cx, info.room_id(), InviteState::WaitingForJoinResult);
                     self.has_shown_confirmation = false;
                 } else {
                     cx.action(JoinLeaveRoomModalAction::Open {
@@ -357,11 +381,17 @@ impl Widget for InviteScreen {
                     _ => {}
                 }
 
-                if let Some(JoinLeaveRoomModalAction::Close { successful, .. }) = action.downcast_ref() {
-                    // If the modal didn't result in a successful join/leave,
-                    // then we must reset the invite state to waiting for user input.
-                    if !*successful {
-                        self.invite_state = InviteState::WaitingOnUserInput;
+                if let Some(JoinLeaveRoomModalAction::Close { room_id, .. }) = action.downcast_ref() {
+                    if room_id == info.room_id() {
+                        // check the latest invite state for this room, as it may have changed
+                        // even after the modal was closed.
+                        let current = get_invited_rooms(cx)
+                            .borrow()
+                            .get(room_id)
+                            .map(|invite| invite.invite_state);
+                        if let Some(state) = current {
+                            self.invite_state = state;
+                        }
                     }
                     continue;
                 }
@@ -392,11 +422,13 @@ impl Widget for InviteScreen {
         let (is_visible, invite_text) = if let Some(inviter) = info.inviter.as_ref() {
             let inviter_avatar = inviter_view.avatar(cx, ids!(inviter_avatar));
             let mut drew_avatar = false;
-            if let Some(avatar_image) = inviter.avatar.as_ref() {
+            if let Some(uri) = inviter.avatar_url.as_ref()
+                && let AvatarCacheEntry::Loaded(data) = avatar_cache::get_or_fetch_avatar(cx, uri)
+            {
                 drew_avatar = inviter_avatar.show_image(
                     cx,
                     None, // don't make this avatar clickable.
-                    |cx, img| utils::load_avatar_image(&img, cx, avatar_image),
+                    |cx, img| utils::load_avatar_image(&img, cx, &(uri.clone(), data).into()),
                 ).is_ok();
             }
             if !drew_avatar {
@@ -497,8 +529,12 @@ impl Widget for InviteScreen {
 impl InviteScreen {
     /// Sets the ID of the invited room that will be displayed by this screen.
     pub fn set_displayed_invite(&mut self, cx: &mut Cx, room_name_id: &RoomNameId) {
+        // If we re-display the same invite, we should remember whether a confirmation modal
+        // has already been shown for it.
+        let is_same_room = self.room_name_id.as_ref().is_some_and(|r| r.room_id() == room_name_id.room_id());
+
         self.room_name_id = Some(room_name_id.clone());
-        if let Some(invite) = super::rooms_list::get_invited_rooms(cx)
+        if let Some(invite) = get_invited_rooms(cx)
             .borrow()
             .get(room_name_id.room_id())
         {
@@ -510,7 +546,9 @@ impl InviteScreen {
                 inviter: invite.inviter_info.clone(),
             });
             self.invite_state = invite.invite_state;
-            self.has_shown_confirmation = false;
+            if !is_same_room {
+                self.has_shown_confirmation = false;
+            }
             self.is_loaded = true;
             self.all_rooms_loaded = true;
             self.redraw(cx);
@@ -530,6 +568,13 @@ impl InviteScreen {
     }
 
     pub fn hide_displayed_invite(&mut self, cx: &mut Cx) {
+        let cancel_button = self.view.button(cx, ids!(cancel_button));
+        cancel_button.set_visible(cx, true);
+        cancel_button.reset_hover(cx);
+        let accept_button = self.view.button(cx, ids!(accept_button));
+        accept_button.set_visible(cx, true);
+        accept_button.reset_hover(cx);
+        self.view.label(cx, ids!(completion_label)).set_text(cx, "");
         self.room_name_id = None;
         self.info = None;
         self.invite_state = InviteState::default();

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -22,11 +22,11 @@ use makepad_widgets::*;
 use matrix_sdk_ui::spaces::room_list::SpaceRoomListPaginationState;
 use ruma::events::tag::TagName;
 use tokio::sync::mpsc::UnboundedSender;
-use matrix_sdk::{RoomState, ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch, OwnedRoomAliasId, OwnedRoomId, OwnedUserId}};
+use matrix_sdk::{RoomState, ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId}};
 use crate::{
     app::{AppState, AppStateAction, SelectedRoom},
     home::{
-        navigation_tab_bar::{NavigationBarAction, SelectedTab}, room_context_menu::RoomContextMenuDetails, room_screen::invalidate_timeline_state, rooms_list_entry::RoomsListEntryAction, space_lobby::{SpaceLobbyAction, SpaceLobbyEntryWidgetExt}
+        invite_screen::{InviteScreenAction, JoinRoomResultAction, LeaveRoomResultAction}, navigation_tab_bar::{NavigationBarAction, SelectedTab}, room_context_menu::RoomContextMenuDetails, room_screen::invalidate_timeline_state, rooms_list_entry::RoomsListEntryAction, space_lobby::{SpaceLobbyAction, SpaceLobbyEntryWidgetExt}
     },
     logout::logout_confirm_modal::LogoutAction,
     room::{
@@ -34,7 +34,6 @@ use crate::{
         room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria, SortFn},
     },
     shared::{
-        avatar::AvatarImage,
         collapsible_header::{CollapsibleHeaderAction, CollapsibleHeaderWidgetRefExt, HeaderCategory},
         jump_to_bottom_button::UnreadMessageCount,
         popup_list::{PopupKind, enqueue_popup_notification},
@@ -74,6 +73,19 @@ pub fn get_invited_rooms(_cx: &mut Cx) -> Rc<RefCell<HashMap<OwnedRoomId, Invite
 pub fn clear_all_invited_rooms(_cx: &mut Cx) {
     ALL_INVITED_ROOMS.with(|rooms| {
        rooms.borrow_mut().clear();
+    });
+}
+
+/// Updates the state of an invited room.
+///
+/// This function requires passing in a reference to `Cx`,
+/// which isn't used, but acts as a guarantee that this function
+/// must only be called by the main UI thread.
+pub fn set_invite_state(_cx: &mut Cx, room_id: &OwnedRoomId, new_state: InviteState) {
+    ALL_INVITED_ROOMS.with(|rooms| {
+        if let Some(invite) = rooms.borrow_mut().get_mut(room_id) {
+            invite.invite_state = new_state;
+        }
     });
 }
 
@@ -189,6 +201,11 @@ pub enum RoomsListUpdate {
     UpdateRoomAvatar {
         room_id: OwnedRoomId,
         room_avatar: FetchedRoomAvatar,
+    },
+    /// Update info about who invited us to the given room.
+    UpdateInviterInfo {
+        room_id: OwnedRoomId,
+        inviter_info: InviterInfo,
     },
     /// Update whether the given room is a direct room.
     UpdateIsDirect {
@@ -343,20 +360,14 @@ pub struct InvitedRoomInfo {
 }
 
 /// Info about the user who invited us to a room.
-#[derive(Clone)]
+///
+/// A homeserver might omit inviter info, only the user ID is guaranteed.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InviterInfo {
     pub user_id: OwnedUserId,
     pub display_name: Option<String>,
-    pub avatar: Option<AvatarImage>,
-}
-impl std::fmt::Debug for InviterInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("InviterInfo")
-            .field("user_id", &self.user_id)
-            .field("display_name", &self.display_name)
-            .field("avatar?", &self.avatar.is_some())
-            .finish()
-    }
+    /// The URI of their avatar; we use the avatar cache for the image itself.
+    pub avatar_url: Option<OwnedMxcUri>,
 }
 
 /// The state of a pending invite.
@@ -712,6 +723,16 @@ impl RoomsList {
                     } else {
                         error!("Error: couldn't find room {room_id} to update avatar");
                     }
+                }
+                RoomsListUpdate::UpdateInviterInfo { room_id, inviter_info } => {
+                    if let Some(room) = self.invited_rooms.borrow_mut().get_mut(&room_id) {
+                        room.inviter_info = Some(inviter_info.clone());
+                    } else {
+                        warning!("Warning: couldn't find invited room {room_id} to update its inviter info");
+                        continue;
+                    }
+                    // Broadcast this to an already-open InviteScreen that might be showing this room.
+                    cx.action(InviteScreenAction::InviterInfoUpdated { room_id, inviter_info });
                 }
                 RoomsListUpdate::UpdateLatestEvent { room_id, timestamp, latest_message_text } => {
                     if let Some(room) = self.all_joined_rooms.get_mut(&room_id) {
@@ -1475,6 +1496,32 @@ impl Widget for RoomsList {
                 if let Some(AppStateAction::FocusNone) = action.downcast_ref() {
                     self.set_current_active_room(cx, None);
                     continue;
+                }
+
+                // Watch for updates to join or leave room requests, since an invite screen
+                // might've been closed before we got the result
+                // (and we still want to track the state of that invite here in the rooms list).
+                match action.downcast_ref() {
+                    Some(JoinRoomResultAction::Joined { room_id }) => {
+                        set_invite_state(cx, room_id, InviteState::WaitingForJoinedRoom);
+                        continue;
+                    }
+                    Some(JoinRoomResultAction::Failed { room_id, .. }) => {
+                        set_invite_state(cx, room_id, InviteState::WaitingOnUserInput);
+                        continue;
+                    }
+                    _ => {}
+                }
+                match action.downcast_ref() {
+                    Some(LeaveRoomResultAction::Left { room_id }) => {
+                        set_invite_state(cx, room_id, InviteState::RoomLeft);
+                        continue;
+                    }
+                    Some(LeaveRoomResultAction::Failed { room_id, .. }) => {
+                        set_invite_state(cx, room_id, InviteState::WaitingOnUserInput);
+                        continue;
+                    }
+                    _ => {}
                 }
 
                 // Clear widget state upon logout.

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -8,7 +8,7 @@ use makepad_widgets::*;
 use matrix_sdk::ruma::OwnedRoomId;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::{home::invite_screen::{InviteDetails, JoinRoomResultAction, LeaveRoomResultAction}, room::BasicRoomDetails, shared::{popup_list::{PopupKind, enqueue_popup_notification}, styles::{apply_negative_button_style, apply_neutral_button_style, apply_positive_button_style, apply_primary_button_style}}, sliding_sync::{MatrixRequest, submit_async_request}, space_service_sync::{SpaceRequest, SpaceRoomListAction}, utils::{self, RoomNameId}};
+use crate::{home::{invite_screen::{InviteDetails, JoinRoomResultAction, LeaveRoomResultAction}, rooms_list::{InviteState, set_invite_state}}, room::BasicRoomDetails, shared::{popup_list::{PopupKind, enqueue_popup_notification}, styles::{apply_negative_button_style, apply_neutral_button_style, apply_positive_button_style, apply_primary_button_style}}, sliding_sync::{MatrixRequest, submit_async_request}, space_service_sync::{SpaceRequest, SpaceRoomListAction}, utils::{self, RoomNameId}};
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -148,9 +148,8 @@ pub enum JoinLeaveRoomModalAction {
     },
     /// The modal requested its parent widget to close.
     Close {
-        /// `True` if the modal was closed after a successful join/leave action.
-        /// `False` if the modal was dismissed or closed after a failure/error.
-        successful: bool,
+        /// The room that the modal was acting upon.
+        room_id: OwnedRoomId,
         /// Whether the modal was dismissed by the user clicking an internal button.
         was_internal: bool,
     },
@@ -177,10 +176,10 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
         if cancel_clicked ||
             actions.iter().any(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)))
         {
-            if self.kind.is_some() {
+            if let Some(kind) = self.kind.as_ref() {
                 // Inform other widgets that this modal has been closed.
                 cx.action(JoinLeaveRoomModalAction::Close {
-                    successful: self.final_success.unwrap_or(false),
+                    room_id: kind.room_id().clone(),
                     was_internal: cancel_clicked,
                 });
                 self.reset_state();
@@ -192,8 +191,11 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
         let mut needs_redraw = false;
 
         if accept_button.clicked(actions) {
-            if let Some(successful) = self.final_success {
-                cx.action(JoinLeaveRoomModalAction::Close { successful, was_internal: true });
+            if self.final_success.is_some() {
+                cx.action(JoinLeaveRoomModalAction::Close {
+                    room_id: kind.room_id().clone(),
+                    was_internal: true,
+                });
                 self.reset_state();
                 return;
             }
@@ -213,6 +215,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                         submit_async_request(MatrixRequest::JoinRoom {
                             room_id: invite.room_id().clone(),
                         });
+                        set_invite_state(cx, invite.room_id(), InviteState::WaitingForJoinResult);
                     }
                     JoinLeaveModalKind::RejectInvite(invite) => {
                         title = "Rejecting this invite...".into();
@@ -225,6 +228,7 @@ impl WidgetMatchEvent for JoinLeaveRoomModal {
                         submit_async_request(MatrixRequest::LeaveRoom {
                             room_id: invite.room_id().clone(),
                         });
+                        set_invite_state(cx, invite.room_id(), InviteState::WaitingForLeaveResult);
                     }
                     JoinLeaveModalKind::JoinRoom { details, is_space } => {
                         title = format!("Joining this {}...", if *is_space { "space" } else { "room" }).into();

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -2851,6 +2851,8 @@ struct RoomListServiceRoomInfo {
     num_unread_mentions: u64,
     display_name: Option<RoomDisplayName>,
     room_avatar: Option<OwnedMxcUri>,
+    /// Only ever set for invited rooms.
+    inviter_info: Option<InviterInfo>,
     room: matrix_sdk::Room,
 }
 impl RoomListServiceRoomInfo {
@@ -2861,7 +2863,7 @@ impl RoomListServiceRoomInfo {
     ) -> Self {
         // Parallelize fetching of independent room data.
         // Only joined rooms actually use tags and power levels.
-        let (is_direct, tags, display_name, user_power_levels) = tokio::join!(
+        let (is_direct, tags, display_name, user_power_levels, inviter_info) = tokio::join!(
             room.is_direct(),
             async {
                 if room.state() == RoomState::Joined { room.tags().await } else { Ok(None) }
@@ -2871,6 +2873,18 @@ impl RoomListServiceRoomInfo {
                 if !fetch_power_levels || room.state() != RoomState::Joined { return None; }
                 let Some(user_id) = current_user_id else { return None; };
                 UserPowerLevels::from_room(&room, user_id.deref()).await
+            },
+            async {
+                if room.state() != RoomState::Invited { return None; }
+                let invite = room.invite_details().await
+                    .inspect_err(|e| error!("Couldn't obtain who invited us to room {}: {e}", room.room_id()))
+                    .ok()?;
+                let inviter = invite.inviter;
+                Some(InviterInfo {
+                    display_name: inviter.as_ref().and_then(|m| m.display_name().map(str::to_owned)),
+                    avatar_url: inviter.and_then(|m| m.avatar_url().map(ToOwned::to_owned)),
+                    user_id: invite.inviter_id,
+                })
             }
         );
 
@@ -2888,6 +2902,7 @@ impl RoomListServiceRoomInfo {
             num_unread_mentions: room.num_unread_mentions(),
             display_name: display_name.ok(),
             room_avatar: room.avatar_url(),
+            inviter_info,
             room,
         }
     }
@@ -3608,15 +3623,29 @@ async fn update_room(
         // First, we check for changes to room data that is relevant to any room,
         // including joined, invited, and other rooms.
         // This includes the room name and room avatar.
-        if old_room.room_avatar != new_room.room_avatar {
+        let was_name_changed = old_room.display_name != new_room.display_name;
+        // A room with no avatar image uses a text avatar based on the room name, so we update that too.
+        if old_room.room_avatar != new_room.room_avatar
+            || (was_name_changed && new_room.room_avatar.is_none())
+        {
             log!("Updating room avatar for room {}", new_room_id);
             spawn_fetch_room_avatar(new_room);
         }
-        if old_room.display_name != new_room.display_name {
+        if was_name_changed {
             log!("Updating room {} name: {:?} --> {:?}", new_room_id, old_room.display_name, new_room.display_name);
 
             enqueue_rooms_list_update(RoomsListUpdate::UpdateRoomName {
                 new_room_name: (new_room.display_name.clone(), new_room_id.clone()).into(),
+            });
+        }
+
+        // If we know anything new about the inviter, send it to the rooms list.
+        if old_room.inviter_info != new_room.inviter_info
+            && let Some(inviter_info) = new_room.inviter_info.clone()
+        {
+            enqueue_rooms_list_update(RoomsListUpdate::UpdateInviterInfo {
+                room_id: new_room_id.clone(),
+                inviter_info,
             });
         }
 
@@ -3780,31 +3809,12 @@ async fn add_new_room(
             return Ok(());
         }
         RoomState::Invited => {
-            let invite_details = new_room.room.invite_details().await.ok();
             let room_name_id = RoomNameId::from((new_room.display_name.clone(), new_room.room_id.clone()));
             // Start with a basic text avatar; the avatar image will be fetched asynchronously below.
             let room_avatar = avatar_from_room_name(room_name_id.name_for_avatar());
-            let inviter_info = if let Some(inviter) = invite_details.and_then(|d| d.inviter) {
-                let avatar = match inviter.avatar_url() {
-                    Some(uri) => inviter
-                        .avatar(AVATAR_THUMBNAIL_FORMAT.into())
-                        .await
-                        .ok()
-                        .flatten()
-                        .map(|data| (uri, data).into()),
-                    None => None,
-                };
-                Some(InviterInfo {
-                    user_id: inviter.user_id().to_owned(),
-                    display_name: inviter.display_name().map(|n| n.to_string()),
-                    avatar,
-                })
-            } else {
-                None
-            };
             rooms_list::enqueue_rooms_list_update(RoomsListUpdate::AddInvitedRoom(InvitedRoomInfo {
                 room_name_id: room_name_id.clone(),
-                inviter_info,
+                inviter_info: new_room.inviter_info.clone(),
                 room_avatar,
                 canonical_alias: new_room.room.canonical_alias(),
                 alt_aliases: new_room.room.alt_aliases(),
@@ -3818,6 +3828,7 @@ async fn add_new_room(
                 room_name_id,
                 is_invite: true,
             });
+            // Spawn this after the update above, so the rooms list knows about the room first.
             spawn_fetch_room_avatar(new_room);
             return Ok(());
         }


### PR DESCRIPTION
apparently there is a separate `inviter_id` that always has the user ID of the inviter, even when the inviter's `RoomMember` data isn't available. So we can use that as a fallback.

We also ensure that invite info is properly shown and updated across both the rooms list entry preview and an InviteScreen.

Fixes #1015