### PR TITLE
fix other sdk behaviors: deal with `HttpError::Cached`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -182,12 +182,14 @@ impl ScriptHook for App {
 impl MatchEvent for App {
     fn handle_startup(&mut self, cx: &mut Cx) {
         // only init logging/tracing once.
-        // `matrix_sdk::latest_events` emits a noisy per-room "Timer ... finished"
-        // INFO line on every load; silence it by default. RUST_LOG still wins
-        // when set, so you can re-enable it with `RUST_LOG=matrix_sdk::latest_events=info`.
+        //
+        // We silence a few overly noisy SDK logs:
+        // * `matrix_sdk::latest_events` emits a per-room "Timer ... finished" info log
+        // * the timeline warns about "No avatar changes to update" on every user's display name change.
+        // Note that this can still be overridden by setting RUST_LOG, e.g. `RUST_LOG=matrix_sdk::latest_events=info`
         let filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(
-                "info,matrix_sdk::latest_events=warn",
+                "info,matrix_sdk::latest_events=warn,matrix_sdk_ui::timeline::tasks=error",
             ));
         let _ = tracing_subscriber::fmt()
             .with_env_filter(filter)

--- a/src/media_cache.rs
+++ b/src/media_cache.rs
@@ -202,11 +202,16 @@ impl MediaCache {
 pub(crate) fn error_to_media_cache_entry(error: Error, request: &MediaRequestParameters) -> MediaCacheEntry {
     match error {
         Error::Http(http_error) => {
+            // Sometimes http errors are wrapped in the `Cached` variant.
+            let mut http_error: &HttpError = &http_error;
+            while let HttpError::Cached(cached) = http_error {
+                http_error = cached;
+            }
             if let Some(client_error) = http_error.as_client_api_error() {
                 error!("Error {client_error} for request: {:?}", request);
                 MediaCacheEntry::Failed(client_error.status_code)
             } else {
-                match *http_error {
+                match http_error {
                     HttpError::Reqwest(reqwest_error) => {
                         // Checking if the connection is timeout is not important as Matrix SDK has implemented maximum timeout duration.
                         if !reqwest_error.is_connect() {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -3084,6 +3084,11 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
             error!("BUG: unexpectedly replaced an existing client when initializing the matrix client.");
         }
 
+        // Eagerly fetch the homeserver's supported versions such that it gets cached locally.
+        if let Err(e) = client.supported_versions().await {
+            warning!("Couldn't cache the homeserver's supported versions: {e:?}");
+        }
+
         // Track all async tasks so we can nicely clean them up with abort+await.
         // Generally anything that holds a reference to `Client` should be here.
         let mut subscriber_task_handles: Vec<JoinHandle<()>> = Vec::new();


### PR DESCRIPTION
silence other noisy logs/warnings like the "no avatar changes" on every change to a user's display name. that's probably an SDK bug, tbh

Also, the SDK v0.18 wraps certain HTTP errors in a new `Cached` variant, so we now dig into it in order to get better error reporting. To avoid that problem, we eagerly fetch things that rely on that error not occurring, i.e., the homeserver's supported versions.