### PR TITLE
Fix reply-preview shader, update to latest makepad for windows fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "accessory"
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "arrayvec"
 version = "0.7.6"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "as_variant"
@@ -238,7 +238,7 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
 [[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "libloading 0.8.9",
 ]
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "bit-set"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "bit-vec",
 ]
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "bit-vec"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "bitflags"
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "2.10.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "bitmaps"
@@ -834,7 +834,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 [[package]]
 name = "bytemuck"
 version = "1.25.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "byteorder"
@@ -845,7 +845,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "byteorder"
 version = "1.5.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "bytes"
@@ -904,7 +904,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "cfg_aliases"
@@ -915,7 +915,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "chacha20"
@@ -1252,7 +1252,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crunchy"
 version = "0.2.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "crypto-bigint"
@@ -1632,7 +1632,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 [[package]]
 name = "downcast-rs"
 version = "1.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "dunce"
@@ -1767,7 +1767,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "equivalent"
 version = "1.0.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "errno"
@@ -1945,7 +1945,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "foldhash"
 version = "0.2.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "foreign-types"
@@ -2102,9 +2102,9 @@ dependencies = [
 [[package]]
 name = "fxhash"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "byteorder 1.5.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "byteorder 1.5.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
@@ -2300,9 +2300,9 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.16.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "foldhash 0.2.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "foldhash 0.2.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
@@ -2335,7 +2335,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexf-parse"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "hilog-sys"
@@ -2774,10 +2774,10 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.13.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "equivalent 1.0.2 (git+https://github.com/makepad/makepad?branch=dev)",
- "hashbrown 0.16.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "equivalent 1.0.2 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
@@ -2963,15 +2963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "windows-targets 0.53.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "libloading"
 version = "0.8.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/makepad/makepad?branch=dev)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "windows-link 0.2.1",
 ]
 
@@ -3043,7 +3043,7 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 [[package]]
 name = "log"
 version = "0.4.29"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "loom"
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "makepad-apple-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-objc-sys",
 ]
@@ -3132,12 +3132,12 @@ dependencies = [
 [[package]]
 name = "makepad-byteorder-lite"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-code-editor"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-widgets",
 ]
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -3162,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -3178,16 +3178,15 @@ dependencies = [
  "makepad-zune-qoi",
  "rustybuzz",
  "sdfer",
- "serde",
- "unicode-bidi 0.3.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "unicode-linebreak",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
 name = "makepad-error-log"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3195,27 +3194,27 @@ dependencies = [
 [[package]]
 name = "makepad-fast-inflate"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-filesystem-watcher"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-gif"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "weezl",
 ]
@@ -3223,10 +3222,10 @@ dependencies = [
 [[package]]
 name = "makepad-half"
 version = "2.7.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "cfg-if 1.0.4 (git+https://github.com/makepad/makepad?branch=dev)",
- "crunchy 0.2.4 (git+https://github.com/makepad/makepad?branch=dev)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
+ "crunchy 0.2.4 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "num-traits 0.2.20",
  "zerocopy 0.8.39",
 ]
@@ -3234,7 +3233,7 @@ dependencies = [
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-live-id",
 ]
@@ -3248,7 +3247,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-latex-math"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "ttf-parser",
 ]
@@ -3256,16 +3255,15 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-live-id-macros",
- "serde",
 ]
 
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3273,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-reload-core"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-filesystem-watcher",
 ]
@@ -3281,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -3289,12 +3287,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -3303,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3311,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "makepad-network"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-apple-sys",
  "makepad-error-log",
@@ -3325,15 +3323,15 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-platform"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "ash",
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "ctrlc",
  "hilog-sys",
  "makepad-android-state",
@@ -3356,7 +3354,7 @@ dependencies = [
  "napi-derive-ohos",
  "napi-ohos",
  "ohos-sys",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
@@ -3368,12 +3366,12 @@ dependencies = [
 [[package]]
 name = "makepad-regex"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-error-log",
  "makepad-html",
@@ -3381,13 +3379,13 @@ dependencies = [
  "makepad-math",
  "makepad-regex",
  "makepad-script-derive",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -3395,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-std"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-network",
  "makepad-script",
@@ -3404,14 +3402,14 @@ dependencies = [
 [[package]]
 name = "makepad-shared-bytes"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "makepad-studio-protocol"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "makepad-error-log",
  "makepad-live-id",
  "makepad-micro-serde",
@@ -3421,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "makepad-svg"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-html",
  "makepad-live-id",
@@ -3430,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "makepad-tsdf"
 version = "0.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-math",
  "makepad-micro-serde",
@@ -3439,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "makepad-video"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-apple-sys",
  "makepad-objc-sys",
@@ -3449,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -3458,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "makepad-webp"
 version = "0.2.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-byteorder-lite",
 ]
@@ -3466,22 +3464,21 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "2.0.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
  "makepad-html",
  "makepad-latex-math",
  "pulldown-cmark 0.12.2",
- "serde",
  "ttf-parser",
- "unicode-segmentation 1.12.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
 name = "makepad-zune-bmp"
 version = "0.5.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "log 0.4.28",
  "makepad-zune-core",
@@ -3490,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "log 0.4.28",
 ]
@@ -3498,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "simd-adler32",
 ]
@@ -3506,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.5.15"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3514,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.5.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-fast-inflate",
  "makepad-zune-core",
@@ -3524,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-qoi"
 version = "0.5.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -3906,7 +3903,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "memchr"
 version = "2.7.6"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "memoffset"
@@ -3978,23 +3975,23 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "27.0.3"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "arrayvec 0.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
+ "arrayvec 0.7.6 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "bit-set",
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 1.0.4 (git+https://github.com/makepad/makepad?branch=dev)",
- "cfg_aliases 0.2.1 (git+https://github.com/makepad/makepad?branch=dev)",
- "hashbrown 0.16.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "cfg-if 1.0.4 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
+ "cfg_aliases 0.2.1 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
+ "hashbrown 0.16.1 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "hexf-parse",
- "indexmap 2.13.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "indexmap 2.13.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "makepad-error-log",
  "makepad-half",
  "num-traits 0.2.20",
- "once_cell 1.21.3 (git+https://github.com/makepad/makepad?branch=dev)",
+ "once_cell 1.21.3 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "thiserror 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "unicode-ident",
 ]
 
@@ -4162,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.20"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "num_cpus"
@@ -4326,7 +4323,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "once_cell"
 version = "1.21.3"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4636,7 +4633,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "polling"
@@ -4795,10 +4792,10 @@ dependencies = [
 [[package]]
 name = "pulldown-cmark"
 version = "0.12.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
- "memchr 2.7.6 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
+ "memchr 2.7.6 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "unicase 2.9.0",
 ]
 
@@ -5580,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "rustc-hash"
@@ -5705,12 +5702,12 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rustybuzz"
 version = "0.18.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "bitflags 2.10.0 (git+https://github.com/makepad/makepad?branch=dev)",
+ "bitflags 2.10.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "bytemuck",
  "makepad-error-log",
- "smallvec 1.15.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "smallvec 1.15.1 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
@@ -5799,7 +5796,7 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 [[package]]
 name = "scoped-tls"
 version = "1.0.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "scopeguard"
@@ -5810,7 +5807,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "sealed"
@@ -6120,7 +6117,7 @@ dependencies = [
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "siphasher"
@@ -6146,7 +6143,7 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.15.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "socket2"
@@ -6170,7 +6167,7 @@ dependencies = [
 [[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6541,9 +6538,9 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "2.0.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
- "thiserror-impl 2.0.18 (git+https://github.com/makepad/makepad?branch=dev)",
+ "thiserror-impl 2.0.18 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
@@ -6571,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "thiserror-impl"
 version = "2.0.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -6953,7 +6950,7 @@ dependencies = [
 [[package]]
 name = "ttf-parser"
 version = "0.24.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "tungstenite"
@@ -7016,7 +7013,7 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 [[package]]
 name = "unicase"
 version = "2.9.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-bidi"
@@ -7027,17 +7024,17 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-bidi"
 version = "0.3.18"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-bidi-mirroring"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-ccc"
 version = "0.3.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-ident"
@@ -7048,7 +7045,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-normalization"
@@ -7068,12 +7065,12 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 [[package]]
 name = "unicode-properties"
 version = "0.1.4"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-script"
 version = "0.5.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7084,7 +7081,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "unicode-xid"
@@ -7410,11 +7407,11 @@ dependencies = [
 [[package]]
 name = "wayland-backend"
 version = "0.3.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "downcast-rs",
  "libc",
- "scoped-tls 1.0.1 (git+https://github.com/makepad/makepad?branch=dev)",
+ "scoped-tls 1.0.1 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "smallvec 1.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys",
 ]
@@ -7422,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "wayland-client"
 version = "0.31.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
@@ -7432,7 +7429,7 @@ dependencies = [
 [[package]]
 name = "wayland-egl"
 version = "0.32.9"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "wayland-backend",
  "wayland-sys",
@@ -7441,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "wayland-protocols"
 version = "0.32.10"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "bitflags 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-backend",
@@ -7451,10 +7448,10 @@ dependencies = [
 [[package]]
 name = "wayland-sys"
 version = "0.31.8"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "log 0.4.29",
- "pkg-config 0.3.32 (git+https://github.com/makepad/makepad?branch=dev)",
+ "pkg-config 0.3.32 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]
 
 [[package]]
@@ -7502,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "weezl"
 version = "0.1.12"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "whoami"
@@ -7555,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "windows"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "windows-collections 0.3.2",
  "windows-core 0.62.2",
@@ -7574,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7607,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.62.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -7628,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "windows-future"
 version = "0.3.2"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "windows-core 0.62.2",
 ]
@@ -7692,7 +7689,7 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 [[package]]
 name = "windows-link"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "windows-numerics"
@@ -7736,7 +7733,7 @@ dependencies = [
 [[package]]
 name = "windows-result"
 version = "0.4.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -7753,7 +7750,7 @@ dependencies = [
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "windows-link 0.2.1",
 ]
@@ -8316,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.39"
-source = "git+https://github.com/makepad/makepad?branch=dev#6cf59e1509bcb8adb21151e79aafea09b036f4b4"
+source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 
 [[package]]
 name = "zerocopy-derive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,6 +3178,7 @@ dependencies = [
  "makepad-zune-qoi",
  "rustybuzz",
  "sdfer",
+ "serde",
  "unicode-bidi 0.3.18 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
  "unicode-linebreak",
  "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
@@ -3258,6 +3259,7 @@ version = "1.0.0"
 source = "git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness#7070e40dfe6bcc5662367184e5f670afde03bd84"
 dependencies = [
  "makepad-live-id-macros",
+ "serde",
 ]
 
 [[package]]
@@ -3471,6 +3473,7 @@ dependencies = [
  "makepad-html",
  "makepad-latex-math",
  "pulldown-cmark 0.12.2",
+ "serde",
  "ttf-parser",
  "unicode-segmentation 1.12.0 (git+https://github.com/kevinaboos/makepad?branch=windows_backend_robustness)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ version = "1.0.0-alpha.2"
 metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 
 [dependencies]
-makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
-makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+# makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
+# makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
+
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "windows_backend_robustness" }
+makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "windows_backend_robustness" }
 
 
 robius-directories = { git = "https://github.com/project-robius/robius" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ metadata.makepad-auto-version = "zqpv-Yj-K7WNVK2I8h5Okhho46Q="
 # makepad-widgets = { git = "https://github.com/makepad/makepad", branch = "dev", features = ["serde"] }
 # makepad-code-editor = { git = "https://github.com/makepad/makepad", branch = "dev" }
 
-makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "windows_backend_robustness" }
+makepad-widgets = { git = "https://github.com/kevinaboos/makepad", branch = "windows_backend_robustness", features = ["serde"] }
 makepad-code-editor = { git = "https://github.com/kevinaboos/makepad", branch = "windows_backend_robustness" }
 
 

--- a/src/persistence/app_state.rs
+++ b/src/persistence/app_state.rs
@@ -14,7 +14,7 @@ const WINDOW_GEOM_STATE_FILE_NAME: &str = "window_geom_state.json";
 pub struct WindowGeomState {
     /// A tuple containing the window's width and height.
     pub inner_size: (f64, f64),
-    /// A tuple containing the window's x and y position.
+    /// A tuple containing the x and y position of the window's top-left corner.
     pub position: (f64, f64),
     /// Maximise fullscreen if true.
     pub is_fullscreen: bool,
@@ -53,7 +53,8 @@ pub fn save_window_state(window_ref: WindowRef, cx: &Cx) -> anyhow::Result<()> {
         })
         .unwrap_or(1.0);
     let inner_size = window_ref.get_inner_size(cx) * layout_to_native;
-    // Position is unaffected by the dpi override, so it's saved as-is.
+    // `get_position` returns physical screen pixels, the same units expected by `configure_window`,
+    // so we don't need to adjust anything w.r.t. the DPI scale factor.
     let position = window_ref.get_position(cx);
     let window_geom = WindowGeomState {
         inner_size: (inner_size.x, inner_size.y),

--- a/src/room/reply_preview.rs
+++ b/src/room/reply_preview.rs
@@ -26,7 +26,7 @@ script_mod! {
             fade_end: uniform(1.0)
             fade_enabled: uniform(0.0)
             pixel: fn() {
-                let c = self.image.sample_rt(self.pos * self.scale + self.shift)
+                let c = self.image.sample(self.pos * self.scale + self.shift)
                 let t = clamp((self.pos.y - self.fade_start) / max(self.fade_end - self.fade_start, 0.0001), 0.0, 1.0)
                 let f = 1.0 - t * t * (3.0 - 2.0 * t)
                 return c * mix(1.0, f, self.fade_enabled)


### PR DESCRIPTION
See our latest few makepad PRs that fixed various windows issues:
* makepad/makepad#1200
* makepad/makepad#1198
* makepad/makepad#1197
* makepad/makepad#1196

Now that we're on the latest upstream makepad `dev` version, there's no more `sample_rt`, so we use `sample` now for the shader that does the CachedView texture effect (for reply previews)

Fixes #1032
Fixes #1031
