### PR TITLE
ok another stupid review, still fixing issues

### DIFF
--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -535,6 +535,9 @@ impl InviteScreen {
             let room_name_id = cx.get_global::<RoomsListRef>()
                 .get_room_name(room_name_id.room_id())
                 .unwrap_or_else(|| room_name_id.clone());
+            // We've resolved what this screen should show, so stop the `Event::Signal`
+            // handler coming back here and re-emitting this action on every signal.
+            self.is_loaded = true;
             cx.widget_action(self.widget_uid(), RoomsListAction::InviteAccepted { room_name_id });
             return;
         }

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -535,8 +535,7 @@ impl InviteScreen {
             let room_name_id = cx.get_global::<RoomsListRef>()
                 .get_room_name(room_name_id.room_id())
                 .unwrap_or_else(|| room_name_id.clone());
-            // We've resolved what this screen should show, so stop the `Event::Signal`
-            // handler coming back here and re-emitting this action on every signal.
+
             self.is_loaded = true;
             cx.widget_action(self.widget_uid(), RoomsListAction::InviteAccepted { room_name_id });
             return;

--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -138,9 +138,7 @@ impl Drop for LoadingPaneState {
 pub struct LoadingPane {
     #[deref] view: View,
     #[rust] state: LoadingPaneState,
-    /// The area we gave key focus to in `start_search()`, so `hide()` can tell
-    /// whether we still hold that focus and should hand it back.
-    #[rust] key_focus_area: Option<Area>,
+    #[rust] orig_key_focus_area: Option<Area>,
 }
 
 
@@ -231,10 +229,8 @@ impl LoadingPane {
             request_sender,
         });
         self.visible = true;
-        // Remember what we focused. Before this pane's first draw its area is still
-        // empty, and `hide()` has to give focus back either way.
         let area = self.view.area();
-        self.key_focus_area = Some(area);
+        self.orig_key_focus_area = Some(area);
         cx.set_key_focus(area);
         self.redraw(cx);
     }
@@ -270,10 +266,8 @@ impl LoadingPane {
     /// Hides this pane, which also cancels any search it was showing.
     pub fn hide(&mut self, cx: &mut Cx) {
         self.set_state(cx, LoadingPaneState::None);
-        // Give key focus back, but only if we still hold the focus we took.
-        if let Some(area) = self.key_focus_area.take()
-            && cx.has_key_focus(area)
-        {
+        // Give key focus back if we're still holding the focus we initially took.
+        if let Some(area) = self.orig_key_focus_area.take() && cx.has_key_focus(area) {
             cx.revert_key_focus();
         }
         self.visible = false;

--- a/src/home/loading_pane.rs
+++ b/src/home/loading_pane.rs
@@ -138,6 +138,9 @@ impl Drop for LoadingPaneState {
 pub struct LoadingPane {
     #[deref] view: View,
     #[rust] state: LoadingPaneState,
+    /// The area we gave key focus to in `start_search()`, so `hide()` can tell
+    /// whether we still hold that focus and should hand it back.
+    #[rust] key_focus_area: Option<Area>,
 }
 
 
@@ -228,7 +231,11 @@ impl LoadingPane {
             request_sender,
         });
         self.visible = true;
-        cx.set_key_focus(self.view.area());
+        // Remember what we focused. Before this pane's first draw its area is still
+        // empty, and `hide()` has to give focus back either way.
+        let area = self.view.area();
+        self.key_focus_area = Some(area);
+        cx.set_key_focus(area);
         self.redraw(cx);
     }
 
@@ -263,9 +270,10 @@ impl LoadingPane {
     /// Hides this pane, which also cancels any search it was showing.
     pub fn hide(&mut self, cx: &mut Cx) {
         self.set_state(cx, LoadingPaneState::None);
-        // if the pane was actually drawn and had key focus, give it back.
-        let area = self.view.area();
-        if !matches!(area, Area::Empty) && cx.has_key_focus(area) {
+        // Give key focus back, but only if we still hold the focus we took.
+        if let Some(area) = self.key_focus_area.take()
+            && cx.has_key_focus(area)
+        {
             cx.revert_key_focus();
         }
         self.visible = false;


### PR DESCRIPTION
* the "invite was already accepted elsewhere" branch returned without setting `is_loaded`, so it kept re-emitted the `InviteAccepted` action on every signal
* the classic makepad problem of not being able to set key focus on a widget that hasn't been drawn yet, this time with the loading pane. 
