### PR TITLE
Misc fixes related to a review of recent changes

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -210,8 +210,12 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
           ## Snapshot what we compared against, so the push job can detect an AUR
-          ## that moved while the run waited for environment approval.
-          cp aur/PKGBUILD work/PKGBUILD.baseline
+          ## that moved while the run waited for environment approval. All three
+          ## files get overwritten by the push, so a concurrent change to any of
+          ## them has to invalidate this run, not just a change to the PKGBUILD.
+          for f in PKGBUILD .SRCINFO LICENSE; do
+            if [[ -f "aur/$f" ]]; then cp "aur/$f" "work/${f#.}.baseline"; fi
+          done
           {
             echo "### AUR render"
             echo '```'
@@ -227,6 +231,8 @@ jobs:
           path: |
             work/PKGBUILD
             work/PKGBUILD.baseline
+            work/SRCINFO.baseline
+            work/LICENSE.baseline
             work/.SRCINFO
             work/LICENSE
           if-no-files-found: error
@@ -283,8 +289,13 @@ jobs:
 
           ## The AUR may have moved while this run sat waiting for approval; pushing
           ## a render made against the old state would silently revert that work.
-          cmp -s work/PKGBUILD.baseline aur/PKGBUILD \
-            || { echo "::error::the AUR changed since this run rendered. Re-run the workflow against fresh state."; exit 1; }
+          for f in PKGBUILD .SRCINFO LICENSE; do
+            if [[ -f "work/${f#.}.baseline" || -f "aur/$f" ]] \
+               && ! cmp -s "work/${f#.}.baseline" "aur/$f"; then
+              echo "::error::the AUR's $f changed since this run rendered. Re-run the workflow against fresh state."
+              exit 1
+            fi
+          done
           cp work/PKGBUILD work/.SRCINFO work/LICENSE aur/
           ## The AUR hook rejects subdirectories and any root file over 250 KiB.
           [[ -z "$(find aur -mindepth 1 -maxdepth 1 -type d ! -name .git)" ]] || { echo "::error::subdirectory in the AUR checkout"; exit 1; }

--- a/src/app.rs
+++ b/src/app.rs
@@ -276,8 +276,14 @@ impl MatchEvent for App {
                 Some(LogoutAction::ClearAppState { on_clear_appstate }) =>  {
                     // Clear user profile cache, invited_rooms timeline states
                     clear_all_app_state(cx);
+                    // A verification flow belongs to the account that started it,
+                    // so don't leave its modal up for whoever logs in next.
+                    self.ui.modal(cx, ids!(verification_modal)).close(cx);
                     // Reset all app state to its default.
                     self.app_state = Default::default();
+                    // Push those defaults out too, otherwise the globals and the
+                    // receipt atomic keep serving the previous account's values.
+                    self.app_state.app_prefs.broadcast_all(cx);
                     on_clear_appstate.notify_one();
                     continue;
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -274,15 +274,12 @@ impl MatchEvent for App {
                     continue;
                 }
                 Some(LogoutAction::ClearAppState { on_clear_appstate }) =>  {
-                    // Clear user profile cache, invited_rooms timeline states
+                    // Clear and reset all app state to its default.
                     clear_all_app_state(cx);
-                    // A verification flow belongs to the account that started it,
-                    // so don't leave its modal up for whoever logs in next.
                     self.ui.modal(cx, ids!(verification_modal)).close(cx);
-                    // Reset all app state to its default.
                     self.app_state = Default::default();
-                    // Push those defaults out too, otherwise the globals and the
-                    // receipt atomic keep serving the previous account's values.
+                    // We also need to broadcast those default values out,
+                    // such that all other widgets can be reset to their default state.
                     self.app_state.app_prefs.broadcast_all(cx);
                     on_clear_appstate.notify_one();
                     continue;

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -768,14 +768,14 @@ struct ReadReceiptState {
 impl ReadReceiptState {
     /// Starts the read receipt timer for a direct user interaction.
     ///
-    /// A pending timer gets restarted so the send lands after movement stops, but we
-    /// keep the original anchor so we can still tell if the user has since scrolled up.
+    /// If a timer was already running, it gets restarted because that means
+    /// the scrolling action has continued.
     fn start_timer(&mut self, cx: &mut Cx, portal_list: &PortalListRef) {
-        let already_pending = !self.timer.is_empty() && self.from_user_input;
+        let was_already_pending = !self.timer.is_empty() && self.from_user_input;
         cx.stop_timer(self.timer);
         self.timer = cx.start_timeout(READ_RECEIPT_SEND_DELAY);
         self.from_user_input = true;
-        if !already_pending {
+        if !was_already_pending {
             self.user_scroll_travel_at_timer_start = portal_list.user_scroll_travel();
         }
     }
@@ -893,27 +893,6 @@ pub struct RoomScreen {
     #[rust] pending_read_receipt_jump: Option<OwnedUserId>,
     /// Fires when a background search for a jumped-to event has gone quiet.
     #[rust] jump_search_timer: Timer,
-}
-
-/// Subscribes to (or unsubscribes from) the room-level updates that only matter
-/// while a main room's timeline is shown. Threads have no per-thread equivalent.
-fn set_room_subscriptions(timeline_kind: &TimelineKind, subscribe: bool) {
-    if !matches!(timeline_kind, TimelineKind::MainRoom { .. }) {
-        return;
-    }
-    let room_id = timeline_kind.room_id();
-    submit_async_request(MatrixRequest::SubscribeToOwnUserReadReceiptsChanged {
-        room_id: room_id.clone(),
-        subscribe,
-    });
-    submit_async_request(MatrixRequest::SubscribeToTypingNotices {
-        room_id: room_id.clone(),
-        subscribe,
-    });
-    submit_async_request(MatrixRequest::SubscribeToPinnedEvents {
-        room_id: room_id.clone(),
-        subscribe,
-    });
 }
 
 /// Cached references to RoomScreen child widgets used in every event handler.
@@ -2035,15 +2014,15 @@ impl RoomScreen {
                 }
                 TimelineUpdate::RoomMembersSynced => {
                     // log!("process_timeline_updates(): room members fetched for room {}", tl.kind.room_id());
-                    // Here, to be most efficient, we could redraw only the user avatars and names in the timeline,
-                    // but for now we just fall through and let the final `redraw()` call re-draw the whole timeline view.
-                    // `show_timeline()` read the local member cache before this sync landed, so it
-                    // only got whatever lazy-loading had delivered. Re-read it now that it's complete.
+                    // Now that the full room members list has been synced in the background,
+                    // we need to actually get the new list for use in this room screen.
                     submit_async_request(MatrixRequest::GetRoomMembers {
                         timeline_kind: tl.kind.clone(),
                         memberships: matrix_sdk::RoomMemberships::JOIN,
                         local_only: true,
                     });
+                    // Here, to be most efficient, we could redraw only the user avatars and names in the timeline,
+                    // but for now we just fall through and let the final `redraw()` call re-draw the whole timeline view.
                 }
                 TimelineUpdate::RoomMembersListFetched { members } => {
                     // Store room members directly in TimelineUiState
@@ -3032,7 +3011,7 @@ impl RoomScreen {
             // Only main room timelines can subscribe to typing notices, pinned events,
             // and read receipt changes (the SDK has no per-thread unread counts).
             if matches!(tl_state.kind, TimelineKind::MainRoom { .. }) {
-                set_room_subscriptions(&tl_state.kind, true);
+                subscribe_to_room_updates(&tl_state.kind, true);
                 // The matrix spec says that opening a room should clear the marked-as-unread flag.
                 if cx.global::<AppPreferencesGlobal>().0.mark_as_read_behavior != MarkAsReadBehavior::Manual {
                     submit_async_request(MatrixRequest::SetUnreadFlag {
@@ -3067,13 +3046,11 @@ impl RoomScreen {
         self.redraw(cx);
     }
 
-    /// Sets this timeline's endpoints to the latest one created by the backend task, if it has new ones.
+    /// Sets this timeline's endpoints to the latest ones created by the backend task,
+    /// if there are any new ones.
     ///
     /// `take_timeline_endpoints()` only returns `Some` when a fresh unclaimed channel exists,
     /// so it's safe to call this repeatedly as a check.
-    ///
-    /// Pass `resubscribe: false` from `show_timeline()`, which has already subscribed;
-    /// anywhere else it must be `true`, since a rebuilt room dropped the old subscriptions.
     fn reconnect_timeline_endpoints(&mut self, cx: &mut Cx, resubscribe: bool) {
         let Some(tl) = self.tl_state.as_mut() else { return };
         // An invalidated state means we destructed the timeline on purpose
@@ -3129,10 +3106,11 @@ impl RoomScreen {
         tl.request_sender.send_if_modified(|req| !std::mem::replace(&mut req.is_timeline_open, true));
         let reconnected_sender = tl.request_sender.clone();
         let timeline_kind = tl.kind.clone();
-        // The rebuilt room dropped the old subscriber tasks, and the surviving ones
-        // still hold the discarded sender, so they have to be re-issued here.
+        // Re-subscribe to things needed for this main room timeline to be properly updated
+        // while it's open. The previously-created async tasks for these things are either dead
+        // or still running but with the old channel endpoints, so they're useless either way.
         if resubscribe {
-            set_room_subscriptions(&timeline_kind, true);
+            subscribe_to_room_updates(&timeline_kind, true);
         }
         let loading_pane = self.loading_pane(cx, ids!(loading_pane));
         // Also update the loading pane's timeline request sender.
@@ -3178,7 +3156,7 @@ impl RoomScreen {
         //   when a given room isn't visible.
         // * Unsubscribe from updates to this room's pinned events, for the same reason.
         // * Unsubscribe from updates to our own user's read receipts, for the same reason.
-        set_room_subscriptions(&timeline_kind, false);
+        subscribe_to_room_updates(&timeline_kind, false);
     }
 
     /// Removes the current room's visual UI state from this widget
@@ -3468,6 +3446,30 @@ impl RoomScreenRef {
         let Some(mut inner) = self.borrow_mut() else { return };
         inner.hide_displayed_room(cx);
     }
+}
+
+
+/// Subscribes to or unsubscribes from room-level updates that are needed
+/// while a main room's timeline is open and being shown.
+///
+/// Does nothing for thread-specific timelines.
+fn subscribe_to_room_updates(timeline_kind: &TimelineKind, subscribe: bool) {
+    if !matches!(timeline_kind, TimelineKind::MainRoom { .. }) {
+        return;
+    }
+    let room_id = timeline_kind.room_id();
+    submit_async_request(MatrixRequest::SubscribeToOwnUserReadReceiptsChanged {
+        room_id: room_id.clone(),
+        subscribe,
+    });
+    submit_async_request(MatrixRequest::SubscribeToTypingNotices {
+        room_id: room_id.clone(),
+        subscribe,
+    });
+    submit_async_request(MatrixRequest::SubscribeToPinnedEvents {
+        room_id: room_id.clone(),
+        subscribe,
+    });
 }
 
 

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -767,14 +767,17 @@ struct ReadReceiptState {
 
 impl ReadReceiptState {
     /// Starts the read receipt timer for a direct user interaction.
+    ///
+    /// A pending timer gets restarted so the send lands after movement stops, but we
+    /// keep the original anchor so we can still tell if the user has since scrolled up.
     fn start_timer(&mut self, cx: &mut Cx, portal_list: &PortalListRef) {
-        if !self.timer.is_empty() && self.from_user_input {
-            return;
-        }
+        let already_pending = !self.timer.is_empty() && self.from_user_input;
         cx.stop_timer(self.timer);
         self.timer = cx.start_timeout(READ_RECEIPT_SEND_DELAY);
         self.from_user_input = true;
-        self.user_scroll_travel_at_timer_start = portal_list.user_scroll_travel();
+        if !already_pending {
+            self.user_scroll_travel_at_timer_start = portal_list.user_scroll_travel();
+        }
     }
 
     /// Cancels any pending read receipt send.
@@ -890,6 +893,27 @@ pub struct RoomScreen {
     #[rust] pending_read_receipt_jump: Option<OwnedUserId>,
     /// Fires when a background search for a jumped-to event has gone quiet.
     #[rust] jump_search_timer: Timer,
+}
+
+/// Subscribes to (or unsubscribes from) the room-level updates that only matter
+/// while a main room's timeline is shown. Threads have no per-thread equivalent.
+fn set_room_subscriptions(timeline_kind: &TimelineKind, subscribe: bool) {
+    if !matches!(timeline_kind, TimelineKind::MainRoom { .. }) {
+        return;
+    }
+    let room_id = timeline_kind.room_id();
+    submit_async_request(MatrixRequest::SubscribeToOwnUserReadReceiptsChanged {
+        room_id: room_id.clone(),
+        subscribe,
+    });
+    submit_async_request(MatrixRequest::SubscribeToTypingNotices {
+        room_id: room_id.clone(),
+        subscribe,
+    });
+    submit_async_request(MatrixRequest::SubscribeToPinnedEvents {
+        room_id: room_id.clone(),
+        subscribe,
+    });
 }
 
 /// Cached references to RoomScreen child widgets used in every event handler.
@@ -1123,7 +1147,7 @@ impl Widget for RoomScreen {
                 if let Some(TimelineEndpointsRecreated { room_id }) = action.downcast_ref()
                     && self.timeline_kind.as_ref().is_some_and(|k| k.room_id() == room_id)
                 {
-                    self.reconnect_timeline_endpoints(cx);
+                    self.reconnect_timeline_endpoints(cx, true);
                     continue;
                 }
 
@@ -3001,18 +3025,7 @@ impl RoomScreen {
             // Only main room timelines can subscribe to typing notices, pinned events,
             // and read receipt changes (the SDK has no per-thread unread counts).
             if matches!(tl_state.kind, TimelineKind::MainRoom { .. }) {
-                submit_async_request(MatrixRequest::SubscribeToOwnUserReadReceiptsChanged {
-                    room_id: room_id.clone(),
-                    subscribe: true,
-                });
-                submit_async_request(MatrixRequest::SubscribeToTypingNotices {
-                    room_id: room_id.clone(),
-                    subscribe: true,
-                });
-                submit_async_request(MatrixRequest::SubscribeToPinnedEvents {
-                    room_id: room_id.clone(),
-                    subscribe: true,
-                });
+                set_room_subscriptions(&tl_state.kind, true);
                 // The matrix spec says that opening a room should clear the marked-as-unread flag.
                 if cx.global::<AppPreferencesGlobal>().0.mark_as_read_behavior != MarkAsReadBehavior::Manual {
                     submit_async_request(MatrixRequest::SetUnreadFlag {
@@ -3041,7 +3054,7 @@ impl RoomScreen {
         // Now that we have restored the TimelineUiState into this RoomScreen widget,
         // we can proceed to processing pending background updates.
         // We first need to check that we have the latest endpoints, to get the latest updates.
-        self.reconnect_timeline_endpoints(cx);
+        self.reconnect_timeline_endpoints(cx, false);
         self.process_timeline_updates(cx, &list);
 
         self.redraw(cx);
@@ -3051,7 +3064,10 @@ impl RoomScreen {
     ///
     /// `take_timeline_endpoints()` only returns `Some` when a fresh unclaimed channel exists,
     /// so it's safe to call this repeatedly as a check.
-    fn reconnect_timeline_endpoints(&mut self, cx: &mut Cx) {
+    ///
+    /// Pass `resubscribe: false` from `show_timeline()`, which has already subscribed;
+    /// anywhere else it must be `true`, since a rebuilt room dropped the old subscriptions.
+    fn reconnect_timeline_endpoints(&mut self, cx: &mut Cx, resubscribe: bool) {
         let Some(tl) = self.tl_state.as_mut() else { return };
         // An invalidated state means we destructed the timeline on purpose
         // (e.g., for a left/banned room or a closed thread),
@@ -3106,6 +3122,11 @@ impl RoomScreen {
         tl.request_sender.send_if_modified(|req| !std::mem::replace(&mut req.is_timeline_open, true));
         let reconnected_sender = tl.request_sender.clone();
         let timeline_kind = tl.kind.clone();
+        // The rebuilt room dropped the old subscriber tasks, and the surviving ones
+        // still hold the discarded sender, so they have to be re-issued here.
+        if resubscribe {
+            set_room_subscriptions(&timeline_kind, true);
+        }
         let loading_pane = self.loading_pane(cx, ids!(loading_pane));
         // Also update the loading pane's timeline request sender.
         loading_pane.set_timeline_request_sender(reconnected_sender);
@@ -3150,20 +3171,7 @@ impl RoomScreen {
         //   when a given room isn't visible.
         // * Unsubscribe from updates to this room's pinned events, for the same reason.
         // * Unsubscribe from updates to our own user's read receipts, for the same reason.
-        if matches!(timeline_kind, TimelineKind::MainRoom { .. }) {
-            submit_async_request(MatrixRequest::SubscribeToTypingNotices {
-                room_id: timeline_kind.room_id().clone(),
-                subscribe: false,
-            });
-            submit_async_request(MatrixRequest::SubscribeToPinnedEvents {
-                room_id: timeline_kind.room_id().clone(),
-                subscribe: false,
-            });
-            submit_async_request(MatrixRequest::SubscribeToOwnUserReadReceiptsChanged {
-                room_id: timeline_kind.room_id().clone(),
-                subscribe: false,
-            });
-        }
+        set_room_subscriptions(&timeline_kind, false);
     }
 
     /// Removes the current room's visual UI state from this widget

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2037,6 +2037,13 @@ impl RoomScreen {
                     // log!("process_timeline_updates(): room members fetched for room {}", tl.kind.room_id());
                     // Here, to be most efficient, we could redraw only the user avatars and names in the timeline,
                     // but for now we just fall through and let the final `redraw()` call re-draw the whole timeline view.
+                    // `show_timeline()` read the local member cache before this sync landed, so it
+                    // only got whatever lazy-loading had delivered. Re-read it now that it's complete.
+                    submit_async_request(MatrixRequest::GetRoomMembers {
+                        timeline_kind: tl.kind.clone(),
+                        memberships: matrix_sdk::RoomMemberships::JOIN,
+                        local_only: true,
+                    });
                 }
                 TimelineUpdate::RoomMembersListFetched { members } => {
                     // Store room members directly in TimelineUiState

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -577,8 +577,12 @@ impl RoomsList {
             return;
         }
 
+        // With a sort function active the list isn't in `all_known_rooms_order` at all,
+        // so we have no slot to compute; append and let the next regeneration place it.
         let order = &self.all_known_rooms_order;
-        let rank = order.iter().position(|r| r == &room_id);
+        let rank = self.sort_fn.is_none()
+            .then(|| order.iter().position(|r| r == &room_id))
+            .flatten();
 
         let (displayed_rooms, unread_mentions, unread_messages) = if is_direct {
             (

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -577,6 +577,9 @@ impl RoomsList {
             return;
         }
 
+        let order = &self.all_known_rooms_order;
+        let rank = order.iter().position(|r| r == &room_id);
+
         let (displayed_rooms, unread_mentions, unread_messages) = if is_direct {
             (
                 &mut self.displayed_direct_rooms,
@@ -590,7 +593,16 @@ impl RoomsList {
                 &mut self.displayed_regular_rooms_unread_messages,
             )
         };
-        displayed_rooms.push(room_id);
+        // Displayed rooms follow `all_known_rooms_order`, so count the shown rooms ahead
+        // of this one to find its slot. Appending would misplace a newly-matching room.
+        let index = match rank {
+            Some(rank) => order.iter()
+                .take(rank)
+                .filter(|id| displayed_rooms.contains(id))
+                .count(),
+            None => displayed_rooms.len(),
+        };
+        displayed_rooms.insert(index, room_id);
         *unread_mentions = unread_mentions.saturating_add(num_unread_mentions);
         *unread_messages = unread_messages.saturating_add(num_unread_messages);
     }
@@ -762,6 +774,7 @@ impl RoomsList {
                             warning!("Warning: couldn't find room {room_id} to update its aliases.");
                         }
                     }
+                    self.update_status();
                 }
                 RoomsListUpdate::UpdateRoomAvatar { room_id, room_avatar } => {
                     if let Some(room) = self.all_joined_rooms.get_mut(&room_id) {
@@ -872,6 +885,7 @@ impl RoomsList {
                             warning!("Warning: couldn't find room {new_room_name} to update its name.");
                         }
                     }
+                    self.update_status();
                 }
                 RoomsListUpdate::UpdateIsDirect { room_id, is_direct } => {
                     if let Some(room) = self.all_joined_rooms.get_mut(&room_id) {

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -577,8 +577,8 @@ impl RoomsList {
             return;
         }
 
-        // With a sort function active the list isn't in `all_known_rooms_order` at all,
-        // so we have no slot to compute; append and let the next regeneration place it.
+        // If the sort fn is active, the list's order is different, so we just append it
+        // and let the next regenerate call fix it and put it in the right spot.
         let order = &self.all_known_rooms_order;
         let rank = self.sort_fn.is_none()
             .then(|| order.iter().position(|r| r == &room_id))
@@ -597,8 +597,7 @@ impl RoomsList {
                 &mut self.displayed_regular_rooms_unread_messages,
             )
         };
-        // Displayed rooms follow `all_known_rooms_order`, so count the shown rooms ahead
-        // of this one to find its slot. Appending would misplace a newly-matching room.
+        // Find the right place to insert this new room in the already-ordered list.
         let index = match rank {
             Some(rank) => order.iter()
                 .take(rank)

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -571,10 +571,14 @@ impl SpacesBar {
                     let space_id = joined_space.space_name_id.room_id().clone();
                     let should_display = (self.display_filter)(&joined_space);
                     let replaced = self.all_joined_spaces.insert(space_id.clone(), joined_space);
-                    if replaced.is_none() {
-                        adjust_displayed_spaces(false, should_display, space_id, &mut self.displayed_spaces);
+                    if let Some(old) = replaced.as_ref() {
+                        warning!("Note: re-added joined space {space_id} that already existed.");
+                        // The re-added space carries fresh data, so whether it should show can
+                        // differ from before. Treat it as an update instead of dropping it.
+                        let was_displayed = (self.display_filter)(old);
+                        adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
                     } else {
-                        error!("BUG: Added joined space {space_id} that already existed");
+                        adjust_displayed_spaces(false, should_display, space_id, &mut self.displayed_spaces);
                     }
                 }
 

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -571,15 +571,10 @@ impl SpacesBar {
                     let space_id = joined_space.space_name_id.room_id().clone();
                     let should_display = (self.display_filter)(&joined_space);
                     let replaced = self.all_joined_spaces.insert(space_id.clone(), joined_space);
-                    if let Some(old) = replaced.as_ref() {
-                        warning!("Note: re-added joined space {space_id} that already existed.");
-                        // The re-added space carries fresh data, so whether it should show can
-                        // differ from before. Treat it as an update instead of dropping it.
-                        let was_displayed = (self.display_filter)(old);
-                        adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
-                    } else {
-                        adjust_displayed_spaces(false, should_display, space_id, &mut self.displayed_spaces);
-                    }
+                    // if we got a new space that has the same ID as one that already existed,
+                    // that just means its data was updated and we need to re-evaluate whether to display it.
+                    let was_displayed = replaced.is_some_and(|old| { (self.display_filter)(&old) });
+                    adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
                 }
 
                 SpacesListUpdate::UpdateCanonicalAlias { space_id, new_canonical_alias } => {

--- a/src/profile/user_profile_cache.rs
+++ b/src/profile/user_profile_cache.rs
@@ -33,8 +33,10 @@ pub enum RoomMemberEntry {
     Requested,
     /// The room member info has been successfully loaded from the server.
     Loaded(RoomMember),
-    /// The request completed without member info, e.g. the user isn't in that room.
-    /// Terminal, so we stop re-requesting until the next offline/online transition.
+    /// The request completed but didn't return any member info.
+    /// This means that the user isn't in that room, or the lookup failed.
+    ///
+    /// This won't be retried until the next transition from offline --> online.
     Failed,
 }
 impl RoomMemberEntry {
@@ -89,8 +91,7 @@ pub enum UserProfileUpdate {
     },
     /// An update to the user's profile only, without changes to room membership info.
     UserProfileOnly(UserProfile),
-    /// A room-specific lookup completed without member info, so the pending
-    /// entry for that room can be marked terminal instead of blocking forever.
+    /// A room-specific user profile request failed, meaning the user isn't in that room.
     RoomMemberFailed {
         user_id: OwnedUserId,
         room_id: OwnedRoomId,
@@ -205,7 +206,7 @@ impl UserProfileUpdate {
             }
             UserProfileUpdate::RoomMemberFailed { user_id, room_id } => {
                 if let Some(UserProfileCacheEntry::Loaded { rooms, .. }) = cache.get_mut(&user_id) {
-                    // Never clobber member info that loaded in the meantime.
+                    // Don't overwrite actual member profile data that does exist.
                     let member = rooms.entry(room_id).or_insert(RoomMemberEntry::Failed);
                     if matches!(member, RoomMemberEntry::Requested) {
                         *member = RoomMemberEntry::Failed;

--- a/src/profile/user_profile_cache.rs
+++ b/src/profile/user_profile_cache.rs
@@ -360,3 +360,77 @@ pub fn clear_user_profile_cache(_cx: &mut Cx) {
         cache.clear();
     });
 }
+
+
+#[cfg(test)]
+mod tests_room_member_entry {
+    use super::*;
+    use matrix_sdk::ruma::{room_id, user_id};
+
+    fn loaded_entry(rooms: BTreeMap<OwnedRoomId, RoomMemberEntry>) -> UserProfileCacheEntry {
+        UserProfileCacheEntry::Loaded {
+            user_profile: UserProfile {
+                user_id: user_id!("@alice:matrix.org").to_owned(),
+                username: Some("Alice".into()),
+                avatar_state: AvatarState::Unknown,
+            },
+            rooms,
+        }
+    }
+
+    fn apply_failed(cache: &mut BTreeMap<OwnedUserId, UserProfileCacheEntry>) {
+        UserProfileUpdate::RoomMemberFailed {
+            user_id: user_id!("@alice:matrix.org").to_owned(),
+            room_id: room_id!("!room:matrix.org").to_owned(),
+        }.apply_to_cache(cache);
+    }
+
+    fn room_entry(cache: &BTreeMap<OwnedUserId, UserProfileCacheEntry>) -> Option<&RoomMemberEntry> {
+        match cache.get(user_id!("@alice:matrix.org"))? {
+            UserProfileCacheEntry::Loaded { rooms, .. } => rooms.get(room_id!("!room:matrix.org")),
+            UserProfileCacheEntry::Requested => None,
+        }
+    }
+
+    #[test]
+    fn pending_room_entry_becomes_failed() {
+        let mut rooms = BTreeMap::new();
+        rooms.insert(room_id!("!room:matrix.org").to_owned(), RoomMemberEntry::Requested);
+        let mut cache = BTreeMap::new();
+        cache.insert(user_id!("@alice:matrix.org").to_owned(), loaded_entry(rooms));
+
+        apply_failed(&mut cache);
+        assert!(matches!(room_entry(&cache), Some(RoomMemberEntry::Failed)));
+    }
+
+    #[test]
+    fn missing_room_entry_is_inserted_as_failed() {
+        let mut cache = BTreeMap::new();
+        cache.insert(user_id!("@alice:matrix.org").to_owned(), loaded_entry(BTreeMap::new()));
+
+        apply_failed(&mut cache);
+        assert!(matches!(room_entry(&cache), Some(RoomMemberEntry::Failed)));
+    }
+
+    #[test]
+    fn failure_for_an_uncached_user_is_ignored() {
+        let mut cache = BTreeMap::new();
+        apply_failed(&mut cache);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn a_still_pending_account_wide_entry_is_left_alone() {
+        let mut cache = BTreeMap::new();
+        cache.insert(user_id!("@alice:matrix.org").to_owned(), UserProfileCacheEntry::Requested);
+
+        apply_failed(&mut cache);
+        assert!(matches!(cache.get(user_id!("@alice:matrix.org")), Some(UserProfileCacheEntry::Requested)));
+    }
+
+    #[test]
+    fn failed_is_not_a_loaded_member() {
+        assert!(RoomMemberEntry::Failed.loaded().is_none());
+        assert!(RoomMemberEntry::Requested.loaded().is_none());
+    }
+}

--- a/src/profile/user_profile_cache.rs
+++ b/src/profile/user_profile_cache.rs
@@ -33,13 +33,16 @@ pub enum RoomMemberEntry {
     Requested,
     /// The room member info has been successfully loaded from the server.
     Loaded(RoomMember),
+    /// The request completed without member info, e.g. the user isn't in that room.
+    /// Terminal, so we stop re-requesting until the next offline/online transition.
+    Failed,
 }
 impl RoomMemberEntry {
     /// Returns the loaded room member info, if any.
     pub fn loaded(&self) -> Option<&RoomMember> {
         match self {
             RoomMemberEntry::Loaded(member) => Some(member),
-            RoomMemberEntry::Requested => None,
+            RoomMemberEntry::Requested | RoomMemberEntry::Failed => None,
         }
     }
 }
@@ -86,6 +89,12 @@ pub enum UserProfileUpdate {
     },
     /// An update to the user's profile only, without changes to room membership info.
     UserProfileOnly(UserProfile),
+    /// A room-specific lookup completed without member info, so the pending
+    /// entry for that room can be marked terminal instead of blocking forever.
+    RoomMemberFailed {
+        user_id: OwnedUserId,
+        room_id: OwnedRoomId,
+    },
 }
 impl UserProfileUpdate {
     /// Returns the user ID associated with this update.
@@ -95,6 +104,7 @@ impl UserProfileUpdate {
             UserProfileUpdate::Full { new_profile, .. } => &new_profile.user_id,
             UserProfileUpdate::RoomMemberOnly { room_member, .. } => room_member.user_id(),
             UserProfileUpdate::UserProfileOnly(profile) => &profile.user_id,
+            UserProfileUpdate::RoomMemberFailed { user_id, .. } => user_id,
         }
     }
 
@@ -190,6 +200,15 @@ impl UserProfileUpdate {
                             user_profile: new_profile,
                             rooms: BTreeMap::new(),
                         });
+                    }
+                }
+            }
+            UserProfileUpdate::RoomMemberFailed { user_id, room_id } => {
+                if let Some(UserProfileCacheEntry::Loaded { rooms, .. }) = cache.get_mut(&user_id) {
+                    // Never clobber member info that loaded in the meantime.
+                    let member = rooms.entry(room_id).or_insert(RoomMemberEntry::Failed);
+                    if matches!(member, RoomMemberEntry::Requested) {
+                        *member = RoomMemberEntry::Failed;
                     }
                 }
             }

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -433,8 +433,6 @@ impl MatchEvent for AccountSettings {
                 self.own_device = None;
                 self.verification_state = VerificationState::Unknown;
                 self.account_management_url = AccountManagementUrl::Unknown;
-                // An operation still in flight for the old account would otherwise
-                // leave its spinner up and its input locked for the next one.
                 self.view.widget(cx, ids!(upload_avatar_spinner)).set_visible(cx, false);
                 self.view.widget(cx, ids!(delete_avatar_spinner)).set_visible(cx, false);
                 self.view.widget(cx, ids!(save_name_spinner)).set_visible(cx, false);

--- a/src/settings/account_settings.rs
+++ b/src/settings/account_settings.rs
@@ -433,6 +433,13 @@ impl MatchEvent for AccountSettings {
                 self.own_device = None;
                 self.verification_state = VerificationState::Unknown;
                 self.account_management_url = AccountManagementUrl::Unknown;
+                // An operation still in flight for the old account would otherwise
+                // leave its spinner up and its input locked for the next one.
+                self.view.widget(cx, ids!(upload_avatar_spinner)).set_visible(cx, false);
+                self.view.widget(cx, ids!(delete_avatar_spinner)).set_visible(cx, false);
+                self.view.widget(cx, ids!(save_name_spinner)).set_visible(cx, false);
+                display_name_input.set_is_read_only(cx, false);
+                display_name_input.set_disabled(cx, false);
                 self.update_verification_banner(cx);
                 continue;
             }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -914,18 +914,22 @@ async fn matrix_worker_task(
                                 if direction == PaginationDirection::Forwards { "end" } else { "start" },
                                 if fully_paginated { "yes" } else { "no" },
                             );
-                            sender.send(TimelineUpdate::PaginationIdle {
+                            if sender.send(TimelineUpdate::PaginationIdle {
                                 fully_paginated,
                                 direction,
-                            }).unwrap();
+                            }).is_err() {
+                                error!("Failed to send pagination result to UI for {timeline_kind}");
+                            }
                             SignalToUI::set_ui_signal();
                         }
                         Err(error) => {
                             error!("Error sending {direction} pagination request for {timeline_kind}: {error:?}");
-                            sender.send(TimelineUpdate::PaginationError {
+                            if sender.send(TimelineUpdate::PaginationError {
                                 error,
                                 direction,
-                            }).unwrap();
+                            }).is_err() {
+                                error!("Failed to send pagination error to UI for {timeline_kind}");
+                            }
                             SignalToUI::set_ui_signal();
                         }
                     }
@@ -946,10 +950,12 @@ async fn matrix_worker_task(
                         Ok(_) => log!("Successfully edited message {timeline_event_item_id:?} in {timeline_kind}."),
                         Err(ref e) => error!("Error editing message {timeline_event_item_id:?} in {timeline_kind}: {e:?}"),
                     }
-                    sender.send(TimelineUpdate::MessageEdited {
+                    if sender.send(TimelineUpdate::MessageEdited {
                         timeline_event_item_id,
                         result,
-                    }).unwrap();
+                    }).is_err() {
+                        error!("Failed to send edit result to UI for {timeline_kind}");
+                    }
                     SignalToUI::set_ui_signal();
                 });
             }
@@ -1435,11 +1441,24 @@ async fn matrix_worker_task(
                         }
                     }
 
+                    // A room lookup that came back without member info still needs a terminal
+                    // state, otherwise its entry sits at `Requested` and blocks every retry.
+                    let room_member_missing = room_id.clone()
+                        .filter(|_| !local_only)
+                        .filter(|_| !matches!(update, Some(UserProfileUpdate::Full { .. })));
+
                     if let Some(upd) = update {
                         // log!("Successfully completed get user profile request: user: {user_id}, room: {room_id:?}, local_only: {local_only}.");
                         enqueue_user_profile_update(upd);
                     } else {
                         log!("Failed to get user profile: user: {user_id}, room: {room_id:?}, local_only: {local_only}.");
+                    }
+
+                    if let Some(room_id) = room_member_missing {
+                        enqueue_user_profile_update(UserProfileUpdate::RoomMemberFailed {
+                            user_id,
+                            room_id,
+                        });
                     }
                 });
             }
@@ -2022,7 +2041,9 @@ async fn matrix_worker_task(
                         }
                     }
                 });
-                subscribers_pinned_events.insert(room_id, subscribe_pinned_events_task);
+                if let Some(old) = subscribers_pinned_events.insert(room_id, subscribe_pinned_events_task) {
+                    old.abort();
+                }
             }
 
             MatrixRequest::SpawnSSOServer { brand, homeserver_url, identity_provider_id} => {

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -1441,9 +1441,9 @@ async fn matrix_worker_task(
                         }
                     }
 
-                    // A room lookup that came back without member info still needs a terminal
-                    // state, otherwise its entry sits at `Requested` and blocks every retry.
-                    let room_member_missing = room_id.clone()
+                    // Even if we didn't get room-specific member info, we still need to send an error update
+                    // to ensure that the cache entry transitions from Requested to Failed.
+                    let missing_member_room_id = room_id.clone()
                         .filter(|_| !local_only)
                         .filter(|_| !matches!(update, Some(UserProfileUpdate::Full { .. })));
 
@@ -1454,7 +1454,7 @@ async fn matrix_worker_task(
                         log!("Failed to get user profile: user: {user_id}, room: {room_id:?}, local_only: {local_only}.");
                     }
 
-                    if let Some(room_id) = room_member_missing {
+                    if let Some(room_id) = missing_member_room_id {
                         enqueue_user_profile_update(UserProfileUpdate::RoomMemberFailed {
                             user_id,
                             room_id,


### PR DESCRIPTION
* on logout, we didn't re-broadcast the default preferences, so things like read receipt timers kept the old account's value
* `reconnect_timeline_endpoints()` didn't properly re-setup room subscriptions after a timeline got recreated.
* find more unwraps and handle them as errors in the sliding_sync backedn
* Properly fix the read receipt timer to only fire after ALL Scrolling motion has ended, not throughout it (e.g., during a long fast flick via touch or trackpad)
* `add_displayed_joined_room` just blindly appended the room instead of using the proper ordering (not really a problem since we don't actually use the sort fn, but still, we might one day)
* some minor fixes to the arch AUR build/PKGBUILD, but still not tested cuz AUR registration is closed