### PR TITLE
RoomInputBar: restore the send button (and other) state after script reapply

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,10 +247,12 @@ jobs:
           set -euo pipefail
           TAG="${{ steps.resolve.outputs.tag }}"
           version="${TAG#v}"
-          pkgver="$(packaging/aur/render-pkgbuild.sh --print-pkgver --tag "$TAG")"
           notes="docs/RELEASE_NOTES_${TAG}.md"
           body="${RUNNER_TEMP}/release-body.md"
           if [[ -f "$notes" ]]; then
+            ## Only needed to substitute into the notes, and it hard-fails on a non-`v` tag,
+            ## so don't compute it when there are no notes to render.
+            pkgver="$(packaging/aur/render-pkgbuild.sh --print-pkgver --tag "$TAG")"
             sed -e "s|@VERSION@|${version}|g" -e "s|@PKGVER@|${pkgver}|g" "$notes" > "$body"
             echo "Rendered $notes ($(wc -l < "$body") lines)"
           else

--- a/packaging/arch/PKGBUILD.in
+++ b/packaging/arch/PKGBUILD.in
@@ -30,12 +30,13 @@ depends=(
   'alsa-lib'
   'libpulse'
   'openssl'
-  ## These four are dlopen'd, spawned, or read off disk rather than linked, so no
+  ## These five are dlopen'd, spawned, or read off disk rather than linked, so no
   ## tooling finds them and namcap calls them unneeded. Don't drop them.
   'libglvnd'         ## libEGL.so.1, loaded by Makepad at startup
   'dbus'             ## libdbus-1.so.3, loaded by the file picker
   'xdg-utils'        ## xdg-open, spawned to open links and attachments
   'ca-certificates'  ## /etc/ssl/certs, read at runtime by both TLS stacks
+  'geoclue'          ## org.freedesktop.GeoClue2, used for sharing your location
   'hicolor-icon-theme'
 )
 ## With neither of these the attach and save-as dialogs never open.

--- a/src/app.rs
+++ b/src/app.rs
@@ -363,6 +363,7 @@ impl MatchEvent for App {
                 if let Some(selected_room) = self.app_state.selected_room.as_mut() {
                     selected_room.update_room_name(new_room_name);
                 }
+                self.app_state.selected_tab.update_space_name(new_room_name);
                 for saved in std::iter::once(&mut self.app_state.saved_dock_state_home)
                     .chain(self.app_state.saved_dock_state_per_space.values_mut())
                 {

--- a/src/event_preview.rs
+++ b/src/event_preview.rs
@@ -611,7 +611,7 @@ pub fn text_preview_of_room_membership_change(
         ),
         StateEventContentChange::Redacted(content) => (&content.membership, None, None),
     };
-    let end = match reason.map(|r| r.trim_end_matches('.')) {
+    let end = match reason.map(|r| r.trim().trim_end_matches('.')).filter(|r| !r.is_empty()) {
         Some(r) if format_as_html => format!(": {}.", htmlize::escape_text(r)),
         Some(r) => format!(": {r}."),
         None => String::from("."),

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -643,6 +643,9 @@ impl Widget for HomeScreen {
                     for room in &mut self.mobile_screen_history {
                         room.update_room_name(new_room_name);
                     }
+                    // Restored when the user closes Settings, so it'd otherwise put
+                    // the pre-rename name back into the rooms list header.
+                    self.previous_selection.update_space_name(new_room_name);
                     let stack_navigation = self.view.stack_navigation(cx, ids!(view_stack));
                     if let Some(view_id) = stack_navigation.destination_view()
                         && let Some(room) = app_state.selected_room.as_ref()

--- a/src/home/navigation_tab_bar.rs
+++ b/src/home/navigation_tab_bar.rs
@@ -602,6 +602,21 @@ pub enum SelectedTab {
     // AlertsInbox,
     Space { space_name_id: RoomNameId },
 }
+impl SelectedTab {
+    /// Updates this tab's cached space name if it refers to the same space.
+    ///
+    /// Returns `true` if the name was replaced.
+    pub fn update_space_name(&mut self, new_room_name: &RoomNameId) -> bool {
+        let SelectedTab::Space { space_name_id } = self else { return false };
+        if space_name_id.room_id() != new_room_name.room_id()
+            || space_name_id.display_name() == new_room_name.display_name()
+        {
+            return false;
+        }
+        *space_name_id = new_room_name.clone();
+        true
+    }
+}
 
 
 /// Actions for navigating through the top-level views of the app,

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -925,12 +925,16 @@ impl ScriptHook for RoomScreen {
                 tl_state.content_drawn_since_last_update.clear();
                 tl_state.profile_drawn_since_last_update.clear();
                 // The reapply also resets the RoomInputBar, so we need to re-update its state.
-                self.view.room_input_bar(cx, ids!(room_input_bar)).update_room_state(
+                let room_input_bar = self.view.room_input_bar(cx, ids!(room_input_bar));
+                room_input_bar.update_room_state(
                     cx,
                     tl_state.kind.room_id(),
                     tl_state.tombstone_info.as_ref(),
                     tl_state.user_power,
                 );
+                // That doesn't cover the send button, whose `enabled` flag and colors
+                // were reset to the DSL defaults, so restore those too.
+                room_input_bar.update_encryption_state(cx, tl_state.is_encrypted);
                 self.view.redraw(cx);
             }
         });

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -2798,6 +2798,8 @@ impl RoomScreen {
         portal_list: &PortalListRef,
         loading_pane: &LoadingPaneRef,
     ) {
+        // Jumping isn't the user reading wherever we land, so drop any pending receipt.
+        self.read_receipt_state.cancel_timer(cx);
         let Some(tl) = self.tl_state.as_mut() else { return };
         let max_tl_idx = max_tl_idx.unwrap_or_else(|| tl.items.len());
 

--- a/src/shared/file_upload_modal.rs
+++ b/src/shared/file_upload_modal.rs
@@ -452,6 +452,8 @@ pub struct FileUploadModal {
 
     /// The preview page being shown, so a reapply can restore it.
     #[rust] preview_page: LiveId,
+    /// Whether that preview was truncated, so a reapply can restore its notice too.
+    #[rust] preview_truncated: bool,
 }
 
 impl ScriptHook for FileUploadModal {
@@ -597,6 +599,12 @@ impl FileUploadModal {
         self.label(cx, ids!(empty_attachment_warning_label))
             .set_visible(cx, size == 0);
         self.page_flip(cx, ids!(preview_flip)).set_active_page(cx, self.preview_page);
+        // `show_preview()` isn't re-run on a reapply, so restore its truncation notice here.
+        let truncated = self.preview_truncated;
+        self.label(cx, ids!(code_truncated_label))
+            .set_visible(cx, truncated && self.preview_page == id!(code_text_page));
+        self.label(cx, ids!(plain_truncated_label))
+            .set_visible(cx, truncated && self.preview_page == id!(plain_text_page));
     }
 
     /// Displays the generated filed preview.
@@ -613,6 +621,7 @@ impl FileUploadModal {
     }
 
     fn show_preview(&mut self, cx: &mut Cx, preview: FilePreview) {
+        self.preview_truncated = false;
         self.preview_page = match preview {
             FilePreview::Loading => id!(loading_page),
             FilePreview::Image(buffer) => {
@@ -623,11 +632,13 @@ impl FileUploadModal {
             FilePreview::Text(tp) if tp.is_code => {
                 self.code_view(cx, ids!(code_preview)).set_text(cx, &tp.content);
                 self.label(cx, ids!(code_truncated_label)).set_visible(cx, tp.truncated);
+                self.preview_truncated = tp.truncated;
                 id!(code_text_page)
             }
             FilePreview::Text(tp) => {
                 self.code_view(cx, ids!(plain_preview)).set_text(cx, &tp.content);
                 self.label(cx, ids!(plain_truncated_label)).set_visible(cx, tp.truncated);
+                self.preview_truncated = tp.truncated;
                 id!(plain_text_page)
             }
             FilePreview::None => id!(no_preview_page),
@@ -640,6 +651,7 @@ impl FileUploadModal {
         self.upload = None;
         self.preview_id = None;
         self.is_text_preview = false;
+        self.preview_truncated = false;
         self.image(cx, ids!(image_preview)).set_texture(cx, None);
         self.code_view(cx, ids!(code_preview)).set_text(cx, "");
         self.code_view(cx, ids!(plain_preview)).set_text(cx, "");

--- a/src/shared/slash_commands.rs
+++ b/src/shared/slash_commands.rs
@@ -248,6 +248,11 @@ pub fn parse_input(text: &str) -> SlashCommandOutcome {
             arg,
             format!("<span data-mx-spoiler>{}</span>", htmlize::escape_text(arg)),
         ),
+        "rainbow" | "rainbowme" if arg.chars().count() > RAINBOW_MAX_CHARS => {
+            return SlashCommandOutcome::Error(format!(
+                "That message is too long to rainbow; the limit is {RAINBOW_MAX_CHARS} characters."
+            ));
+        }
         "rainbow" => RoomMessageEventContent::text_html(arg, rainbow_html(arg)),
         "rainbowme" => RoomMessageEventContent::emote_html(arg, rainbow_html(arg)),
         "shrug" | "tableflip" | "unflip" | "lenny" => {
@@ -317,10 +322,36 @@ fn html_to_plaintext(html: &str) -> String {
     /// Tags we turn into a line break, so "a<br/>b" doesn't come out as "ab".
     const BREAKING_TAGS: &[&str] = &["br", "p", "li", "div", "tr", "blockquote", "h1", "h2", "h3"];
 
+    /// Consumes everything through the closing tag of a raw-text element.
+    fn skip_raw_text(chars: &mut impl Iterator<Item = char>, tag_name: &str) {
+        let close: Vec<char> = format!("</{tag_name}").chars().collect();
+        let mut matched = 0;
+        for ch in chars.by_ref() {
+            let ch = ch.to_ascii_lowercase();
+            if ch == close[matched] {
+                matched += 1;
+                if matched == close.len() {
+                    break;
+                }
+            } else {
+                matched = usize::from(ch == close[0]);
+            }
+        }
+        for ch in chars {
+            if ch == '>' {
+                break;
+            }
+        }
+    }
+
     let mut out = String::with_capacity(html.len());
     let mut tag_name = String::new();
     let mut in_tag = false;
     let mut in_name = false;
+    let mut is_close_tag = false;
+    // Set once the name reads as `<!--`, since a bare '>' doesn't end a comment.
+    let mut in_comment = false;
+    let mut prev = ['\0', '\0'];
     // Set while we're inside a quoted attribute value, where a '>' doesn't end the tag.
     let mut quote: Option<char> = None;
     let mut chars = html.chars().peekable();
@@ -333,10 +364,21 @@ fn html_to_plaintext(html: &str) -> String {
             if starts_tag {
                 in_tag = true;
                 in_name = true;
+                is_close_tag = chars.peek() == Some(&'/');
+                in_comment = false;
+                prev = ['\0', '\0'];
                 tag_name.clear();
             } else {
                 out.push(c);
             }
+            continue;
+        }
+        // A comment runs all the way to "-->".
+        if in_comment {
+            if c == '>' && prev == ['-', '-'] {
+                in_tag = false;
+            }
+            prev = [prev[1], c];
             continue;
         }
         match c {
@@ -347,6 +389,10 @@ fn html_to_plaintext(html: &str) -> String {
                 if BREAKING_TAGS.contains(&tag_name.as_str()) && !out.ends_with('\n') {
                     out.push('\n');
                 }
+                // These hold JS/CSS rather than markup, so their contents aren't body text.
+                if !is_close_tag && matches!(tag_name.as_str(), "script" | "style") {
+                    skip_raw_text(&mut chars, &tag_name);
+                }
             }
             // The name runs from just after the '<' (or '</') up to the first space.
             _ if quote.is_none() && in_name => {
@@ -354,6 +400,7 @@ fn html_to_plaintext(html: &str) -> String {
                     in_name = false;
                 } else if c != '/' {
                     tag_name.push(c.to_ascii_lowercase());
+                    in_comment = tag_name == "!--";
                 }
             }
             _ => {}
@@ -367,6 +414,10 @@ fn html_to_plaintext(html: &str) -> String {
         false => text,
     }
 }
+
+/// Past this, `rainbow_html`'s ~37 bytes of markup per character would push
+/// `formatted_body` over the 64 KiB event limit and the homeserver would reject it.
+const RAINBOW_MAX_CHARS: usize = 1500;
 
 fn rainbow_html(text: &str) -> String {
     // This is borrowed from Element's CIELAB behavior
@@ -673,6 +724,26 @@ mod tests_slash_commands {
         assert!(matches!(from_link, SlashCommandAction::OpenDirectMessage(u) if u == user_id));
         // A link to something that isn't a user is still rejected.
         assert!(error("/dm [A Room](https://matrix.to/#/%23room:server.org)").contains("user ID"));
+    }
+
+    #[test]
+    fn html_fallback_strips_comments_and_raw_text() {
+        // A '>' inside the comment must not end it early.
+        assert_eq!(message("/html <!-- c > d -->visible").body(), "visible");
+        assert_eq!(message("/html <!-- secret -->ok").body(), "ok");
+        // Script/style hold code, not body text.
+        assert_eq!(message("/html <script>alert(1)</script>hi").body(), "hi");
+        assert_eq!(message("/html <style>a{b:c}</style>hi").body(), "hi");
+        assert_eq!(message("/html a<script>x</script>b").body(), "ab");
+    }
+
+    #[test]
+    fn rainbow_rejects_a_message_past_the_event_limit() {
+        let too_long = "a".repeat(RAINBOW_MAX_CHARS + 1);
+        assert!(error(&format!("/rainbow {too_long}")).contains("too long to rainbow"));
+        assert!(error(&format!("/rainbowme {too_long}")).contains("too long to rainbow"));
+        let at_limit = "a".repeat(RAINBOW_MAX_CHARS);
+        assert_eq!(message(&format!("/rainbow {at_limit}")).body(), at_limit);
     }
 
     #[test]


### PR DESCRIPTION
More script reapply issues, we really ought to fix this properly in makepad.
