### PR TITLE
show latest events in all cases. fetch thread summaries just once

### DIFF
--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -5256,9 +5256,9 @@ fn populate_thread_root_summary(
             if td.is_unavailable()
                 && let Some(thread_root_event_id) = thread_root_event_id.clone()
             {
-                let needs_refresh = fetched_summary
-                    .is_none_or(|fs| fs.latest_reply_preview_text.is_none());
-                if needs_refresh && pending_thread_summary_fetches.insert(thread_root_event_id.clone()) {
+                if fetched_summary.is_none()
+                    && pending_thread_summary_fetches.insert(thread_root_event_id.clone())
+                {
                     submit_async_request(MatrixRequest::FetchThreadSummaryDetails {
                         timeline_kind: timeline_kind.clone(),
                         thread_root_event_id,

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -3666,19 +3666,11 @@ async fn update_room(
         // including the latest event, tags, unread counts, is_direct, tombstoned state, power levels, etc.
         // Invited or left rooms don't care about these details.
         if matches!(new_room.state, RoomState::Joined) { 
-            // For some reason, the latest event API does not reliably catch *all* changes
-            // to the latest event in a given room, such as redactions.
-            // Thus, we have to re-obtain the latest event on *every* update, regardless of timestamp.
-            //
-            let update_latest = match (old_room.latest_event_timestamp, new_room.room.latest_event_timestamp()) {
-                (Some(old_ts), Some(new_ts)) => new_ts >= old_ts,
-                (None, Some(_)) => true,
-                _ => false,
-            };
-            if update_latest {
+            // we can't just assume the latest event timestamp is larger. If a redaction happens,
+            // then the latest event timestamp might go backwards, so we just need to test if they're different.
+            if old_room.latest_event_timestamp != new_room.room.latest_event_timestamp() {
                 update_latest_event(&new_room.room).await;
             }
-
 
             if old_room.tags != new_room.tags {
                 log!("Updating room {} tags from {:?} to {:?}", new_room_id, old_room.tags, new_room.tags);


### PR DESCRIPTION
when we moved to the SDK v0.18, we missed a few small changes in behavior.