### PR TITLE
invalidated/drop a left or banned room's main *and* thread timelines' states

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use matrix_sdk::{RoomState, ruma::{OwnedEventId, OwnedRoomId, OwnedUserId, RoomI
 use serde::{Deserialize, Serialize};
 use crate::{
     avatar_cache::clear_avatar_cache, room_preview_cache::clear_room_preview_cache, home::{
-        event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states, invalidate_timeline_state}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
+        event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states, invalidate_single_timeline_state}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
     }, join_leave_room_modal::{
         JoinLeaveModalKind, JoinLeaveRoomModalAction, JoinLeaveRoomModalWidgetRefExt
     }, login::login_screen::LoginAction, logout::logout_confirm_modal::{LogoutAction, LogoutConfirmModalAction, LogoutConfirmModalWidgetRefExt}, persistence, profile::user_profile_cache::clear_user_profile_cache, room::BasicRoomDetails, settings::app_preferences::{AppPreferences, UiZoom}, shared::{confirmation_modal::{ConfirmationModalContent, ConfirmationModalWidgetRefExt}, context_menu::{ContextMenuClosed, menu_position_margin}, image_viewer::{ImageViewerAction, LoadState}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{DirectMessageRoomAction, MatrixRequest, TimelineKind, current_user_id, submit_async_request}, utils::RoomNameId, verification::VerificationAction, verification_modal::{
@@ -1161,7 +1161,7 @@ impl SelectedRoom {
         let room_id = room_name_id.room_id().clone();
         // Drop the stale UI cache so reopening rebuilds a fresh timeline instead of reusing
         // a cache whose backend is about to be freed.
-        invalidate_timeline_state(cx, &TimelineKind::Thread {
+        invalidate_single_timeline_state(cx, &TimelineKind::Thread {
             room_id: room_id.clone(),
             thread_root_event_id: thread_root_event_id.clone(),
         });

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -9,7 +9,7 @@ use makepad_widgets::{image_cache::ImageBuffer, makepad_platform::event::finger:
 use matrix_sdk::reqwest::StatusCode;
 use matrix_sdk::{
     OwnedServerName, media::{MediaFormat, MediaRequestParameters}, room::RoomMember, ruma::{
-        EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedMxcUri, OwnedRoomId, UserId, events::{
+        EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedMxcUri, OwnedRoomId, RoomId, UserId, events::{
             receipt::Receipt,
             room::{
                 ImageInfo, MediaSource, message::{
@@ -3776,6 +3776,26 @@ mod timeline_state_store {
         });
     }
 
+    /// Invalidates the states of a room's main timeline and all of its thread timelines,
+    /// e.g., for when that room has been left or banned.
+    pub(super) fn invalidate_entire_room(_cx: &mut Cx, room_id: &RoomId) {
+        TIMELINE_STATES.with_borrow_mut(|states| {
+            states.retain(|kind, entry| {
+                if kind.room_id() != room_id {
+                    return true;
+                }
+                // Same as `invalidate()`: keep the shown UI state but flag it
+                // such that `put_back()` drops it when the RoomScreen hides it.
+                if let StateEntry::Taken { invalidated, .. } = entry {
+                    *invalidated = true;
+                    true
+                } else {
+                    false
+                }
+            });
+        });
+    }
+
     /// Returns `true` if the given timeline's state was invalidated while a RoomScreen was still displaying it,
     /// meaning we deliberately destructed it (and therefore it shouldn't be auto-reconnected to new endpoints).
     pub(super) fn is_invalidated(kind: &TimelineKind) -> bool {
@@ -6238,12 +6258,18 @@ pub fn clear_timeline_states(cx: &mut Cx) {
     timeline_state_store::clear_all(cx);
 }
 
-/// Invalidates the UI-side cached state for a timeline whose backend was just closed, so the
-/// next show rebuilds it instead of reusing the stale cache.
+/// Invalidates the UI-side cached state for a single timeline whose backend was just closed,
+/// so the next time it's shown, it'll rebuild it instead of reusing the stale cached data.
 ///
 /// Takes `&mut Cx` (unused) to enforce that it's only called from the main UI thread.
-pub fn invalidate_timeline_state(cx: &mut Cx, kind: &TimelineKind) {
+pub fn invalidate_single_timeline_state(cx: &mut Cx, kind: &TimelineKind) {
     timeline_state_store::invalidate(cx, kind);
+}
+
+/// Invalidates the cached UI states of the given room's main timeline
+/// and all of its thread timelines.
+pub fn invalidate_entire_room_timeline_states(cx: &mut Cx, room_id: &RoomId) {
+    timeline_state_store::invalidate_entire_room(cx, room_id);
 }
 
 /// A pending "Reply In Thread" request to focus a thread's input bar once its RoomScreen is

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -26,7 +26,7 @@ use matrix_sdk::{RoomState, ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch
 use crate::{
     app::{AppState, AppStateAction, SelectedRoom},
     home::{
-        invite_screen::{InviteScreenAction, JoinRoomResultAction, LeaveRoomResultAction}, navigation_tab_bar::{NavigationBarAction, SelectedTab}, room_context_menu::RoomContextMenuDetails, room_screen::invalidate_timeline_state, rooms_list_entry::RoomsListEntryAction, space_lobby::{SpaceLobbyAction, SpaceLobbyEntryWidgetExt}
+        invite_screen::{InviteScreenAction, JoinRoomResultAction, LeaveRoomResultAction}, navigation_tab_bar::{NavigationBarAction, SelectedTab}, room_context_menu::RoomContextMenuDetails, room_screen::invalidate_entire_room_timeline_states, rooms_list_entry::RoomsListEntryAction, space_lobby::{SpaceLobbyAction, SpaceLobbyEntryWidgetExt}
     },
     logout::logout_confirm_modal::LogoutAction,
     room::{
@@ -928,9 +928,9 @@ impl RoomsList {
                     self.hidden_rooms.remove(&room_id);
 
                     // If the removed room is no longer joined (left/kicked/banned),
-                    // drop all of its saved UI state.
+                    // drop all of its saved UI state, including its thread timelines.
                     if matches!(new_state, RoomState::Left | RoomState::Banned) {
-                        invalidate_timeline_state(cx, &TimelineKind::MainRoom { room_id });
+                        invalidate_entire_room_timeline_states(cx, &room_id);
                     }
 
                     self.update_status();


### PR DESCRIPTION
When a room is left or the user got banned, we were only invalidating its main room timeline state, so any thread timeline states for that room lingered until that room was shown again.
Now we include all the thread timelines states, since you can't show threads for a room that was left, and it's unlikely that it'll ever be shown again, so no point waiting.