### PR TITLE
LoadingPane: refactor to move state out of room screen

### DIFF
--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -1,5 +1,5 @@
 use makepad_widgets::*;
-use matrix_sdk::ruma::OwnedEventId;
+use matrix_sdk::ruma::{EventId, OwnedEventId};
 
 use crate::sliding_sync::TimelineRequestSender;
 
@@ -89,10 +89,18 @@ script_mod! {
 }
 
 
+/// The error shown when a jumped-to event can't be found.
+/// `noun` is what the search covered, i.e. "room" or "thread".
+fn jump_target_not_found_msg(noun: &str) -> String {
+    format!("Couldn't find that message in this {noun}'s history.\n\n\
+        It may have been deleted, it may be a kind of event that Robrix doesn't display, \
+        or the server may not be able to return it.")
+}
+
 
 /// The state of a LoadingPane: the possible tasks that it may be performing.
 #[derive(Default)]
-pub enum LoadingPaneState {
+enum LoadingPaneState {
     /// The room is being backwards paginated until the target event is reached.
     BackwardsPaginateUntilEvent {
         target_event_id: OwnedEventId,
@@ -100,6 +108,8 @@ pub enum LoadingPaneState {
         description: String,
         /// The number of events paginated so far, which is only used to display progress.
         events_paginated: usize,
+        /// "room" or "thread", used when telling the user we couldn't find the event.
+        timeline_noun: &'static str,
         /// The sender for timeline requests for the room that is showing this modal.
         /// This is used to inform the `timeline_subscriber_handler` that the user has
         /// cancelled the request, so that it can stop looking for the target event.
@@ -187,55 +197,120 @@ impl LoadingPane {
         self.visible
     }
 
-    /// Hides this pane, which also cancels any search it was showing.
-    pub fn hide(&mut self, cx: &mut Cx) {
-        self.set_state(cx, LoadingPaneState::None);
-        // Only give back key focus if we still had it; something else may have taken it.
-        if cx.has_key_focus(self.view.area()) {
-            cx.revert_key_focus();
-        }
-        self.visible = false;
+    /// Returns `true` if this pane is currently searching for any event.
+    pub fn is_searching(&self) -> bool {
+        matches!(self.state, LoadingPaneState::BackwardsPaginateUntilEvent { .. })
     }
 
-    pub fn show(&mut self, cx: &mut Cx) {
+    /// Returns the event ID this pane is currently searching for, if any.
+    pub fn searching_for(&self) -> Option<OwnedEventId> {
+        match &self.state {
+            LoadingPaneState::BackwardsPaginateUntilEvent { target_event_id, .. } => Some(target_event_id.clone()),
+            _ => None,
+        }
+    }
+
+    /// Shows this pane and starts searching backwards for the given event.
+    ///
+    /// If another search was in progress, it will be cancelled.
+    pub fn start_search(
+        &mut self,
+        cx: &mut Cx,
+        target_event_id: OwnedEventId,
+        description: String,
+        timeline_noun: &'static str,
+        request_sender: TimelineRequestSender,
+    ) {
+        self.set_state(cx, LoadingPaneState::BackwardsPaginateUntilEvent {
+            target_event_id,
+            description,
+            events_paginated: 0,
+            timeline_noun,
+            request_sender,
+        });
         self.visible = true;
         cx.set_key_focus(self.view.area());
         self.redraw(cx);
     }
 
-    pub fn set_state(&mut self, cx: &mut Cx, state: LoadingPaneState) {
-        let cancel_button = self.button(cx, ids!(cancel_button));
-        match &state {
-            LoadingPaneState::BackwardsPaginateUntilEvent {
-                description,
-                events_paginated,
-                ..
-            } => {
-                self.set_title(cx, "Searching older messages...");
-                self.set_status(cx, &format!(
+    /// Adds `num_events` to the progress shown by an in-progress search.
+    ///
+    /// This is additive, not a replacement.
+    pub fn paginated_more_events(&mut self, cx: &mut Cx, num_events: usize) {
+        let LoadingPaneState::BackwardsPaginateUntilEvent { events_paginated, .. } = &mut self.state else { return };
+        *events_paginated += num_events;
+        self.populate(cx);
+    }
+
+    /// Sets the timeline request sender for this loading pane's current search.
+    ///
+    /// Does nothing if there's no search in progress.
+    ///
+    /// This is useful for when the timeline endpoint channels get re-created,
+    /// and we need to update them so that the loading pane can send requests
+    /// back to the new backend task that's doing the searching.
+    pub fn set_timeline_request_sender(&mut self, request_sender: TimelineRequestSender) {
+        let LoadingPaneState::BackwardsPaginateUntilEvent { request_sender: sender, .. } = &mut self.state else { return };
+        *sender = request_sender;
+    }
+
+    /// Ends the current search and shows an error (we couldn't find the event).
+    pub fn search_failed(&mut self, cx: &mut Cx) {
+        let LoadingPaneState::BackwardsPaginateUntilEvent { timeline_noun, .. } = &self.state else { return };
+        let error_message = jump_target_not_found_msg(timeline_noun);
+        self.set_state(cx, LoadingPaneState::Error(error_message));
+    }
+
+    /// Hides this pane, which also cancels any search it was showing.
+    pub fn hide(&mut self, cx: &mut Cx) {
+        self.set_state(cx, LoadingPaneState::None);
+        // if the pane was actually drawn and had key focus, give it back.
+        let area = self.view.area();
+        if !matches!(area, Area::Empty) && cx.has_key_focus(area) {
+            cx.revert_key_focus();
+        }
+        self.visible = false;
+    }
+
+    /// Returns `true` if this pane is searching for the given target event.
+    pub fn is_searching_for(&self, target_event_id: &EventId) -> bool {
+        matches!(
+            &self.state,
+            LoadingPaneState::BackwardsPaginateUntilEvent { target_event_id: id, .. }
+                if &**id == target_event_id
+        )
+    }
+
+    fn set_state(&mut self, cx: &mut Cx, state: LoadingPaneState) {
+        // This will drop the previous `self.state`, which cancels its background request.
+        self.state = state;
+        self.populate(cx);
+    }
+
+    /// Populates this pane's labels and button from its current state.
+    fn populate(&mut self, cx: &mut Cx) {
+        let ui_text = match &self.state {
+            LoadingPaneState::BackwardsPaginateUntilEvent { description, events_paginated, .. } => Some((
+                "Searching older messages...",
+                format!(
                     "Looking for {description}...\n\n\
                     Fetched {events_paginated} messages so far...",
-                ));
-                cancel_button.set_text(cx, "Cancel");
-            }
-            LoadingPaneState::Error(error_message) => {
-                self.set_title(cx, "Error loading content");
-                self.set_status(cx, error_message);
-                cancel_button.set_text(cx, "Okay");
-            }
-            LoadingPaneState::None => { }
+                ),
+                "Cancel",
+            )),
+            LoadingPaneState::Error(error_message) => Some((
+                "Error loading content",
+                error_message.clone(),
+                "Okay",
+            )),
+            LoadingPaneState::None => None,
+        };
+        if let Some((title_text, status_text, button_text)) = ui_text {
+            self.label(cx, ids!(title)).set_text(cx, title_text);
+            self.label(cx, ids!(status)).set_text(cx, &status_text);
+            self.button(cx, ids!(cancel_button)).set_text(cx, button_text);
         }
-
-        self.state = state;
         self.redraw(cx);
-    }
-
-    pub fn set_status(&mut self, cx: &mut Cx, status: &str) {
-        self.label(cx, ids!(status)).set_text(cx, status);
-    }
-
-    pub fn set_title(&mut self, cx: &mut Cx, title: &str) {
-        self.label(cx, ids!(title)).set_text(cx, title);
     }
 }
 
@@ -246,51 +321,55 @@ impl LoadingPaneRef {
         inner.is_currently_shown(cx)
     }
 
-    /// See [`LoadingPane::show()`]
-    pub fn show(&self, cx: &mut Cx) {
+    /// See [`LoadingPane::is_searching()`]
+    pub fn is_searching(&self) -> bool {
+        self.borrow().is_some_and(|inner| inner.is_searching())
+    }
+
+    /// See [`LoadingPane::is_searching_for()`]
+    pub fn is_searching_for(&self, target_event_id: &EventId) -> bool {
+        self.borrow().is_some_and(|inner| inner.is_searching_for(target_event_id))
+    }
+
+    /// See [`LoadingPane::searching_for()`]
+    pub fn searching_for(&self) -> Option<OwnedEventId> {
+        self.borrow().and_then(|inner| inner.searching_for())
+    }
+
+    /// See [`LoadingPane::start_search()`]
+    pub fn start_search(
+        &self,
+        cx: &mut Cx,
+        target_event_id: OwnedEventId,
+        description: String,
+        timeline_noun: &'static str,
+        request_sender: TimelineRequestSender,
+    ) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.show(cx);
+        inner.start_search(cx, target_event_id, description, timeline_noun, request_sender);
+    }
+
+    /// See [`LoadingPane::paginated_more_events()`]
+    pub fn paginated_more_events(&self, cx: &mut Cx, num_events: usize) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.paginated_more_events(cx, num_events);
+    }
+
+    /// See [`LoadingPane::set_timeline_request_sender()`]
+    pub fn set_timeline_request_sender(&self, request_sender: TimelineRequestSender) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.set_timeline_request_sender(request_sender);
+    }
+
+    /// See [`LoadingPane::search_failed()`]
+    pub fn search_failed(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.search_failed(cx);
     }
 
     /// See [`LoadingPane::hide()`]
     pub fn hide(&self, cx: &mut Cx) {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.hide(cx);
-    }
-
-    /// Returns `true` if this pane is currently searching for any event.
-    pub fn is_searching(&self) -> bool {
-        self.borrow().is_some_and(|inner|
-            matches!(inner.state, LoadingPaneState::BackwardsPaginateUntilEvent { .. })
-        )
-    }
-
-    /// Returns the target event ID this pane is currently searching for, if any.
-    pub fn searching_for(&self) -> Option<OwnedEventId> {
-        self.borrow().and_then(|inner| match &inner.state {
-            LoadingPaneState::BackwardsPaginateUntilEvent { target_event_id, .. } => Some(target_event_id.clone()),
-            _ => None,
-        })
-    }
-
-    pub fn take_state(&self) -> LoadingPaneState {
-        self.borrow_mut()
-            .map(|mut inner| std::mem::take(&mut inner.state))
-            .unwrap_or(LoadingPaneState::None)
-    }
-
-    pub fn set_state(&self, cx: &mut Cx, state: LoadingPaneState) {
-        let Some(mut inner) = self.borrow_mut() else { return }; 
-        inner.set_state(cx, state);
-    }
-
-    pub fn set_status(&self, cx: &mut Cx, status: &str) {
-        let Some(mut inner) = self.borrow_mut() else { return }; 
-        inner.set_status(cx, status);
-    }
-
-    pub fn set_title(&self, cx: &mut Cx, title: &str) {
-        let Some(mut inner) = self.borrow_mut() else { return }; 
-        inner.set_title(cx, title);
     }
 }

--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -92,9 +92,8 @@ script_mod! {
 /// The error shown when a jumped-to event can't be found.
 /// `noun` is what the search covered, i.e. "room" or "thread".
 fn jump_target_not_found_msg(noun: &str) -> String {
-    format!("Couldn't find that message in this {noun}'s history.\n\n\
-        It may have been deleted, it may be a kind of event that Robrix doesn't display, \
-        or the server may not be able to return it.")
+    format!("Couldn't find that event in this {noun}'s history.\n\n\
+        It may have been deleted, or the homeserver may not be able to return it.")
 }
 
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -27,7 +27,7 @@ use ruma::{OwnedUserId, api::client::receipt::create_receipt::v3::ReceiptType, e
 
 use matrix_sdk_ui::sync_service::State;
 use crate::{
-    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::{LoadingPaneState, LoadingPaneWidgetExt}, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
+    app::{AppStateAction, ConfirmDeleteAction, SelectedRoom}, avatar_cache, event_preview::{plaintext_body_of_timeline_item, text_preview_of_encrypted_message, text_preview_of_member_profile_change, text_preview_of_other_message_like, text_preview_of_other_state, text_preview_of_room_membership_change, text_preview_of_timeline_item}, home::{edited_indicator::EditedIndicatorWidgetRefExt, link_preview::{LinkPreviewCache, LinkPreviewRef, LinkPreviewWidgetRefExt}, loading_pane::LoadingPaneWidgetExt, room_image_viewer::{fetch_full_image_for_viewer, get_image_name_and_filesize}, rooms_list::{RoomsListAction, RoomsListRef}, rooms_list_header::RoomsListHeaderAction, tombstone_footer::SuccessorRoomDetails}, media_cache::{MediaCache, MediaCacheEntry}, profile::{
         user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId, UserProfilePaneAction, UserProfilePaneInfo, UserProfileSlidingPaneRef, UserProfileSlidingPaneWidgetExt},
         user_profile_cache,
     },
@@ -66,14 +66,6 @@ const READ_RECEIPT_SEND_DELAY: f64 = 0.5;
 
 /// The timeout/delay between pagination finishing and us showing an error.
 const JUMP_SEARCH_NOT_FOUND_DELAY: f64 = 2.0;
-
-/// The error shown when a jumped-to event can't be found.
-/// `noun` is what the search covered, i.e. "room" or "thread".
-fn jump_target_not_found_msg(noun: &str) -> String {
-    format!("Couldn't find that message in this {noun}'s history.\n\n\
-        It may have been deleted, it may be a kind of event that Robrix doesn't display, \
-        or the server may not be able to return it.")
-}
 
 static UNNAMED_ROOM: &str = "Unnamed Room";
 
@@ -997,19 +989,13 @@ impl Widget for RoomScreen {
             // Process pending timeline updates, since they might include the event we're looking for.
             self.process_timeline_updates(cx, &portal_list);
             // If we didn't find it and nothing else changed, we have to assume the search is over (unsuccessfully).
-            let is_search_over = search_target.is_some()
-                && loading_pane.searching_for() == search_target
+            if let Some(target_event_id) = search_target
+                && loading_pane.is_searching_for(&target_event_id)
                 && self.jump_search_timer.is_empty()
-                && !self.tl_state.as_ref().is_some_and(|tl| tl.is_paginating);
-            if is_search_over && let Some(target_event_id) = search_target {
+                && !self.tl_state.as_ref().is_some_and(|tl| tl.is_paginating)
+            {
                 warning!("Couldn't find event {target_event_id} in room {:?}", self.room_id());
-                // Dropping the taken state cancels the search request.
-                drop(loading_pane.take_state());
-                loading_pane.set_state(cx, LoadingPaneState::Error(
-                    jump_target_not_found_msg(
-                        self.tl_state.as_ref().map_or("room", |tl| tl.kind.desc())
-                    )
-                ));
+                loading_pane.search_failed(cx);
             }
         }
 
@@ -1854,17 +1840,8 @@ impl RoomScreen {
                     }
 
                     if prior_items_changed {
-                        // If this RoomScreen is showing the loading pane and has an ongoing backwards pagination request,
-                        // then we should update the status message in that loading pane.
-                        // Note that we do this here because `clear_cache` will always be true if backwards pagination occurred.
-                        let mut loading_pane_state = loading_pane.take_state();
-                        if let LoadingPaneState::BackwardsPaginateUntilEvent {
-                            events_paginated, target_event_id, ..
-                        } = &mut loading_pane_state {
-                            *events_paginated += new_items.len().saturating_sub(tl.items.len());
-                            log!("While finding target event {target_event_id}, we have now loaded {events_paginated} messages...");
-                        }
-                        loading_pane.set_state(cx, loading_pane_state);
+                        // update the loading pane with the number of new items we back-paginated
+                        loading_pane.paginated_more_events(cx, new_items.len().saturating_sub(tl.items.len()));
                     }
 
                     if clear_cache {
@@ -1897,7 +1874,7 @@ impl RoomScreen {
                 TimelineUpdate::TargetEventFound { target_event_id, index } => {
                     // log!("Target event found in room {}: {target_event_id}, index: {index}", tl.kind.room_id());
                     // Ignore a target-event-found result if we're no longer waiting on it.
-                    if loading_pane.searching_for().as_ref() != Some(&target_event_id) {
+                    if !loading_pane.is_searching_for(&target_event_id) {
                         continue;
                     }
                     // Stop & reset the timeout timer now that we've found it.
@@ -1915,7 +1892,6 @@ impl RoomScreen {
                     if is_valid {
                         // We successfully found the target event, so we can close the loading pane,
                         // reset the loading panestate to `None`, and stop issuing backwards pagination requests.
-                        loading_pane.set_status(cx, "Successfully found the target message!");
                         loading_pane.hide(cx);
 
                         // NOTE: this code was copied from the `MessageAction::JumpToRelated` handler;
@@ -1933,9 +1909,7 @@ impl RoomScreen {
                         // which means we encountered an error and are unable to jump to the target event.
                         error!("Target event index {index} of {} is out of bounds for room {}", tl.items.len(), tl.kind.room_id());
                         // Show this error in the loading pane, which should already be open.
-                        loading_pane.set_state(cx, LoadingPaneState::Error(
-                            jump_target_not_found_msg(tl.kind.desc())
-                        ));
+                        loading_pane.search_failed(cx);
                     }
 
                     should_continue_backwards_pagination = false;
@@ -2833,19 +2807,15 @@ impl RoomScreen {
             log!("The related event {target_event_id} wasn't immediately available in room {}, searching for it in the background...", tl.kind.room_id());
             cx.stop_timer(self.jump_search_timer);
             self.jump_search_timer = Timer::empty();
-            // Here, we set the state of the loading pane and display it to the user.
-            // The main logic will be handled in `process_timeline_updates()`, which is the only
-            // place where we can receive updates to the timeline from the background tasks.
-            loading_pane.set_state(
+            // The main logic is handled in `process_timeline_updates()`, the only
+            // place where we receive updates to the timeline from background tasks.
+            loading_pane.start_search(
                 cx,
-                LoadingPaneState::BackwardsPaginateUntilEvent {
-                    target_event_id: target_event_id.clone(),
-                    description: searching_for,
-                    events_paginated: 0,
-                    request_sender: tl.request_sender.clone(),
-                },
+                target_event_id.clone(),
+                searching_for,
+                tl.kind.desc(),
+                tl.request_sender.clone(),
             );
-            loading_pane.show(cx);
 
             tl.request_sender.send_if_modified(|req| {
                 if let Some(existing) = req.backwards_paginate.iter_mut().find(|r| &r.room_id == tl.kind.room_id()) {
@@ -3137,6 +3107,9 @@ impl RoomScreen {
         // If `tl_state` was Some here, it means the timeline is being shown (it's visible),
         // so inform the subscribers of that status.
         tl.request_sender.send_if_modified(|req| !std::mem::replace(&mut req.is_timeline_open, true));
+        // A search shown by the loading pane still points at the old channel, so move it over too.
+        let reconnected_sender = tl.request_sender.clone();
+        self.loading_pane(cx, ids!(loading_pane)).set_timeline_request_sender(reconnected_sender);
         self.redraw(cx);
     }
 
@@ -3280,7 +3253,7 @@ impl RoomScreen {
 
         self.hide_timeline();
         // Reset the the state of the inner loading pane.
-        self.loading_pane(cx, ids!(loading_pane)).take_state();
+        self.loading_pane(cx, ids!(loading_pane)).hide(cx);
         // Reset the user profile sliding pane so a previous room's open profile
         // pane doesn't remain shown when this RoomScreen is reused for a new room.
         self.user_profile_sliding_pane(cx, ids!(user_profile_sliding_pane)).reset(cx);
@@ -3301,7 +3274,7 @@ impl RoomScreen {
             self.hide_timeline();
         }
         // Dropping the loading pane state cancels any in-progress event search.
-        drop(self.loading_pane(cx, ids!(loading_pane)).take_state());
+        self.loading_pane(cx, ids!(loading_pane)).hide(cx);
         self.room_name_id = None;
         self.timeline_kind = None;
         self.pinned_events.clear();

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2360,11 +2360,8 @@ impl RoomScreen {
         {
             return Some(event);
         }
-        items.iter()
-            .rev()
-            .take(MAX_ITEMS_TO_SEARCH_THROUGH)
-            .filter_map(|item| item.as_event())
-            .find(|ev| ev.event_id().is_some_and(|id| id == target_event_id))
+        let index = index_of_event(items, target_event_id, items.len(), MAX_ITEMS_TO_SEARCH_THROUGH)?;
+        items.get(index).and_then(|item| item.as_event())
     }
 
     /// Registers a pending download for a media transfer (e.g., download, share)


### PR DESCRIPTION
`LoadingPaneState` is now private, so RoomScreen can't modify it. Instead the RoomScreen just calls LoadingPane fns to update its state, which is generally a much cleaner design.

Also fixes a few rare conditions, e.g., a loading pane being shown while a timeline is recreated in the backend. That's now handled properly.