### PR TITLE
reconnect timeline endpoints if it gets recreated in the backend

### DIFF
--- a/src/event_preview.rs
+++ b/src/event_preview.rs
@@ -7,7 +7,7 @@
 
 use std::borrow::Cow;
 
-use matrix_sdk::{ruma::{OwnedUserId, events::{room::{guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule, message::{MessageFormat, MessageType}}, AnyRedactionEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, StateEventContentChange, SyncMessageLikeEvent}, serde::Raw, UserId}};
+use matrix_sdk::{ruma::{OwnedUserId, events::{room::{guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule, member::MembershipState, message::{MessageFormat, MessageType}}, AnyRedactionEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, StateEventContentChange, SyncMessageLikeEvent}, serde::Raw, UserId}};
 use matrix_sdk_base::crypto::types::events::UtdCause;
 use matrix_sdk_ui::timeline::{self, AnyOtherStateEventContentChange, EncryptedMessage, EventTimelineItem, MemberProfileChange, MembershipChange, MsgLikeKind, OtherMessageLike, RoomMembershipChange, TimelineItemContent};
 
@@ -101,23 +101,12 @@ pub fn text_preview_of_timeline_item(
                 MsgLikeKind::Other(oml) => text_preview_of_other_message_like(oml),
             }
         }
-        TimelineItemContent::MembershipChange(membership_change) => {
-            text_preview_of_room_membership_change(membership_change, true)
-                .unwrap_or_else(|| TextPreview::from((
-                    String::from("<i>underwent a membership change</i>"),
-                    BeforeText::UsernameWithoutColon,
-                )))
-        }
-        TimelineItemContent::ProfileChange(profile_change) => {
-            text_preview_of_member_profile_change(profile_change, sender_username, true)
-        }
-        TimelineItemContent::OtherState(other_state) => {
-            text_preview_of_other_state(other_state, true)
-                .unwrap_or_else(|| TextPreview::from((
-                    String::from("<i>initiated another state change</i>"),
-                    BeforeText::UsernameWithoutColon,
-                )))
-        }
+        TimelineItemContent::MembershipChange(membership_change) =>
+            text_preview_of_room_membership_change(membership_change, sender_user_id, true),
+        TimelineItemContent::ProfileChange(profile_change) =>
+            text_preview_of_member_profile_change(profile_change, sender_username, true),
+        TimelineItemContent::OtherState(other_state) =>
+            text_preview_of_other_state(other_state, true),
         TimelineItemContent::FailedToParseMessageLike { event_type, .. } => TextPreview::from((
             format!("[Failed to parse <i>{}</i> message]", htmlize::escape_text(event_type.to_string())),
             BeforeText::UsernameWithColon,
@@ -178,26 +167,16 @@ pub fn plaintext_body_of_timeline_item(
             }
         }
         TimelineItemContent::MembershipChange(membership_change) => {
-            text_preview_of_room_membership_change(membership_change, false)
-                .unwrap_or_else(|| TextPreview::from((
-                    String::from("underwent a membership change."),
-                    BeforeText::UsernameWithoutColon,
-                )))
+            text_preview_of_room_membership_change(membership_change, event_tl_item.sender(), false)
                 .format_with(&utils::get_or_fetch_event_sender(event_tl_item, None), false)
         }
         TimelineItemContent::ProfileChange(profile_change) => {
-            text_preview_of_member_profile_change(
-                profile_change,
-                &utils::get_or_fetch_event_sender(event_tl_item, None),
-                false,
-            ).text
+            let sender = utils::get_or_fetch_event_sender(event_tl_item, None);
+            text_preview_of_member_profile_change(profile_change, &sender, false)
+                .format_with(&sender, false)
         }
         TimelineItemContent::OtherState(other_state) => {
             text_preview_of_other_state(other_state, false)
-                .unwrap_or_else(|| TextPreview::from((
-                    String::from("initiated another state change."),
-                    BeforeText::UsernameWithoutColon,
-                )))
                 .format_with(&utils::get_or_fetch_event_sender(event_tl_item, None), false)
         }
         TimelineItemContent::FailedToParseMessageLike { event_type, error } => {
@@ -451,31 +430,31 @@ pub fn text_preview_of_other_message_like(
 pub fn text_preview_of_other_state(
     other_state: &timeline::OtherState,
     format_as_html: bool,
-) -> Option<TextPreview> {
+) -> TextPreview {
     let text = match other_state.content() {
         AnyOtherStateEventContentChange::RoomAvatar(_) => {
-            Some(String::from("set this room's avatar picture."))
+            String::from("set this room's avatar picture.")
         }
         AnyOtherStateEventContentChange::RoomCanonicalAlias(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("set the main address of this room to {}.",
+            format!("set the main address of this room to {}.",
                 content.alias.as_ref().map(|a| a.as_str()).unwrap_or("none")
-            ))
+            )
         }
         AnyOtherStateEventContentChange::RoomCreate(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("created this room (v{}).", content.room_version.as_str()))
+            format!("created this room (v{}).", content.room_version.as_str())
         }
         AnyOtherStateEventContentChange::RoomEncryption(_) => {
-            Some(String::from("enabled encryption in this room."))
+            String::from("enabled encryption in this room.")
         }
         AnyOtherStateEventContentChange::RoomGuestAccess(StateEventContentChange::Original { content, .. }) => {
-            Some(match &content.guest_access {
+            match &content.guest_access {
                 GuestAccess::CanJoin => String::from("has allowed guests to join this room."),
                 GuestAccess::Forbidden => String::from("has forbidden guests from joining this room."),
                 custom => format!("has set custom guest access rules for this room: {}", custom.as_str()),
-            })
+            }
         }
         AnyOtherStateEventContentChange::RoomHistoryVisibility(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("set this room's history to be visible by {}",
+            format!("set this room's history to be visible by {}",
                 match &content.history_visibility {
                     HistoryVisibility::Invited => "invited users, since they were invited.",
                     HistoryVisibility::Joined => "joined users, since they joined.",
@@ -483,10 +462,10 @@ pub fn text_preview_of_other_state(
                     HistoryVisibility::WorldReadable => "anyone for all time.",
                     custom => custom.as_str(),
                 },
-            ))
+            )
         }
         AnyOtherStateEventContentChange::RoomJoinRules(StateEventContentChange::Original { content, .. }) => {
-            Some(match &content.join_rule {
+            match &content.join_rule {
                 JoinRule::Public => String::from("set this room to be joinable by anyone."),
                 JoinRule::Knock => String::from("set this room to be joinable by invite only or by request."),
                 JoinRule::Private => String::from("set this room to be private."),
@@ -494,10 +473,10 @@ pub fn text_preview_of_other_state(
                 JoinRule::KnockRestricted(_) => String::from("set this room to be joinable by invite only or requestable with restrictions."),
                 JoinRule::Invite  => String::from("set this room to be joinable by invite only."),
                 custom => format!("set custom join rules for this room: {}", custom.as_str()),
-            })
+            }
         }
         AnyOtherStateEventContentChange::RoomPinnedEvents(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("pinned {} events in this room.", content.pinned.len()))
+            format!("pinned {} events in this room.", content.pinned.len())
         }
         AnyOtherStateEventContentChange::RoomName(StateEventContentChange::Original { content, .. }) => {
             let name = if format_as_html {
@@ -505,16 +484,24 @@ pub fn text_preview_of_other_state(
             } else {
                 Cow::Borrowed(content.name.as_str())
             };
-            Some(format!("changed this room's name to \"{name}\"."))
+            format!("changed this room's name to \"{name}\".")
         }
         AnyOtherStateEventContentChange::RoomPowerLevels(_) => {
-            Some(String::from("set the power levels for this room."))
+            String::from("set the power levels for this room.")
         }
         AnyOtherStateEventContentChange::RoomServerAcl(_) => {
-            Some(String::from("set the server access control list for this room."))
+            String::from("set the server access control list for this room.")
+        }
+        AnyOtherStateEventContentChange::RoomThirdPartyInvite(StateEventContentChange::Original { content, .. }) => {
+            let invitee = if format_as_html {
+                htmlize::escape_text(&content.display_name)
+            } else {
+                Cow::Borrowed(content.display_name.as_str())
+            };
+            format!("invited {invitee} to this room.")
         }
         AnyOtherStateEventContentChange::RoomTombstone(StateEventContentChange::Original { content, .. }) => {
-            Some(format!("closed this room and upgraded it to {}", content.replacement_room.matrix_to_uri()))
+            format!("closed this room and upgraded it to {}", content.replacement_room.matrix_to_uri())
         }
         AnyOtherStateEventContentChange::RoomTopic(StateEventContentChange::Original { content, .. }) => {
             let topic = if format_as_html {
@@ -522,7 +509,7 @@ pub fn text_preview_of_other_state(
             } else {
                 Cow::Borrowed(content.topic.as_str())
             };
-            Some(format!("changed this room's topic to \"{topic}\"."))
+            format!("changed this room's topic to \"{topic}\".")
         }
         AnyOtherStateEventContentChange::SpaceParent(_) => {
             let state_key  = if format_as_html {
@@ -530,7 +517,7 @@ pub fn text_preview_of_other_state(
             } else {
                 Cow::Borrowed(other_state.state_key())
             };
-            Some(format!("set this room's parent space to \"{state_key}\"."))
+            format!("set this room's parent space to \"{state_key}\".")
         }
         AnyOtherStateEventContentChange::SpaceChild(_) => {
             let state_key  = if format_as_html {
@@ -538,14 +525,16 @@ pub fn text_preview_of_other_state(
             } else {
                 Cow::Borrowed(other_state.state_key())
             };
-            Some(format!("added a new child to this space: \"{state_key}\"."))
+            format!("added a new child to this space: \"{state_key}\".")
         }
-        _other => {
-            // log!("*** Unhandled: {:?}.", _other);
-            None
+        other => {
+            let event_type = other.event_type().to_string();
+            format!("changed this room's {} state.",
+                if format_as_html { htmlize::escape_text(event_type) } else { event_type.into() },
+            )
         }
     };
-    text.map(|t| TextPreview::from((t, BeforeText::UsernameWithoutColon)))
+    TextPreview::from((text, BeforeText::UsernameWithoutColon))
 }
 
 
@@ -583,6 +572,15 @@ pub fn text_preview_of_member_profile_change(
         String::new()
     };
 
+    if name_text.is_empty() && avatar_text.is_empty() {
+        // When a profile change is redacted, both these fields are cleared,
+        // so just fall back to a generic message.
+        return TextPreview::from((
+            String::from("changed their profile."),
+            BeforeText::UsernameWithoutColon,
+        ));
+    }
+
     TextPreview::from((
         format!("{}{}.", name_text, avatar_text),
         BeforeText::Nothing,
@@ -594,8 +592,9 @@ pub fn text_preview_of_member_profile_change(
 /// as a plaintext or HTML-formatted string.
 pub fn text_preview_of_room_membership_change(
     change: &RoomMembershipChange,
+    sender: &UserId,
     format_as_html: bool,
-) -> Option<TextPreview> {
+) -> TextPreview {
     let dn = change.display_name();
     let change_user_id = dn.as_deref()
         .unwrap_or_else(|| change.user_id().as_str());
@@ -604,42 +603,79 @@ pub fn text_preview_of_room_membership_change(
     } else {
         change_user_id.into()
     };
+    let (membership, prev_membership, reason) = match change.content() {
+        StateEventContentChange::Original { content, prev_content } => (
+            &content.membership,
+            prev_content.as_ref().map(|prev| &prev.membership),
+            content.reason.as_deref(),
+        ),
+        StateEventContentChange::Redacted(content) => (&content.membership, None, None),
+    };
+    let end = match reason.map(|r| r.trim_end_matches('.')) {
+        Some(r) if format_as_html => format!(": {}.", htmlize::escape_text(r)),
+        Some(r) => format!(": {r}."),
+        None => String::from("."),
+    };
     let text = match change.change() {
-        None
-        | Some(MembershipChange::NotImplemented)
-        | Some(MembershipChange::None)
-        | Some(MembershipChange::Error) => {
-            // Don't actually display anything for nonexistent/unimportant membership changes.
-            return None;
-        }
         Some(MembershipChange::Joined) =>
             String::from("joined this room."),
         Some(MembershipChange::Left) =>
-            String::from("left this room."),
+            format!("left this room{end}"),
         Some(MembershipChange::Banned) =>
-            format!("banned {} from this room.", change_user_id),
+            format!("banned {change_user_id} from this room{end}"),
         Some(MembershipChange::Unbanned) =>
-            format!("unbanned {} from this room.", change_user_id),
+            format!("unbanned {change_user_id} from this room."),
         Some(MembershipChange::Kicked) =>
-            format!("kicked {} from this room.", change_user_id),
+            format!("kicked {change_user_id} from this room{end}"),
         Some(MembershipChange::Invited) =>
-            format!("invited {} to this room.", change_user_id),
+            format!("invited {change_user_id} to this room."),
         Some(MembershipChange::KickedAndBanned) =>
-            format!("kicked and banned {} from this room.", change_user_id),
+            format!("kicked and banned {change_user_id} from this room{end}"),
         Some(MembershipChange::InvitationAccepted) =>
             String::from("accepted an invitation to this room."),
         Some(MembershipChange::InvitationRejected) =>
-            String::from("rejected an invitation to this room."),
+            format!("rejected an invitation to this room{end}"),
         Some(MembershipChange::InvitationRevoked) =>
-            format!("revoked {}'s invitation to this room.", change_user_id),
+            format!("revoked {change_user_id}'s invitation to this room{end}"),
         Some(MembershipChange::Knocked) =>
-            String::from("requested to join this room."),
+            format!("requested to join this room{end}"),
         Some(MembershipChange::KnockAccepted) =>
-            format!("accepted {}'s request to join this room.", change_user_id),
+            format!("accepted {change_user_id}'s request to join this room."),
         Some(MembershipChange::KnockRetracted) =>
             String::from("retracted their request to join this room."),
         Some(MembershipChange::KnockDenied) =>
-            format!("denied {}'s request to join this room.", change_user_id),
+            format!("denied {change_user_id}'s request to join this room{end}"),
+        // Anything else will be reported by ruma as one of the variants below,
+        // so we treat them all the same and just check the new membership state.
+        None
+        | Some(MembershipChange::NotImplemented)
+        | Some(MembershipChange::None)
+        | Some(MembershipChange::Error) => match membership {
+            MembershipState::Invite =>
+                format!("invited {change_user_id} to this room."),
+            MembershipState::Knock =>
+                format!("requested to join this room{end}"),
+            MembershipState::Ban =>
+                format!("banned {change_user_id} from this room{end}"),
+            MembershipState::Leave if sender == change.user_id() =>
+                format!("left this room{end}"),
+            MembershipState::Leave =>
+                format!("removed {change_user_id} from this room{end}"),
+            // A join re-send is a no-op; the timeline hides it, so this string
+            // only shows up in text-preview contexts.
+            MembershipState::Join if prev_membership == Some(&MembershipState::Join) =>
+                String::from("made no changes to their membership."),
+            MembershipState::Join =>
+                String::from("joined this room."),
+            custom => {
+                let custom = if format_as_html {
+                    htmlize::escape_text(custom.as_str())
+                } else {
+                    custom.as_str().into()
+                };
+                format!("set {change_user_id}'s membership to \"{custom}\".")
+            }
+        }
     };
-    Some(TextPreview::from((text, BeforeText::UsernameWithoutColon)))
+    TextPreview::from((text, BeforeText::UsernameWithoutColon))
 }

--- a/src/home/link_preview.rs
+++ b/src/home/link_preview.rs
@@ -513,7 +513,7 @@ where
     })
 }
 
-/// The cache for link previews.
+/// The cache for link previews, specific to a given timeline.
 pub struct LinkPreviewCache {
     /// The actual cached data.
     cache: BTreeMap<String, Arc<Mutex<TimestampedCacheEntry>>>,
@@ -531,6 +531,14 @@ impl LinkPreviewCache {
             cache: BTreeMap::new(),
             timeline_update_sender,
         }
+    }
+
+    /// Sets a new timeline update sender, e.g., for when the backend re-created this room's timeline.
+    pub fn set_timeline_update_sender(
+        &mut self,
+        sender: crossbeam_channel::Sender<TimelineUpdate>,
+    ) {
+        self.timeline_update_sender = Some(sender);
     }
 
     /// Fetches the link preview for the specified URL.

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -21,9 +21,9 @@ use matrix_sdk::{
     }
 };
 use matrix_sdk_ui::timeline::{
-    self, EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, LiveLocationState, MemberProfileChange, MembershipChange, MsgLikeContent, MsgLikeKind, OtherMessageLike, PollState, RoomMembershipChange, TimelineDetails, TimelineEventItemId, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem
+    self, EmbeddedEvent, EncryptedMessage, EventTimelineItem, InReplyToDetails, LiveLocationState, MemberProfileChange, MsgLikeContent, MsgLikeKind, OtherMessageLike, PollState, RoomMembershipChange, TimelineDetails, TimelineEventItemId, TimelineItem, TimelineItemContent, TimelineItemKind, VirtualTimelineItem
 };
-use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, events::{AnyRedactionEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent}};
+use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, events::{AnyRedactionEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent, StateEventContentChange, SyncMessageLikeEvent, room::member::MembershipState}};
 
 use matrix_sdk_ui::sync_service::State;
 use crate::{
@@ -35,7 +35,7 @@ use crate::{
     shared::{
         attachment_download::{enqueue_already_downloading_notification, DownloadDisplayState, DownloadKind, DownloadableAttachment, PendingDownload, PendingDownloadState, TimelineUpdateSenderOption, TransferKind, media_source_mxc, start_attachment_download, start_attachment_share}, avatar::{AvatarState, AvatarWidgetRefExt}, confirmation_modal::ConfirmationModalContent, context_menu::ContextMenuClosed, file_upload_modal::FileUploadAttemptId, hover_highlight::handle_hover_hit, html_or_plaintext::{HtmlOrPlaintextRef, HtmlOrPlaintextWidgetRefExt, RobrixHtmlLinkAction}, image_viewer::{ImageViewerAction, ImageViewerMetaData, LoadState}, jump_to_bottom_button::{JumpToBottomButtonWidgetExt, UnreadMessageCount, SCROLL_TO_BOTTOM_SPEED}, popup_list::{PopupKind, enqueue_popup_notification}, restore_status_view::RestoreStatusViewWidgetExt, room_input_popup_menu::{RoomInputPopupMenuAction, RoomInputPopupMenuRef, RoomInputPopupMenuWidgetExt}, styles::*, text_or_image::{TextOrImageAction, TextOrImageRef, TextOrImageWidgetRefExt}, timestamp::TimestampWidgetRefExt
     },
-    sliding_sync::{BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, submit_async_request, take_timeline_endpoints}, utils::{self, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
+    sliding_sync::{BackwardsPaginateUntilEventRequest, MatrixRequest, PaginationDirection, TimelineEndpoints, TimelineKind, TimelineRequestSender, UserPowerLevels, submit_async_request, take_timeline_endpoints, TimelineEndpointsRecreated}, utils::{self, MEDIA_THUMBNAIL_FORMAT, RoomNameId, unix_time_millis_to_datetime}
 };
 use crate::home::event_reaction_list::ReactionListWidgetRefExt;
 use crate::home::room_read_receipt::AvatarRowWidgetRefExt;
@@ -1132,6 +1132,15 @@ impl Widget for RoomScreen {
             self.handle_message_actions(cx, actions, &portal_list, &loading_pane);
 
             for action in actions {
+                // If the backend sync task rebuilt this room's timeline, our timeline update receiver is dead,
+                // so we need to get a new one.
+                if let Some(TimelineEndpointsRecreated { room_id }) = action.downcast_ref()
+                    && self.timeline_kind.as_ref().is_some_and(|k| k.room_id() == room_id)
+                {
+                    self.reconnect_timeline_endpoints(cx);
+                    continue;
+                }
+
                 if let Some(AppStateAction::RoomNameUpdated(new_room_name)) = action.downcast_ref()
                     && let Some(room_name_id) = self.room_name_id.as_mut()
                     && room_name_id.room_id() == new_room_name.room_id()
@@ -1508,15 +1517,30 @@ impl Widget for RoomScreen {
                                     }
                                 }
                             },
-                            TimelineItemContent::MembershipChange(membership_change) => populate_small_state_event(
-                                cx,
-                                list,
-                                item_id,
-                                &tl_state.kind,
-                                event_tl_item,
-                                membership_change,
-                                item_drawn_status,
-                            ),
+                            TimelineItemContent::MembershipChange(membership_change) => {
+                                // Hide timeline entries that show duplicate join/leaves, unless it has a reason.
+                                let should_hide = membership_change.change() == Some(timeline::MembershipChange::None)
+                                    && matches!(
+                                        membership_change.content(),
+                                        StateEventContentChange::Original { content, .. }
+                                            if content.membership == MembershipState::Join
+                                            || (content.membership == MembershipState::Leave
+                                                && content.reason.is_none())
+                                    );
+                                if should_hide {
+                                    (list.item(cx, item_id, id!(Empty)), ItemDrawnStatus::both_drawn())
+                                } else {
+                                    populate_small_state_event(
+                                        cx,
+                                        list,
+                                        item_id,
+                                        &tl_state.kind,
+                                        event_tl_item,
+                                        membership_change,
+                                        item_drawn_status,
+                                    )
+                                }
+                            }
                             TimelineItemContent::ProfileChange(profile_change) => populate_small_state_event(
                                 cx,
                                 list,
@@ -1526,18 +1550,37 @@ impl Widget for RoomScreen {
                                 profile_change,
                                 item_drawn_status,
                             ),
-                            TimelineItemContent::OtherState(other) => populate_small_state_event(
-                                cx,
-                                list,
-                                item_id,
-                                &tl_state.kind,
-                                event_tl_item,
-                                other,
-                                item_drawn_status,
-                            ),
-                            unhandled => {
+                            TimelineItemContent::OtherState(other) => {
+                                // Don't shown noisy updates like policy rules, server ACLs, space links, custom state events, etc.
+                                // We could always make this configurable, e.g., some kind of dev mode.
+                                let should_hide = matches!(
+                                    other.content(),
+                                    timeline::AnyOtherStateEventContentChange::PolicyRuleRoom(_)
+                                    | timeline::AnyOtherStateEventContentChange::PolicyRuleServer(_)
+                                    | timeline::AnyOtherStateEventContentChange::PolicyRuleUser(_)
+                                    | timeline::AnyOtherStateEventContentChange::RoomServerAcl(_)
+                                    | timeline::AnyOtherStateEventContentChange::SpaceChild(_)
+                                    | timeline::AnyOtherStateEventContentChange::SpaceParent(_)
+                                    | timeline::AnyOtherStateEventContentChange::_Custom { .. }
+                                );
+                                if should_hide {
+                                    (list.item(cx, item_id, id!(Empty)), ItemDrawnStatus::both_drawn())
+                                } else {
+                                    populate_small_state_event(
+                                        cx,
+                                        list,
+                                        item_id,
+                                        &tl_state.kind,
+                                        event_tl_item,
+                                        other,
+                                        item_drawn_status,
+                                    )
+                                }
+                            }
+                            _unhandled => {
                                 let item = list.item(cx, item_id, id!(SmallStateEvent));
-                                item.label(cx, ids!(content)).set_text(cx, &format!("[Unsupported] {:?}", unhandled));
+                                item.label(cx, ids!(content))
+                                    .set_text(cx, &plaintext_body_of_timeline_item(event_tl_item));
                                 (item, ItemDrawnStatus::both_drawn())
                             }
                         }
@@ -1688,6 +1731,23 @@ impl RoomScreen {
         let mut num_updates = 0;
         while let Ok(update) = tl.update_receiver.try_recv() {
             num_updates += 1;
+            let update = match update {
+                // When an existing timeline is reconnected (new channels/tasks in the backend),
+                // it sends a `FirstUpdate` that includes the new channel endpoints.
+                // We differentiate this from the initial `FirstUpdate` that occurs when the timeline
+                // is first created by checking to see if we have any timeline items.
+                // If we do, we just treat it as a `NewItems` update instead, which maintains the user's scroll anchor.
+                TimelineUpdate::FirstUpdate { initial_items } if !tl.items.is_empty() => {
+                    let len = initial_items.len();
+                    TimelineUpdate::NewItems {
+                        new_items: initial_items,
+                        changed_indices: 0..len,
+                        clear_cache: true,
+                        is_append: false,
+                    }
+                }
+                update => update,
+            };
             match update {
                 TimelineUpdate::FirstUpdate { initial_items } => {
                     tl.content_drawn_since_last_update.clear();
@@ -1741,15 +1801,11 @@ impl RoomScreen {
                     if new_items.len() == tl.items.len() {
                         // log!("process_timeline_updates(): no jump necessary for updated timeline of same length: {}", items.len());
                     }
-                    else if curr_first_id > new_items.len() {
-                        log!("process_timeline_updates(): jumping to bottom: curr_first_id {} is out of bounds for {} new items", curr_first_id, new_items.len());
-                        portal_list.set_first_id_and_scroll(new_items.len().saturating_sub(1), 0.0);
-                        portal_list.set_tail_range(true);
-                        jump_to_bottom_button.update_visibility(cx, true);
-                    }
                     // If the prior items changed, we need to find the new index of an item that was visible
                     // in the timeline viewport so that we can maintain the scroll position of that item,
                     // which ensures that the timeline doesn't jump around unexpectedly and ruin the user's experience.
+                    // This must be attempted before the jump below, because a re-created timeline can be
+                    // shorter than the old scroll index while still containing the anchored event.
                     else if let Some((curr_item_idx, new_item_idx, new_item_scroll, _event_id)) =
                         prior_items_changed.then(||
                             find_new_item_matching_current_item(cx, portal_list, curr_first_id, &tl.items, &new_items)
@@ -1762,6 +1818,12 @@ impl RoomScreen {
                             // Hide the tooltip when the timeline jumps, as a hover-out event won't occur.
                             cx.widget_action(ui,  RoomScreenTooltipActions::HoverOut);
                         }
+                    }
+                    else if curr_first_id > new_items.len() {
+                        log!("process_timeline_updates(): jumping to bottom: curr_first_id {} is out of bounds for {} new items", curr_first_id, new_items.len());
+                        portal_list.set_first_id_and_scroll(new_items.len().saturating_sub(1), 0.0);
+                        portal_list.set_tail_range(true);
+                        jump_to_bottom_button.update_visibility(cx, true);
                     }
                     //
                     // TODO: after an (un)ignore user event, all timelines are cleared. Handle that here.
@@ -3011,8 +3073,70 @@ impl RoomScreen {
 
         // Now that we have restored the TimelineUiState into this RoomScreen widget,
         // we can proceed to processing pending background updates.
+        // We first need to check that we have the latest endpoints, to get the latest updates.
+        self.reconnect_timeline_endpoints(cx);
         self.process_timeline_updates(cx, &list);
 
+        self.redraw(cx);
+    }
+
+    /// Sets this timeline's endpoints to the latest one created by the backend task, if it has new ones.
+    ///
+    /// `take_timeline_endpoints()` only returns `Some` when a fresh unclaimed channel exists,
+    /// so it's safe to call this repeatedly as a check.
+    fn reconnect_timeline_endpoints(&mut self, cx: &mut Cx) {
+        let Some(tl) = self.tl_state.as_mut() else { return };
+        // An invalidated state means we destructed the timeline on purpose
+        // (e.g., for a left/banned room or a closed thread),
+        // so don't take the endpoints for it even if they're available.
+        if timeline_state_store::is_invalidated(&tl.kind) {
+            return;
+        }
+        let Some(TimelineEndpoints {
+            update_sender,
+            update_receiver,
+            request_sender,
+            successor_room,
+            is_encrypted,
+        }) = take_timeline_endpoints(&tl.kind) else {
+            // If a room timeline was rebuilt, its thread timelines were also dropped,
+            // so we need to ask the backend to recreate them for us.
+            if let Some(thread_root_event_id) = tl.kind.thread_root_event_id() {
+                submit_async_request(MatrixRequest::CreateThreadTimeline {
+                    room_id: tl.kind.room_id().clone(),
+                    thread_root_event_id: thread_root_event_id.clone(),
+                });
+            }
+            return;
+        };
+
+        log!("Reconnecting timeline {} to its newly-created backend channel.", tl.kind);
+        // Transfer over any pending jump-to-event searches so it isn't silently dropped.
+        let mut pending_searches = Vec::new();
+        tl.request_sender.send_if_modified(|req| {
+            pending_searches = std::mem::take(&mut req.backwards_paginate);
+            false
+        });
+        tl.update_receiver = update_receiver;
+        tl.request_sender = request_sender;
+        if !pending_searches.is_empty() {
+            tl.request_sender.send_if_modified(|req| {
+                req.backwards_paginate = pending_searches;
+                true
+            });
+        }
+        tl.media_cache.set_timeline_update_sender(update_sender.clone());
+        tl.link_preview_cache.set_timeline_update_sender(update_sender);
+        tl.is_encrypted = is_encrypted;
+        if tl.tombstone_info.is_none() && let Some(successor_room) = successor_room {
+            submit_async_request(MatrixRequest::GetSuccessorRoomDetails {
+                tombstoned_room_id: tl.kind.room_id().clone(),
+            });
+            tl.tombstone_info = Some(SuccessorRoomDetails::Basic(successor_room));
+        }
+        // If `tl_state` was Some here, it means the timeline is being shown (it's visible),
+        // so inform the subscribers of that status.
+        tl.request_sender.send_if_modified(|req| !std::mem::replace(&mut req.is_timeline_open, true));
         self.redraw(cx);
     }
 
@@ -3651,6 +3775,14 @@ mod timeline_state_store {
             states.remove(kind);
         });
     }
+
+    /// Returns `true` if the given timeline's state was invalidated while a RoomScreen was still displaying it,
+    /// meaning we deliberately destructed it (and therefore it shouldn't be auto-reconnected to new endpoints).
+    pub(super) fn is_invalidated(kind: &TimelineKind) -> bool {
+        TIMELINE_STATES.with_borrow(|states| {
+            matches!(states.get(kind), Some(StateEntry::Taken { invalidated: true, .. }))
+        })
+    }
 }
 
 /// The UI-side state of a single room's timeline, which is only accessed/updated by the UI thread.
@@ -3855,13 +3987,6 @@ struct FetchedThreadSummary {
     latest_reply_preview_text: Option<String>,
 }
 impl ItemDrawnStatus {
-    /// Returns a new `ItemDrawnStatus` with both `profile_drawn` and `content_drawn` set to `false`.
-    const fn new() -> Self {
-        Self {
-            profile_drawn: false,
-            content_drawn: false,
-        }
-    }
     /// Returns a new `ItemDrawnStatus` with both `profile_drawn` and `content_drawn` set to `true`.
     const fn both_drawn() -> Self {
         Self {
@@ -5437,24 +5562,19 @@ impl SmallStateEventContent for timeline::OtherState {
     fn populate_item_content(
         &self,
         cx: &mut Cx,
-        list: &mut PortalList,
-        item_id: usize,
+        _list: &mut PortalList,
+        _item_id: usize,
         item: WidgetRef,
         _event_tl_item: &EventTimelineItem,
         username: &str,
         _item_drawn_status: ItemDrawnStatus,
         mut new_drawn_status: ItemDrawnStatus,
     ) -> (WidgetRef, ItemDrawnStatus) {
-        let item = if let Some(text_preview) = text_preview_of_other_state(self, false) {
-            item.label(cx, ids!(content))
-                .set_text(cx, &text_preview.format_with(username, false));
-            new_drawn_status.content_drawn = true;
-            item
-        } else {
-            let item = list.item(cx, item_id, id!(Empty));
-            new_drawn_status = ItemDrawnStatus::new();
-            item
-        };
+        item.label(cx, ids!(content)).set_text(
+            cx,
+            &text_preview_of_other_state(self, false).format_with(username, false),
+        );
+        new_drawn_status.content_drawn = true;
         (item, new_drawn_status)
     }
 }
@@ -5485,30 +5605,25 @@ impl SmallStateEventContent for RoomMembershipChange {
     fn populate_item_content(
         &self,
         cx: &mut Cx,
-        list: &mut PortalList,
-        item_id: usize,
+        _list: &mut PortalList,
+        _item_id: usize,
         item: WidgetRef,
-        _event_tl_item: &EventTimelineItem,
+        event_tl_item: &EventTimelineItem,
         username: &str,
         _item_drawn_status: ItemDrawnStatus,
         mut new_drawn_status: ItemDrawnStatus,
     ) -> (WidgetRef, ItemDrawnStatus) {
-        let Some(preview) = text_preview_of_room_membership_change(self, false) else {
-            // Don't actually display anything for nonexistent/unimportant membership changes.
-            return (
-                list.item(cx, item_id, id!(Empty)),
-                ItemDrawnStatus::new(),
-            );
-        };
-
+        let preview = text_preview_of_room_membership_change(self, event_tl_item.sender(), false);
         item.label(cx, ids!(content))
             .set_text(cx, &preview.format_with(username, false));
 
         // The invite_user_button is only used for "Knocked" membership change events.
-        item.button(cx, ids!(invite_user_button)).set_visible(
-            cx,
-            matches!(self.change(), Some(MembershipChange::Knocked)),
-        );
+        let membership = match self.content() {
+            StateEventContentChange::Original { content, .. } => &content.membership,
+            StateEventContentChange::Redacted(content) => &content.membership,
+        };
+        item.button(cx, ids!(invite_user_button))
+            .set_visible(cx, *membership == MembershipState::Knock);
 
         new_drawn_status.content_drawn = true;
         (item, new_drawn_status)

--- a/src/media_cache.rs
+++ b/src/media_cache.rs
@@ -70,6 +70,14 @@ impl MediaCache {
         self.timeline_update_sender.as_ref()
     }
 
+    /// Sets a new timeline update sender for this media cache's timeline.
+    pub fn set_timeline_update_sender(
+        &mut self,
+        sender: crossbeam_channel::Sender<TimelineUpdate>,
+    ) {
+        self.timeline_update_sender = Some(sender);
+    }
+
     /// Tries to get the media from the cache, or submits an async request to fetch it.
     ///
     /// This method *does not* block or wait for the media to be fetched,

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1085,6 +1085,7 @@ async fn matrix_worker_task(
                                     ),
                                 },
                             );
+                            Cx::post_action(TimelineEndpointsRecreated { room_id: room_id.clone() });
                             SignalToUI::set_ui_signal();
                         }
                         Err(error) => {
@@ -2656,6 +2657,15 @@ type ConstHasher = BuildHasherDefault<DefaultHasher>;
 /// We use a `HashMap` for O(1) lookups, as this is accessed frequently (e.g. every timeline update).
 static ALL_JOINED_ROOMS: Mutex<HashMap<OwnedRoomId, JoinedRoomDetails, ConstHasher>> = Mutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
+/// Tells any RoomScreen showing this room that its backend timeline was recreated,
+/// so it needs to take and use the new channel endpoints.
+///
+/// This is *NOT* a widget action.
+#[derive(Debug)]
+pub struct TimelineEndpointsRecreated {
+    pub room_id: OwnedRoomId,
+}
+
 /// Returns the timeline and timeline update sender for the given joined room/thread timeline.
 fn get_per_timeline_details<'a>(
     all_joined_rooms: &'a mut HashMap<OwnedRoomId, JoinedRoomDetails, ConstHasher>,
@@ -3937,6 +3947,9 @@ async fn add_new_room(
             pinned_events_subscriber: None,
         },
     );
+    // A visible RoomScreen might still have this room's previous channel endpoints,
+    // which are now dead, so we inform it that there are new endpoints it needs to take & use.
+    Cx::post_action(TimelineEndpointsRecreated { room_id: new_room.room_id.clone() });
 
     let latest = get_latest_event_details(
         &new_room.room.latest_event().await,
@@ -4672,6 +4685,7 @@ async fn timeline_subscriber_handler(
     }).unwrap_or_else(
         |_e| panic!("Error: timeline update sender couldn't send first update ({} items) to room {room_id}, thread {thread_root_event_id:?}...!", timeline_items.len())
     );
+    SignalToUI::set_ui_signal();
 
     // the event ID to search for while loading previous items into the timeline.
     let mut target_event_id = None;


### PR DESCRIPTION
* Rebuilding a room's timeline (which might happen when the timeline subscriber get a Remove/Truncate/Reset diff) could rarely cause the timeline UI (RoomSCreen) to not receive any more updates via its timeline update sender+receiver channel, which is bad.
* We now fix that via a new `TimelineEndpointsRecreated` action, which informs RoomScreens and other relevant widgets to re-obtain and reconnect to the new endpoints in place, without losing any of the existing timeline items, caches, scroll position, etc

Also, we now show all small state events that matter, regardless of timestamp, just based on whether they are actually relevant to membership changes, for ex.