### PR TITLE
Show and fully handle invites to spaces

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -392,9 +392,9 @@ impl MatchEvent for App {
                     self.app_state.selected_room = None;
                     continue;
                 }
-                Some(AppStateAction::UpgradedInviteToJoinedRoom(room_id)) => {
+                Some(AppStateAction::UpgradedInviteToJoinedRoom { room_id, is_space }) => {
                     if let Some(selected_room) = self.app_state.selected_room.as_mut()
-                        && selected_room.upgrade_invite_to_joined(room_id)
+                        && selected_room.upgrade_invite_to_joined(room_id, *is_space)
                     {
                         self.ui.redraw(cx);
                     }
@@ -403,15 +403,16 @@ impl MatchEvent for App {
                         .chain(self.app_state.saved_dock_state_per_space.values_mut())
                     {
                         for room in saved.selected_room.iter_mut().chain(saved.room_order.iter_mut()) {
-                            room.upgrade_invite_to_joined(room_id);
+                            room.upgrade_invite_to_joined(room_id, *is_space);
                         }
                         // The tab's kind is what decides which screen gets shown when a saved room is loaded,
                         // so we have to change that in addition to the selected room itself.
                         for (tab_id, room) in saved.open_rooms.iter_mut() {
-                            if room.upgrade_invite_to_joined(room_id)
-                                && let Some(DockItem::Tab { kind, .. }) = saved.dock_items.get_mut(tab_id)
+                            if room.upgrade_invite_to_joined(room_id, *is_space)
+                                && let Some(DockItem::Tab { kind, name, .. }) = saved.dock_items.get_mut(tab_id)
                             {
                                 *kind = room.dock_kind();
+                                *name = room.display_name();
                             }
                         }
                     }
@@ -1104,23 +1105,24 @@ impl SelectedRoom {
         }
     }
 
-    /// Upgrades this room from an invite to a joined room
+    /// Returns the joined variant for the given space/room: `Space` if `is_space`, else `JoinedRoom`.
+    pub fn to_joined(room_name_id: RoomNameId, is_space: bool) -> Self {
+        match is_space {
+            true  => SelectedRoom::Space { space_name_id: room_name_id },
+            false => SelectedRoom::JoinedRoom { room_name_id },
+        }
+    }
+
+    /// Upgrades this room from an invite to a joined room or space
     /// if its `room_id` matches the given `room_id`.
     ///
     /// Returns `true` if the room was an `InvitedRoom` with the same `room_id`
-    /// that was successfully upgraded to a `JoinedRoom`;
-    /// otherwise, returns `false`.
-    pub fn upgrade_invite_to_joined(&mut self, room_id: &RoomId) -> bool {
-        match self {
-            SelectedRoom::InvitedRoom { room_name_id } if room_name_id.room_id() == room_id => {
-                let name = room_name_id.clone();
-                *self = SelectedRoom::JoinedRoom {
-                    room_name_id: name,
-                };
-                true
-            }
-            _ => false,
-        }
+    /// that was successfully upgraded; otherwise, returns `false`.
+    pub fn upgrade_invite_to_joined(&mut self, room_id: &RoomId, is_space: bool) -> bool {
+        let SelectedRoom::InvitedRoom { room_name_id } = self else { return false };
+        if room_name_id.room_id() != room_id { return false }
+        *self = Self::to_joined(room_name_id.clone(), is_space);
+        true
     }
 
     /// Updates this room's name if it refers to the same room (same room ID).
@@ -1227,9 +1229,12 @@ pub enum AppStateAction {
     RoomFocused(SelectedRoom),
     /// Resets the focus to none, meaning that no room is selected.
     FocusNone,
-    /// The given room has successfully been upgraded from being displayed
-    /// as an InviteScreen to a RoomScreen.
-    UpgradedInviteToJoinedRoom(OwnedRoomId),
+    /// The given room or space has successfully been upgraded from being displayed
+    /// as an InviteScreen to a RoomScreen or SpaceLobbyScreen.
+    UpgradedInviteToJoinedRoom {
+        room_id: OwnedRoomId,
+        is_space: bool,
+    },
     /// The given room or space has a new name.
     ///
     /// This triggers an update to every cached copy of that room/space name.

--- a/src/home/home_screen.rs
+++ b/src/home/home_screen.rs
@@ -6,8 +6,9 @@ use crate::{
         invite_screen::InviteScreenWidgetRefExt,
         navigation_tab_bar::{NavigationBarAction, SelectedTab},
         room_screen::RoomScreenWidgetRefExt,
-        rooms_list::RoomsListAction,
+        rooms_list::{AcceptedInviteKind, RoomsListAction},
         space_lobby::SpaceLobbyScreenWidgetRefExt,
+        spaces_bar::SpacesBarAction,
     },
     settings::{
         app_preferences::{AppPreferencesGlobal, AppPreferencesAction, ViewModeOverride},
@@ -533,29 +534,13 @@ impl Widget for HomeScreen {
             for action in actions {
                 match action.downcast_ref() {
                     Some(NavigationBarAction::GoToHome) => {
-                        if !matches!(app_state.selected_tab, SelectedTab::Home) {
-                            self.previous_selection = std::mem::replace(&mut app_state.selected_tab, SelectedTab::Home);
-                            cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
-                            self.update_active_page_from_selection(cx, app_state);
-                            self.view.redraw(cx);
-                        }
+                        self.switch_to_tab(cx, app_state, SelectedTab::Home);
                     }
                     Some(NavigationBarAction::GoToAddRoom) => {
-                        if !matches!(app_state.selected_tab, SelectedTab::AddRoom) {
-                            self.previous_selection = std::mem::replace(&mut app_state.selected_tab, SelectedTab::AddRoom);
-                            cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
-                            self.update_active_page_from_selection(cx, app_state);
-                            self.view.redraw(cx);
-                        }
+                        self.switch_to_tab(cx, app_state, SelectedTab::AddRoom);
                     }
                     Some(NavigationBarAction::GoToSpace { space_name_id }) => {
-                        let new_space_selection = SelectedTab::Space { space_name_id: space_name_id.clone() };
-                        if app_state.selected_tab != new_space_selection {
-                            self.previous_selection = std::mem::replace(&mut app_state.selected_tab, new_space_selection);
-                            cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
-                            self.update_active_page_from_selection(cx, app_state);
-                            self.view.redraw(cx);
-                        }
+                        self.switch_to_tab(cx, app_state, SelectedTab::Space { space_name_id: space_name_id.clone() });
                     }
                     // Only open the settings screen if it is not currently open.
                     Some(NavigationBarAction::OpenSettings) => {
@@ -607,6 +592,23 @@ impl Widget for HomeScreen {
                     }
                 }
 
+                // An invited space's InviteScreen should be shown on the main home screen's dock,
+                // so navigate to that first (un-select any selected space).
+                //
+                // This is to ensure that we don't show a new space invite within an existing
+                // unrelated space's separate dock / rooms list.
+                if let SpacesBarAction::InvitedSpaceClicked { space_name_id } = action.as_widget_action().cast()
+                    && !effective_is_desktop(cx)
+                {
+                    self.switch_to_tab(cx, app_state, SelectedTab::Home);
+                    self.push_selected_screen_view(
+                        cx,
+                        app_state,
+                        SelectedRoom::InvitedRoom { room_name_id: space_name_id },
+                    );
+                    continue;
+                }
+
                 // Handle room selections. Desktop owns tab creation in MainDesktopUI,
                 // while mobile owns StackNavigation screen pushes here.
                 match action.as_widget_action().cast() {
@@ -614,11 +616,13 @@ impl Widget for HomeScreen {
                         self.push_selected_screen_view(cx, app_state, selected_room);
                     }
                     // On desktop, `MainDesktopUI` handles this, so we only need to update this in mobile view mode.
-                    RoomsListAction::InviteAccepted { room_name_id } if !effective_is_desktop(cx) => {
-                        self.upgrade_mobile_invite_to_joined(cx, app_state, &room_name_id);
-                        cx.action(AppStateAction::UpgradedInviteToJoinedRoom(
-                            room_name_id.room_id().clone(),
-                        ));
+                    RoomsListAction::InviteAccepted { room_name_id, kind } if !effective_is_desktop(cx) => {
+                        let is_space = kind.is_space();
+                        self.upgrade_mobile_invite_to_joined(cx, app_state, &room_name_id, kind);
+                        cx.action(AppStateAction::UpgradedInviteToJoinedRoom {
+                            room_id: room_name_id.room_id().clone(),
+                            is_space,
+                        });
                     }
                     _ => {}
                 }
@@ -873,7 +877,13 @@ impl HomeScreen {
             return;
         }
         let has_current_mobile_screen = stack_navigation.current_view().is_some();
-        if has_current_mobile_screen && app_state.selected_room.as_ref().is_some_and(|c| c == &sr) {
+        // If it has the same room ID and the same screen type (invite, joined, etc),
+        // then we actually don't need to do anything. Otherwise we need to change it
+        // to a new screen, e.g., a joined RoomScreen or a joined SpaceLobbyScreen.
+        let is_same_screen = app_state.selected_room.as_ref().is_some_and(|c|
+            c == &sr && std::mem::discriminant(c) == std::mem::discriminant(&sr)
+        );
+        if has_current_mobile_screen && is_same_screen {
             return;
         }
         let Some(view_id) = self.populate_mobile_stack_view(cx, &stack_navigation, &sr) else {
@@ -891,22 +901,39 @@ impl HomeScreen {
         self.view.redraw(cx);
     }
 
-    /// Swaps a room's InviteScreen in mobile view mode for that newly-joined room's RoomScreen.
+    /// Switches to (selects) the given navigation tab, if it isn't already the selected one.
+    fn switch_to_tab(&mut self, cx: &mut Cx, app_state: &mut AppState, new_tab: SelectedTab) {
+        if app_state.selected_tab == new_tab { return }
+        self.previous_selection = std::mem::replace(&mut app_state.selected_tab, new_tab);
+        cx.action(NavigationBarAction::TabSelected(app_state.selected_tab.clone()));
+        self.update_active_page_from_selection(cx, app_state);
+        self.view.redraw(cx);
+    }
+
+    /// Upgrades a room's or space's InviteScreen that is being shown in mobile view mode
+    /// to that newly-joined RoomScreen or SpaceLobbyScreen.
     fn upgrade_mobile_invite_to_joined(
         &mut self,
         cx: &mut Cx,
         app_state: &mut AppState,
         room_name_id: &RoomNameId,
+        kind: AcceptedInviteKind,
     ) {
+        let is_space = kind.is_space();
         let room_id = room_name_id.room_id();
         let is_this_invite = |sr: &SelectedRoom| matches!(
             sr, SelectedRoom::InvitedRoom { room_name_id: r } if r.room_id() == room_id
         );
         if app_state.selected_room.as_ref().is_some_and(is_this_invite) {
+            // The new SpaceLobbyScreen should be shown within its top-level ancestor space's tab/dock,
+            // so navigate to that, which also sets the rooms list into that space's mode.
+            if let AcceptedInviteKind::Space { dock_space: Some(dock_space) } = &kind {
+                self.switch_to_tab(cx, app_state, SelectedTab::Space { space_name_id: dock_space.clone() });
+            }
             self.push_selected_screen_view(
                 cx,
                 app_state,
-                SelectedRoom::JoinedRoom { room_name_id: room_name_id.clone() },
+                SelectedRoom::to_joined(room_name_id.clone(), is_space),
             );
             // The invite we replaced was pushed onto the mobile history stack,
             // so we need to remove it to ensure that it won't show up if the user goes back.
@@ -915,7 +942,7 @@ impl HomeScreen {
             }
         }
         for room in &mut self.mobile_screen_history {
-            room.upgrade_invite_to_joined(room_id);
+            room.upgrade_invite_to_joined(room_id, is_space);
         }
     }
 

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{RoomState, ruma::OwnedRoomId};
 
 use crate::{app::AppStateAction, avatar_cache::{self, AvatarCacheEntry}, home::rooms_list::RoomsListRef, join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, room::{BasicRoomDetails, FetchedRoomAvatar}, shared::{avatar::AvatarWidgetRefExt, restore_status_view::RestoreStatusViewWidgetExt}, sliding_sync::{submit_async_request, MatrixRequest}, utils::{self, RoomNameId}};
 
-use super::rooms_list::{InviteState, InviterInfo, RoomsListAction, get_invited_rooms, set_invite_state};
+use super::rooms_list::{AcceptedInviteKind, InviteState, InviterInfo, RoomsListAction, get_invited_rooms, set_invite_state};
 
 
 script_mod! {
@@ -243,6 +243,11 @@ pub enum InviteScreenAction {
         room_id: OwnedRoomId,
         inviter_info: InviterInfo,
     },
+    /// We've determined whether this invite is for a space.
+    IsSpace {
+        room_id: OwnedRoomId,
+        is_space: bool,
+    },
 }
 
 
@@ -257,6 +262,7 @@ pub struct InviteScreen {
     #[rust] room_name_id: Option<RoomNameId>,
     #[rust] is_loaded: bool,
     #[rust] all_rooms_loaded: bool,
+    #[rust] is_space: bool,
 }
 
 impl Widget for InviteScreen {
@@ -297,6 +303,13 @@ impl Widget for InviteScreen {
                         if let Some(info) = self.info.as_mut() {
                             info.inviter = Some(inviter_info.clone());
                         }
+                        self.redraw(cx);
+                    }
+                    continue;
+                }
+                if let Some(InviteScreenAction::IsSpace { room_id, is_space }) = action.downcast_ref() {
+                    if self.room_name_id.as_ref().is_some_and(|r| r.room_id() == room_id) {
+                        self.is_space = *is_space;
                         self.redraw(cx);
                     }
                     continue;
@@ -467,12 +480,13 @@ impl Widget for InviteScreen {
         // Third, set the buttons' text based on the invite state.
         let cancel_button = self.view.button(cx, ids!(cancel_button));
         let accept_button = self.view.button(cx, ids!(accept_button));
+        let join_text = match self.is_space { true => "Join Space", false => "Join Room" };
         match self.invite_state {
             InviteState::WaitingOnUserInput => {
                 cancel_button.set_enabled(cx, true);
                 accept_button.set_enabled(cx, true);
                 cancel_button.set_text(cx, "Reject Invite");
-                accept_button.set_text(cx, "Join Room");
+                accept_button.set_text(cx, join_text);
             }
             InviteState::WaitingForJoinResult => {
                 cancel_button.set_enabled(cx, false);
@@ -484,7 +498,7 @@ impl Widget for InviteScreen {
                 cancel_button.set_enabled(cx, false);
                 accept_button.set_enabled(cx, false);
                 cancel_button.set_text(cx, "Rejecting...");
-                accept_button.set_text(cx, "Join Room");
+                accept_button.set_text(cx, join_text);
             }
             InviteState::WaitingForJoinedRoom => {
                 cancel_button.set_enabled(cx, false);
@@ -522,6 +536,7 @@ impl InviteScreen {
                 inviter: invite.inviter_info.clone(),
             });
             self.invite_state = invite.invite_state;
+            self.is_space = invite.is_space;
             self.is_loaded = true;
             self.all_rooms_loaded = true;
             self.redraw(cx);
@@ -537,7 +552,10 @@ impl InviteScreen {
                 .unwrap_or_else(|| room_name_id.clone());
 
             self.is_loaded = true;
-            cx.widget_action(self.widget_uid(), RoomsListAction::InviteAccepted { room_name_id });
+            cx.widget_action(
+                self.widget_uid(),
+                RoomsListAction::InviteAccepted { room_name_id, kind: AcceptedInviteKind::Room },
+            );
             return;
         }
 
@@ -565,6 +583,7 @@ impl InviteScreen {
         self.room_name_id = None;
         self.info = None;
         self.invite_state = InviteState::default();
+        self.is_space = false;
         self.is_loaded = false;
         self.all_rooms_loaded = false;
         self.view.restore_status_view(cx, ids!(restore_status_view)).set_visible(cx, false);

--- a/src/home/main_desktop_ui.rs
+++ b/src/home/main_desktop_ui.rs
@@ -4,7 +4,7 @@ use tokio::sync::Notify;
 use std::{collections::{HashMap, HashSet}, sync::Arc};
 
 use crate::{app::{AppState, AppStateAction, SavedDockState, SelectedRoom}, home::{navigation_tab_bar::{NavigationBarAction, SelectedTab}, rooms_list::RoomsListRef, space_lobby::SpaceLobbyScreenWidgetRefExt}, utils::RoomNameId};
-use super::{invite_screen::InviteScreenWidgetRefExt, room_screen::RoomScreenWidgetRefExt, rooms_list::RoomsListAction};
+use super::{invite_screen::InviteScreenWidgetRefExt, room_screen::RoomScreenWidgetRefExt, rooms_list::{AcceptedInviteKind, RoomsListAction}, spaces_bar::SpacesBarAction};
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -288,40 +288,63 @@ impl MainDesktopUI {
         cx.action(MainDesktopUiAction::SaveDockIntoAppState);
     }
 
-    /// Replaces an invite with a joined room in the dock.
-    fn replace_invite_with_joined_room(
+    /// Replaces an invite with a joined room or space in the dock.
+    fn replace_invite_with_joined(
         &mut self,
         cx: &mut Cx,
-        _scope: &mut Scope,
         room_name_id: &RoomNameId,
+        is_space: bool,
     ) {
+        let joined = SelectedRoom::to_joined(room_name_id.clone(), is_space);
         let dock = self.view.dock(cx, ids!(dock));
         if let Some((new_widget, _)) = dock.replace_tab(
             cx,
-            LiveId::from_str(room_name_id.room_id().as_str()),
-            id!(room_screen),
-            Some(room_name_id.to_string()),
+            joined.tab_id(),
+            joined.dock_kind(),
+            Some(joined.display_name()),
             false,
         ) {
-            new_widget
-                .as_room_screen()
-                .set_displayed_room(cx, room_name_id, None);
+            match is_space {
+                true => new_widget.as_space_lobby_screen()
+                    .set_displayed_space(cx, room_name_id),
+                false => new_widget.as_room_screen()
+                    .set_displayed_room(cx, room_name_id, None),
+            }
 
             // Note: don't return here. Whether or not this invited room is opened in a tab,
             // we still need to upgrade its SelectedRoom instance, so fall through below.
         }
 
-        // Go through all existing `SelectedRoom` instances and replace the
-        // `SelectedRoom::InvitedRoom`s with `SelectedRoom::JoinedRoom`s.
+        self.upgrade_open_invites(cx, room_name_id, is_space);
+    }
+
+    /// Replaces all invited `SelectedRoom` instances for this room/space with the
+    /// equivalent joined variant for this room/space.
+    ///
+    /// Also emits an action to instruct AppState to update itself accordingly.
+    fn upgrade_open_invites(&mut self, cx: &mut Cx, room_name_id: &RoomNameId, is_space: bool) {
         for selected_room in self.most_recently_selected_room.iter_mut()
             .chain(self.room_order.iter_mut())
             .chain(self.open_rooms.values_mut())
         {
-            selected_room.upgrade_invite_to_joined(room_name_id.room_id());
+            selected_room.upgrade_invite_to_joined(room_name_id.room_id(), is_space);
         }
+        cx.action(AppStateAction::UpgradedInviteToJoinedRoom {
+            room_id: room_name_id.room_id().clone(),
+            is_space,
+        });
+    }
 
-        // Finally, emit an action to update the AppState with the new room.
-        cx.action(AppStateAction::UpgradedInviteToJoinedRoom(room_name_id.room_id().clone()));
+    /// Saves the current dock's state and then loads the given space's dock (or the main dock).
+    fn switch_dock_to_space(
+        &mut self,
+        cx: &mut Cx,
+        app_state: &mut AppState,
+        new_space: Option<OwnedRoomId>,
+    ) {
+        self.save_dock_state_to(cx, app_state);
+        self.selected_space = new_space;
+        self.load_dock_state_from(cx, app_state);
     }
 
     /// Saves a copy of the current UI state of the dock into the given app state,
@@ -417,9 +440,12 @@ impl MainDesktopUI {
         }
 
         // Now that we've loaded the dock content, we can re-select the selected room.
+        // If this dock has no selection, clear the previous dock's selection so that,
+        // for ex, it doesn't mistakenly save a now-closed invite screen as the selected room.
         let selected_room = selected_room.clone();
-        if let Some(selected_room) = selected_room.clone() {
-            self.focus_or_create_tab(cx, selected_room);
+        match selected_room.clone() {
+            Some(selected_room) => self.focus_or_create_tab(cx, selected_room),
+            None => self.most_recently_selected_room = None,
         }
         app_state.selected_room = selected_room;
         self.redraw(cx);
@@ -511,6 +537,19 @@ impl WidgetMatchEvent for MainDesktopUI {
                 continue;
             }
 
+            // An invited space's InviteScreen should be shown in the main home dock.
+            // We switch to that dock directly, here, instead of handling it as a `GoToHome` action,
+            // because it's instant, and then we can create the new InviteScreen tab immediately.
+            if let SpacesBarAction::InvitedSpaceClicked { space_name_id } = widget_action.cast() {
+                if self.selected_space.is_some() {
+                    let app_state = scope.data.get_mut::<AppState>().unwrap();
+                    self.switch_dock_to_space(cx, app_state, None);
+                }
+                cx.action(NavigationBarAction::GoToHome);
+                self.focus_or_create_tab(cx, SelectedRoom::InvitedRoom { room_name_id: space_name_id });
+                continue;
+            }
+
             // If the currently-selected space has been changed, we must handle that
             // by switching the dock to show the layout for another space.
             if let Some(NavigationBarAction::TabSelected(tab)) = action.downcast_ref() {
@@ -524,9 +563,7 @@ impl WidgetMatchEvent for MainDesktopUI {
                     _ => continue,
                 };
                 let app_state = scope.data.get_mut::<AppState>().unwrap();
-                self.save_dock_state_to(cx, app_state);
-                self.selected_space = new_space;
-                self.load_dock_state_from(cx, app_state);
+                self.switch_dock_to_space(cx, app_state, new_space);
                 self.redraw(cx);
                 continue;
             }
@@ -590,8 +627,24 @@ impl WidgetMatchEvent for MainDesktopUI {
                     // a redraw to be happening in order to draw the tab content.
                     self.focus_or_create_tab(cx, selected_room.clone());
                 }
-                RoomsListAction::InviteAccepted { room_name_id } => {
-                    self.replace_invite_with_joined_room(cx, scope, room_name_id);
+                RoomsListAction::InviteAccepted { room_name_id, kind } => {
+                    // A space's SpaceLobbyScreen should be shown in its top-level ancestor space's dock
+                    // (assuming the user is still on that space's InviteScreen).
+                    let space = SelectedRoom::Space { space_name_id: room_name_id.clone() };
+                    if let AcceptedInviteKind::Space { dock_space: Some(dock_space) } = kind
+                        && self.open_rooms.contains_key(&space.tab_id())
+                        && self.most_recently_selected_room.as_ref()
+                            .is_some_and(|sr| sr.room_id() == room_name_id.room_id())
+                    {
+                        self.close_tab(cx, space.tab_id());
+                        self.upgrade_open_invites(cx, room_name_id, true);
+                        let app_state = scope.data.get_mut::<AppState>().unwrap();
+                        self.switch_dock_to_space(cx, app_state, Some(dock_space.room_id().clone()));
+                        cx.action(NavigationBarAction::GoToSpace { space_name_id: dock_space.clone() });
+                        self.focus_or_create_tab(cx, space);
+                    } else {
+                        self.replace_invite_with_joined(cx, room_name_id, kind.is_space());
+                    }
                 }
                 RoomsListAction::OpenRoomContextMenu { .. } => {}
                 RoomsListAction::None => { }

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -26,7 +26,7 @@ use matrix_sdk::{RoomState, ruma::{events::tag::Tags, MilliSecondsSinceUnixEpoch
 use crate::{
     app::{AppState, AppStateAction, SelectedRoom},
     home::{
-        invite_screen::{InviteScreenAction, JoinRoomResultAction, LeaveRoomResultAction}, navigation_tab_bar::{NavigationBarAction, SelectedTab}, room_context_menu::RoomContextMenuDetails, room_screen::invalidate_entire_room_timeline_states, rooms_list_entry::RoomsListEntryAction, space_lobby::{SpaceLobbyAction, SpaceLobbyEntryWidgetExt}
+        invite_screen::{InviteScreenAction, JoinRoomResultAction, LeaveRoomResultAction}, navigation_tab_bar::{NavigationBarAction, SelectedTab}, room_context_menu::RoomContextMenuDetails, room_screen::invalidate_entire_room_timeline_states, rooms_list_entry::RoomsListEntryAction, space_lobby::{SpaceLobbyAction, SpaceLobbyEntryWidgetExt}, spaces_bar::{SpacesListUpdate, enqueue_spaces_list_update}
     },
     logout::logout_confirm_modal::LogoutAction,
     room::{
@@ -218,9 +218,16 @@ pub enum RoomsListUpdate {
         room_id: OwnedRoomId,
         is_direct: bool,
     },
+    /// Update whether the given invited room is a space.
+    UpdateIsSpace {
+        room_id: OwnedRoomId,
+        is_space: bool,
+    },
     /// Remove the given room from the rooms list
     RemoveRoom {
         room_id: OwnedRoomId,
+        /// Whether the removed room is a space, read live at removal time.
+        is_space: bool,
         /// The new state of the room (which caused its removal).
         new_state: RoomState,
     },
@@ -263,16 +270,36 @@ pub fn enqueue_rooms_list_update(update: RoomsListUpdate) {
     SignalToUI::set_ui_signal();
 }
 
+/// What an accepted invite turned into, which decides which screen replaces
+/// its `InviteScreen` and which dock that screen belongs in.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AcceptedInviteKind {
+    /// A regular room, which becomes a `RoomScreen` in the current dock.
+    Room,
+    Space {
+        /// Where we should show the SpaceLobbyScreen for this newly-joined space.
+        ///
+        /// * If `Some`, it should be shown in the given space's dock.
+        /// * If `None`, it should be shown in the current dock (usually the main home dock).
+        dock_space: Option<RoomNameId>,
+    },
+}
+impl AcceptedInviteKind {
+    pub fn is_space(&self) -> bool {
+        matches!(self, Self::Space { .. })
+    }
+}
+
 /// Actions related to a single room in the RoomsList widget.
 #[derive(Debug, Clone, Default)]
 pub enum RoomsListAction {
     /// A new room or space was selected.
     Selected(SelectedRoom),
-    /// A new room was joined from an accepted invite,
-    /// meaning that the existing `InviteScreen` should be converted
-    /// to a `RoomScreen` to display the now-joined room.
+    /// A new room/space was joined by accepting an invite, so we should stop showing
+    /// its `InviteScreen` and replace it with the joined room/space screen.
     InviteAccepted {
         room_name_id: RoomNameId,
+        kind: AcceptedInviteKind,
     },
     /// Instructs the top-level app to show the context menu for the given room.
     ///
@@ -361,6 +388,8 @@ pub struct InvitedRoomInfo {
     pub is_selected: bool,
     /// Whether this is an invite to a direct room.
     pub is_direct: bool,
+    /// Whether this is an invite to a space rather than a regular room.
+    pub is_space: bool,
 }
 
 /// Info about the user who invited us to a room.
@@ -675,6 +704,7 @@ impl RoomsList {
         let mut num_updates: usize = 0;
         let mut needs_sort = false;
         let mut searchable_metadata_changed = false;
+        let mut did_invited_rooms_change = false;
         while let Some(update) = PENDING_ROOM_UPDATES.pop() {
             num_updates += 1;
             match update {
@@ -682,6 +712,7 @@ impl RoomsList {
                     let room_id = invited_room.room_name_id.room_id().clone();
                     let should_display = should_display_room!(self, &room_id, &invited_room);
                     let _replaced = self.invited_rooms.borrow_mut().insert(room_id.clone(), invited_room);
+                    did_invited_rooms_change = true;
                     if should_display && !self.displayed_invited_rooms.contains(&room_id) {
                         self.displayed_invited_rooms.push(room_id);
                     }
@@ -719,6 +750,7 @@ impl RoomsList {
                     //    displaying the invite to this room should be converted to a
                     //    RoomScreen displaying the now-joined room.
                     if let Some(_accepted_invite) = self.invited_rooms.borrow_mut().remove(&room_id) {
+                        did_invited_rooms_change = true;
                         log!("Removed room {room_id} from the list of invited rooms");
                         self.displayed_invited_rooms.iter()
                             .position(|r| r == &room_id)
@@ -728,6 +760,7 @@ impl RoomsList {
                                 self.widget_uid(), 
                                 RoomsListAction::InviteAccepted {
                                     room_name_id: room.room_name_id.clone(),
+                                    kind: AcceptedInviteKind::Room,
                                 }
                             );
                         }
@@ -765,6 +798,7 @@ impl RoomsList {
                         if let Some(invited_room) = invited_rooms.get_mut(&room_id) {
                             invited_room.canonical_alias = canonical_alias;
                             invited_room.alt_aliases = alt_aliases;
+                            did_invited_rooms_change = true;
                             let should_display = should_display_room!(self, &room_id, invited_room);
                             let pos_in_list = self.displayed_invited_rooms.iter()
                                 .position(|r| r == &room_id);
@@ -786,6 +820,7 @@ impl RoomsList {
                         room.room_avatar = room_avatar;
                     } else if let Some(room) = self.invited_rooms.borrow_mut().get_mut(&room_id) {
                         room.room_avatar = room_avatar;
+                        did_invited_rooms_change = true;
                     } else {
                         error!("Error: couldn't find room {room_id} to update avatar");
                     }
@@ -877,6 +912,7 @@ impl RoomsList {
                         let mut invited_rooms = self.invited_rooms.borrow_mut();
                         if let Some(invited_room) = invited_rooms.get_mut(&room_id) {
                             invited_room.room_name_id = new_room_name;
+                            did_invited_rooms_change = true;
                             let should_display = should_display_room!(self, &room_id, invited_room);
                             let pos_in_list = self.displayed_invited_rooms.iter()
                                 .position(|r| r == &room_id);
@@ -923,7 +959,17 @@ impl RoomsList {
                         error!("Error: couldn't find room {room_id} to update is_direct");
                     }
                 }
-                RoomsListUpdate::RemoveRoom { room_id, new_state } => {
+                RoomsListUpdate::UpdateIsSpace { room_id, is_space } => {
+                    // Joined spaces are filtered out of the rooms list service,
+                    // so if a space is here, it must be an invite to a space.
+                    if let Some(room) = self.invited_rooms.borrow_mut().get_mut(&room_id) {
+                        room.is_space = is_space;
+                        did_invited_rooms_change = true;
+                        // Broadcast this update to an already-open InviteScreen that might be showing this room.
+                        cx.action(InviteScreenAction::IsSpace { room_id, is_space });
+                    }
+                }
+                RoomsListUpdate::RemoveRoom { room_id, new_state, is_space } => {
                     // TODO: once we have a dedicated LoadingScreen widget, we should emit an action
                     // to replace this room (if it's currently open) with the LoadingScreen widget,
                     // which should show whether it has been left, kicked, or banned,
@@ -938,11 +984,36 @@ impl RoomsList {
                             removed.num_unread_messages,
                         );
                     }
-                    else if let Some(_removed) = self.invited_rooms.borrow_mut().remove(&room_id) {
+                    else if let Some(removed) = self.invited_rooms.borrow_mut().remove(&room_id) {
+                        did_invited_rooms_change = true;
                         log!("Removed room {room_id} from the list of all invited rooms");
                         self.displayed_invited_rooms.iter()
                             .position(|r| r == &room_id)
                             .map(|index| self.displayed_invited_rooms.remove(index));
+
+                        // A joined space never comes back as a joined room, so this is our only
+                        // chance to ask where its SpaceLobbyScreen should be shown.
+                        if (removed.is_space || is_space) && matches!(
+                            removed.invite_state,
+                            InviteState::WaitingForJoinResult | InviteState::WaitingForJoinedRoom,
+                        ) {
+                            let was_sent = self.space_request_sender.as_ref().is_some_and(|sender|
+                                sender.send(SpaceRequest::ResolveJoinedSpaceAncestor {
+                                    space_name_id: removed.room_name_id.clone(),
+                                }).is_ok()
+                            );
+                            if !was_sent {
+                                error!("Couldn't determine where joined space {room_id} should be shown; opening it here.");
+                                cx.widget_action(
+                                    self.widget_uid(),
+                                    RoomsListAction::InviteAccepted {
+                                        room_name_id: removed.room_name_id.clone(),
+                                        kind: AcceptedInviteKind::Space { dock_space: None },
+                                    },
+                                );
+                            }
+                            // if we DID send the request, we wait for the `JoinedSpaceAncestor` response.
+                        }
                     }
 
                     self.hidden_rooms.remove(&room_id);
@@ -966,6 +1037,7 @@ impl RoomsList {
                     self.displayed_joined_room_ids.clear();
                     self.invited_rooms.borrow_mut().clear();
                     self.displayed_invited_rooms.clear();
+                    did_invited_rooms_change = true;
                     self.update_status();
                 }
                 RoomsListUpdate::NotLoaded => {
@@ -1126,6 +1198,9 @@ impl RoomsList {
             || (searchable_metadata_changed && self.display_filter.is_some())
         {
             self.update_displayed_rooms(cx, false);
+        }
+        if did_invited_rooms_change {
+            enqueue_spaces_list_update(SpacesListUpdate::InvitedSpacesChanged);
         }
         if num_updates > 0 {
             self.redraw(cx);
@@ -1447,9 +1522,19 @@ impl RoomsList {
                     );
                 }
             },
+            // we now know the ancestor space (`dock_space`) of a newly-joined space.
+            SpaceRoomListAction::JoinedSpaceAncestor { space_name_id, dock_space } => {
+                cx.widget_action(
+                    self.widget_uid(),
+                    RoomsListAction::InviteAccepted {
+                        room_name_id: space_name_id.clone(),
+                        kind: AcceptedInviteKind::Space { dock_space: dock_space.clone() },
+                    },
+                );
+            }
             // Details-related space actions are handled by SpaceLobbyScreen, not RoomsList.
             SpaceRoomListAction::DetailedChildren { .. }
-            | SpaceRoomListAction::TopLevelSpaceDetails(_) => { }
+            | SpaceRoomListAction::SpaceDetails(_) => { }
         }
     }
 

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use makepad_widgets::*;
 use matrix_sdk::ruma::{OwnedRoomId, RoomId};
 
@@ -441,7 +442,12 @@ impl RoomsListEntryContent {
         cx: &mut Cx,
         room_info: &InvitedRoomInfo,
     ) {
-        self.view.label(cx, ids!(room_name)).set_text(cx, &room_info.room_name_id.display());
+        let name = room_info.room_name_id.display();
+        let name = match room_info.is_space {
+            true => Cow::Owned(format!("[Space] {name}")),
+            false => name,
+        };
+        self.view.label(cx, ids!(room_name)).set_text(cx, &name);
         // Hide the timestamp field, and use the latest message field to show the inviter.
         self.view.label(cx, ids!(timestamp)).set_text(cx, "");
         let inviter_string = match &room_info.inviter_info {
@@ -450,7 +456,8 @@ impl RoomsListEntryContent {
             None => String::from("You were invited"),
         };
         self.view.html_or_plaintext(cx, ids!(latest_message)).show_html(cx, &inviter_string);
-
+        // an invite cannot ever be tombstoned
+        self.view.view(cx, ids!(tombstone_icon)).set_visible(cx, false);
         self.view
             .unread_badge(cx, ids!(unread_badge))
             .update_counts(false, 1, 0);

--- a/src/home/space_lobby.rs
+++ b/src/home/space_lobby.rs
@@ -1068,8 +1068,8 @@ impl Widget for SpaceLobbyScreen {
                         self.update_children_in_space(cx, space_id, children);
                     }
 
-                    // Handle receiving top-level space details (join rule, member count).
-                    Some(SpaceRoomListAction::TopLevelSpaceDetails(sr))
+                    // Handle receiving space details (join rule, member count).
+                    Some(SpaceRoomListAction::SpaceDetails(sr))
                         if self.space_name_id.as_ref().is_some_and(|sni| sni.room_id() == &sr.room_id) =>
                     {
                         self.space_avatar_state = AvatarState::Known(sr.avatar_url.clone());
@@ -1764,6 +1764,14 @@ impl SpaceLobbyScreen {
         // If this space is already being displayed, then update its name here in case it changed.
         if self.space_name_id.as_ref().is_some_and(|sni| sni.room_id() == space_name_id.room_id()) {
             self.space_name_id = Some(space_name_id.clone());
+            // Only request if the details never arrived (after we previously requested it).
+            if matches!(self.space_avatar_state, AvatarState::Unknown)
+                && let Some(sender) = &self.space_request_sender
+            {
+                let _ = sender.send(SpaceRequest::GetSpaceDetails {
+                    space_id: space_name_id.room_id().clone(),
+                });
+            }
             return;
         }
 
@@ -1779,7 +1787,7 @@ impl SpaceLobbyScreen {
                 space_id: space_name_id.room_id().clone(),
                 parent_chain: parent_chain_opt.unwrap_or_default(),
             });
-            let _ = sender.send(SpaceRequest::GetTopLevelSpaceDetails {
+            let _ = sender.send(SpaceRequest::GetSpaceDetails {
                 space_id: space_name_id.room_id().clone(),
             });
             self.space_request_sender = Some(sender);
@@ -1788,6 +1796,8 @@ impl SpaceLobbyScreen {
         // Clear the main content until we receive the async space info responses.
         self.tree_entries.clear();
         self.view.label(cx, ids!(header.space_info_row.space_info_label)).set_text(cx, "");
+        // Also clear the avatar, so we don't show the previous space's avatar.
+        self.space_avatar_state = AvatarState::Unknown;
         self.is_loading = true;
 
         // Clear the filter bar when switching to a new space.

--- a/src/home/spaces_bar.rs
+++ b/src/home/spaces_bar.rs
@@ -1,5 +1,5 @@
-//! The SpacesBar shows a scrollable strip of avatars,
-//! one per space that the user has currently joined.
+//! The SpacesBar shows a scrollable strip of avatars: first the spaces that the
+//! user has been invited to, then the spaces they have currently joined.
 //!
 //! Like the NavigationTabBar, this widget uses AdaptiveView to show:
 //! 1. a narrow vertical strip, when in Desktop (widescreen) mode,
@@ -7,13 +7,15 @@
 
 use std::{borrow::Cow, collections::HashMap};
 
+use indexmap::IndexMap;
+
 use crossbeam_queue::SegQueue;
 use makepad_widgets::*;
 use matrix_sdk::{RoomDisplayName, RoomState};
 use ruma::{OwnedRoomAliasId, OwnedRoomId, room::JoinRuleSummary};
 
 use crate::{
-    app::AppStateAction, home::navigation_tab_bar::{NavigationBarAction, SelectedTab}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria}}, settings::app_preferences::{AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction}, utils::{self, RoomNameId}
+    app::AppStateAction, home::{navigation_tab_bar::{NavigationBarAction, SelectedTab}, rooms_list::get_invited_rooms}, logout::logout_confirm_modal::LogoutAction, room::{FetchedRoomAvatar, room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria, SortFn}}, settings::app_preferences::{AppPreferencesAction, ViewModeOverride}, shared::{avatar::AvatarWidgetExt, navigation_bar_button::NavigationBarButton, room_filter_input_bar::MainFilterAction, unread_badge::UnreadBadgeWidgetExt as _}, utils::{self, RoomNameId}
 };
 
 script_mod! {
@@ -39,6 +41,8 @@ script_mod! {
         padding: 4,
         margin: 2,
         align: Align{x: 0.5, y: 0.5}
+        // Don't clip (cut-off) the invite badge's glow
+        clip_x: false, clip_y: false
 
         avatar := Avatar {
             width: mod.widgets.NAVIGATION_TAB_BAR_AVATAR_SIZE
@@ -67,6 +71,16 @@ script_mod! {
             draw_text +: {
                 color: (COLOR_NAVIGATION_TAB_FG)
                 text_style: REGULAR_TEXT {font_size: 9}
+            }
+        }
+
+        // Places an unread badge at the top-right of the spaces bar entry/avatar.
+        View {
+            width: Fill, height: Fill
+            align: Align{x: 1.0, y: 0.0}
+            clip_x: false, clip_y: false
+            invite_badge := UnreadBadge {
+                margin: Inset{ top: -2, right: -5 }
             }
         }
     }
@@ -150,6 +164,8 @@ script_mod! {
 pub enum SpacesBarAction {
     /// The user primary-clicked/tapped a space entry in the SpacesBar.
     ButtonClicked { space_name_id: RoomNameId },
+    /// The user clicked a space they've been invited to but haven't joined yet.
+    InvitedSpaceClicked { space_name_id: RoomNameId },
     /// The user secondary-clicked/long-pressed a space entry in the SpacesBar.
     ButtonSecondaryClicked { space_name_id: RoomNameId },
     #[default]
@@ -169,6 +185,7 @@ pub struct SpacesBarEntry {
 
     #[rust] space_name_id: Option<RoomNameId>,
     #[rust] last_avatar: Option<FetchedRoomAvatar>,
+    #[rust] is_invited: bool,
 }
 
 impl Widget for SpacesBarEntry {
@@ -185,7 +202,10 @@ impl Widget for SpacesBarEntry {
                 if let Some(space_name_id) = self.space_name_id.clone() {
                     cx.widget_action(
                         self.widget_uid(),
-                        SpacesBarAction::ButtonClicked { space_name_id },
+                        match self.is_invited {
+                            true => SpacesBarAction::InvitedSpaceClicked { space_name_id },
+                            false => SpacesBarAction::ButtonClicked { space_name_id },
+                        },
                     );
                 }
             }
@@ -212,6 +232,7 @@ impl SpacesBarEntry {
         space_name_id: RoomNameId,
         avatar: &FetchedRoomAvatar,
         is_selected: bool,
+        is_invited: bool,
     ) {
         let space_name = space_name_id.display();
         // The name label isn't visible by default, but we populate it anyway.
@@ -236,8 +257,13 @@ impl SpacesBarEntry {
             self.last_avatar = Some(avatar.clone());
         }
 
+        self.inner.view
+            .unread_badge(cx, ids!(invite_badge))
+            .update_counts(false, is_invited as u64, 0);
+
         self.inner.set_tooltip_text(space_name);
         self.space_name_id = Some(space_name_id);
+        self.is_invited = is_invited;
         self.inner.set_selected(cx, is_selected);
     }
 }
@@ -249,9 +275,10 @@ impl SpacesBarEntryRef {
         space_name_id: RoomNameId,
         avatar: &FetchedRoomAvatar,
         is_selected: bool,
+        is_invited: bool,
     ) {
         let Some(mut inner) = self.borrow_mut() else { return };
-        inner.set_metadata(cx, space_name_id, avatar, is_selected);
+        inner.set_metadata(cx, space_name_id, avatar, is_selected, is_invited);
     }
 }
 
@@ -274,6 +301,11 @@ pub struct JoinedSpaceInfo {
     pub guest_can_join: bool,
     /// The number of children rooms this space has.
     pub children_count: u64,
+}
+
+struct InvitedSpaceInfo {
+    space_name_id: RoomNameId,
+    space_avatar: FetchedRoomAvatar,
 }
 
 
@@ -341,6 +373,8 @@ pub enum SpacesListUpdate {
     ClearSpaces,
     /// Scroll to the given space.
     ScrollToSpace(OwnedRoomId),
+    /// The set of invited rooms changed, so we need to re-generate the list of invited spaces.
+    InvitedSpacesChanged,
 }
 
 
@@ -362,22 +396,30 @@ pub fn enqueue_spaces_list_update(update: SpacesListUpdate) {
 pub struct SpacesBar {
     #[deref] view: AdaptiveView,
 
-    /// The set of all joined spaces, keyed by the space ID.
-    #[rust] all_joined_spaces: HashMap<OwnedRoomId, JoinedSpaceInfo>,
+    /// The set of all joined spaces, keyed by space ID, with homeserver-based ordering.
+    ///
+    /// In the future we could allow the user to re-order this arbitrarily, or apply a sort fn.
+    #[rust] all_joined_spaces: IndexMap<OwnedRoomId, JoinedSpaceInfo>,
 
     /// The currently-active filter function for the list of spaces.
     ///
     /// Note: for performance reasons, this does not get automatically applied
-    /// when its value changes. Instead, you must manually invoke it on the set of `all_joined_spaces`
-    /// in order to update the set of `displayed_spaces` accordingly.
+    /// when its value changes. Instead, you must manually invoke it on the set of
+    /// `all_joined_spaces` in order to re-generate the set of `displayed_joined_spaces`.
     #[rust] display_filter: RoomDisplayFilter,
 
-    /// The list of spaces currently displayed in the UI, in order from top to bottom.
-    /// This is a strict subset of the rooms in `all_joined_spaces`, and should be determined
-    /// by applying the `display_filter` to the set of `all_joined_spaces`.
-    #[rust] displayed_spaces: Vec<OwnedRoomId>,
+    /// The joined spaces currently displayed, in `all_joined_spaces` order.
+    ///
+    /// See `regenerate_displayed_joined_spaces()` for how this is populated.
+    #[rust] displayed_joined_spaces: Vec<OwnedRoomId>,
 
-    /// Whether the list of `displayed_spaces` is currently filtered:
+    /// The sort applied to `displayed_joined_spaces` by the current search filter, if any.
+    #[rust] sort_fn: Option<Box<SortFn>>,
+
+    /// Spaces the user has been invited to, shown in front of `displayed_joined_spaces`.
+    #[rust] displayed_invited_spaces: Vec<InvitedSpaceInfo>,
+
+    /// Whether the list of `displayed_joined_spaces` is currently filtered:
     /// `true` if filtered, `false` if showing everything.
     #[rust] is_filtered: bool,
 
@@ -410,7 +452,7 @@ impl Widget for SpacesBar {
                 // Only handle filter changes from the home screen's filter bar,
                 // not from any other RoomFilterInputBar instance (e.g., SpaceLobbyScreen's).
                 if let Some(MainFilterAction::Changed(keywords)) = action.downcast_ref() {
-                    self.update_displayed_spaces(cx, keywords);
+                    self.update_displayed_joined_spaces(cx, keywords);
                     continue;
                 }
 
@@ -421,6 +463,9 @@ impl Widget for SpacesBar {
                     cx.action(NavigationBarAction::GoToSpace { space_name_id });
                     continue;
                 }
+
+                // Note: `SpacesBarAction::InvitedSpaceClicked` is not handled here.
+                // The MainDesktopUI and HomeScreen handle that action.
 
                 // If another widget programmatically selected a new tab,
                 // we must unselect/deselect the currently-selected space.
@@ -450,7 +495,8 @@ impl Widget for SpacesBar {
                 // Clear widget state upon logout.
                 if let Some(LogoutAction::ClearAppState { .. }) = action.downcast_ref() {
                     self.all_joined_spaces.clear();
-                    self.displayed_spaces.clear();
+                    self.displayed_joined_spaces.clear();
+                    self.displayed_invited_spaces.clear();
                     self.display_filter = Default::default();
                     self.selected_space = None;
                     self.is_filtered = false;
@@ -472,7 +518,8 @@ impl Widget for SpacesBar {
             let is_desktop = self.view.active_variant() == Some(live_id!(Desktop));
             list.set_flow(cx, if is_desktop { Flow::Down } else { Flow::right() });
 
-            let len = self.displayed_spaces.len();
+            let num_invited = self.displayed_invited_spaces.len();
+            let len = num_invited + self.displayed_joined_spaces.len();
             if len == 0 {
                 list.set_item_range(cx, 0, 1);
                 while let Some(portal_list_index) = list.next_visible_item(cx) {
@@ -496,8 +543,19 @@ impl Widget for SpacesBar {
             else {
                 list.set_item_range(cx, 0, len + 1);
                 while let Some(portal_list_index) = list.next_visible_item(cx) {
-                    let item = if let Some(space) = self.displayed_spaces
-                        .get(portal_list_index)
+                    let item = if let Some(invite) = self.displayed_invited_spaces.get(portal_list_index) {
+                        let item = list.item(cx, portal_list_index, id!(spaces_bar_entry));
+                        item.as_spaces_bar_entry().set_metadata(
+                            cx,
+                            invite.space_name_id.clone(),
+                            &invite.space_avatar,
+                            false,
+                            true,
+                        );
+                        item
+                    }
+                    else if let Some(space) = portal_list_index.checked_sub(num_invited)
+                        .and_then(|index| self.displayed_joined_spaces.get(index))
                         .and_then(|space_id| self.all_joined_spaces.get(space_id))
                     {
                         let item = list.item(cx, portal_list_index, id!(spaces_bar_entry));
@@ -506,19 +564,21 @@ impl Widget for SpacesBar {
                             space.space_name_id.clone(),
                             &space.space_avatar,
                             self.selected_space.as_ref().is_some_and(|id| id == space.space_name_id.room_id()),
+                            false,
                         );
                         item
                     }
                     else if portal_list_index == len {
                         let item = list.item(cx, portal_list_index, id!(StatusLabel));
+                        let num_joined = self.displayed_joined_spaces.len();
                         let text: Cow<'static, str> = if self.is_filtered {
                             let total = self.all_joined_spaces.len();
-                            format!("{len} of {total} spaces").into()
+                            format!("{num_joined} of {total} spaces").into()
                         } else {
-                            match len {
+                            match num_joined {
                                 0   => "Found no joined spaces.".into(),
                                 1   => "Found 1 joined space.".into(),
-                                2.. => format!("Found {len} joined spaces.").into(),
+                                2.. => format!("Found {num_joined} joined spaces.").into(),
                             }
                         };
                         item.label(cx, ids!(label)).set_text(cx, &text);
@@ -539,50 +599,37 @@ impl Widget for SpacesBar {
 impl SpacesBar {
      /// Handle all pending updates to the spaces list.
     fn handle_spaces_list_updates(&mut self, cx: &mut Cx, _event: &Event, _scope: &mut Scope) {
-
-        fn adjust_displayed_spaces(
-            was_displayed: bool,
-            should_display: bool,
-            space_id: OwnedRoomId,
-            displayed_spaces: &mut Vec<OwnedRoomId>,
-        ) {
-            match (was_displayed, should_display) {
-                // No need to update anything
-                (true, true) | (false, false) => { }
-                // Space was displayed but should no longer be displayed.
-                (true, false) => {
-                    displayed_spaces.iter()
-                        .position(|s| s == &space_id)
-                        .map(|index| displayed_spaces.remove(index));
-                }
-                // Space was not displayed but should now be displayed.
-                (false, true) => {
-                    displayed_spaces.push(space_id);
-                }
-            }
-        }
-
+        // The matrix SDK frequently issues `Clear` + `Append` updates in one batch,
+        // so we optimize for that. One thing we do is save avatars across a Clear + Append
+        // to avoid briefly flickering between the placeholder text avatar and the space's real avatar image.
+        let mut cleared_space_avatars: HashMap<OwnedRoomId, FetchedRoomAvatar> = HashMap::new();
 
         let mut num_updates: usize = 0;
+        let mut should_regenerate_displayed_spaces = false;
+        let mut scroll_to_space: Option<OwnedRoomId> = None;
         while let Some(update) = PENDING_SPACE_UPDATES.pop() {
             num_updates += 1;
             match update {
-                SpacesListUpdate::AddJoinedSpace(joined_space) => {
+                SpacesListUpdate::AddJoinedSpace(mut joined_space) => {
                     let space_id = joined_space.space_name_id.room_id().clone();
-                    let should_display = (self.display_filter)(&joined_space);
-                    let replaced = self.all_joined_spaces.insert(space_id.clone(), joined_space);
-                    // if we got a new space that has the same ID as one that already existed,
-                    // that just means its data was updated and we need to re-evaluate whether to display it.
-                    let was_displayed = replaced.is_some_and(|old| { (self.display_filter)(&old) });
-                    adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
+                    if let FetchedRoomAvatar::Text(_) = joined_space.space_avatar
+                        && let Some(FetchedRoomAvatar::Image(image)) = self.all_joined_spaces
+                            .get(&space_id)
+                            .map(|s| &s.space_avatar)
+                            // If a space got re-added (e.g., for ordering changes),
+                            // try to recover its avatar from the known spaces (from before this update batch).
+                            .or_else(|| cleared_space_avatars.get(&space_id))
+                    {
+                        joined_space.space_avatar = FetchedRoomAvatar::Image(image.clone());
+                    }
+                    self.all_joined_spaces.insert(space_id, joined_space);
+                    should_regenerate_displayed_spaces = true;
                 }
 
                 SpacesListUpdate::UpdateCanonicalAlias { space_id, new_canonical_alias } => {
                     if let Some(space) = self.all_joined_spaces.get_mut(&space_id) {
-                        let was_displayed = (self.display_filter)(space);
                         space.canonical_alias = new_canonical_alias;
-                        let should_display = (self.display_filter)(space);
-                        adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
+                        should_regenerate_displayed_spaces = true;
                     } else {
                         error!("Error: couldn't find space {space_id} to update space canonical alias");
                     }
@@ -590,14 +637,12 @@ impl SpacesBar {
 
                 SpacesListUpdate::UpdateSpaceName { space_id, new_space_name } => {
                     if let Some(space) = self.all_joined_spaces.get_mut(&space_id) {
-                        let was_displayed = (self.display_filter)(space);
                         space.space_name_id = RoomNameId::new(
                             RoomDisplayName::Named(new_space_name),
                             space_id.clone(),
                         );
                         cx.action(AppStateAction::RoomNameUpdated(space.space_name_id.clone()));
-                        let should_display = (self.display_filter)(space);
-                        adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
+                        should_regenerate_displayed_spaces = true;
                     } else {
                         error!("Error: couldn't find space {space_id} to update space name");
                     }
@@ -606,10 +651,7 @@ impl SpacesBar {
                 SpacesListUpdate::UpdateSpaceTopic { space_id, topic } => {
                     if let Some(space) = self.all_joined_spaces.get_mut(&space_id) {
                         // We don't currently support filtering by topic.
-                        // let was_displayed = (self.display_filter)(space);
                         space.topic = topic;
-                        // let should_display = (self.display_filter)(space);
-                        // adjust_displayed_spaces(was_displayed, should_display, space_id, &mut self.displayed_spaces);
                     } else {
                         error!("Error: couldn't find space {space_id} to update space topic");
                     }
@@ -664,67 +706,95 @@ impl SpacesBar {
                 }
 
                 SpacesListUpdate::RemoveSpace { space_id, .. } => {
-                    self.all_joined_spaces.remove(&space_id);
-                    adjust_displayed_spaces(true, false, space_id, &mut self.displayed_spaces);
+                    // Use `shift_remove` instead of `remove` to preserve the spaces' relative ordering
+                    self.all_joined_spaces.shift_remove(&space_id);
+                    should_regenerate_displayed_spaces = true;
                 }
 
                 SpacesListUpdate::ClearSpaces => {
-                    self.all_joined_spaces.clear();
-                    self.displayed_spaces.clear();
+                    cleared_space_avatars.extend(
+                        self.all_joined_spaces.drain(..)
+                            .map(|(space_id, space)| (space_id, space.space_avatar))
+                    );
+                    should_regenerate_displayed_spaces = true;
+                }
+
+                SpacesListUpdate::InvitedSpacesChanged => {
+                    self.regenerate_invited_spaces(cx);
                 }
 
                 SpacesListUpdate::ScrollToSpace(space_id) => {
-                    if let Some(index) = self.displayed_spaces.iter().position(|s| s == &space_id) {
-                        let portal_list = self.view.portal_list(cx, ids!(spaces_list));
-                        let speed = 40.0;
-                        portal_list.smooth_scroll_to(cx, index, speed, Some(10), 10.0);
-                    }
+                    // Wait until we've handled all updates such that we scroll to the
+                    // final position of the target space.
+                    scroll_to_space = Some(space_id);
                 }
             }
+        }
+        if should_regenerate_displayed_spaces {
+            self.regenerate_displayed_joined_spaces();
+        }
+        if let Some(index) = scroll_to_space.and_then(|space_id|
+            self.displayed_joined_spaces.iter().position(|s| s == &space_id)
+        ) {
+            // account for invited spaces at the beginning
+            let index = index + self.displayed_invited_spaces.len();
+            let speed = 40.0;
+            self.view.portal_list(cx, ids!(spaces_list))
+                .smooth_scroll_to(cx, index, speed, Some(10), 10.0);
         }
         if num_updates > 0 {
             self.redraw(cx);
         }
     }
 
+    /// Re-generates the list of `displayed_joined_spaces` from `all_joined_spaces`,
+    /// applying the `display_filter` and the `sort_fn`, if one is set.
+    fn regenerate_displayed_joined_spaces(&mut self) {
+        self.displayed_joined_spaces = self.all_joined_spaces.iter()
+            .filter(|(_, space)| (self.display_filter)(*space))
+            .map(|(space_id, _)| space_id.clone())
+            .collect();
+        if let Some(sort_fn) = self.sort_fn.as_deref() {
+            let spaces = &self.all_joined_spaces;
+            self.displayed_joined_spaces.sort_by(|a, b| sort_fn(&spaces[a], &spaces[b]));
+        }
+    }
+
+    /// Re-generates the invited spaces shown at the beginning of the spaces bar
+    /// using the invited rooms held by the rooms list.
+    fn regenerate_invited_spaces(&mut self, cx: &mut Cx) {
+        let invited_rooms = get_invited_rooms(cx);
+        let invited_rooms = invited_rooms.borrow();
+        self.displayed_invited_spaces = invited_rooms.values()
+            .filter(|invite| invite.is_space
+                && !self.all_joined_spaces.contains_key(invite.room_name_id.room_id())
+                && (self.display_filter)(*invite)
+            )
+            .map(|invite| InvitedSpaceInfo {
+                space_name_id: invite.room_name_id.clone(),
+                space_avatar: invite.room_avatar.clone(),
+            })
+            .collect();
+        // Use alphabetical ordering for invited spaces (HashMaps don't iterate predictably)
+        self.displayed_invited_spaces.sort_by(|a, b|
+            a.space_name_id.display().cmp(&b.space_name_id.display())
+                .then_with(|| a.space_name_id.room_id().cmp(b.space_name_id.room_id()))
+        );
+    }
 
     /// Updates the lists of displayed spaces based on the current search filter.
-    fn update_displayed_spaces(&mut self, cx: &mut Cx, keywords: &str) {
-        let portal_list = self.view.portal_list(cx, ids!(spaces_list));
-        if keywords.is_empty() {
-            // Reset each of the displayed_* lists to show all rooms.
-            self.is_filtered = false;
-            self.display_filter = RoomDisplayFilter::default();
-            self.displayed_spaces = self.all_joined_spaces.keys().cloned().collect();
-            portal_list.set_first_id_and_scroll(0, 0.0);
-            self.redraw(cx);
-            return;
-        }
-
-        // Create a new filter function based on the given keywords
-        // and store it in this RoomsList such that we can apply it to newly-added rooms.
-        let (filter, sort_fn) = RoomDisplayFilterBuilder::new()
-            .set_keywords(keywords.to_owned())
-            .set_filter_criteria(RoomFilterCriteria::All)
-            .build();
-        self.display_filter = filter;
-        self.is_filtered = true;
-
-        let filtered_spaces_iter = self.all_joined_spaces.iter()
-            .filter(|(_, space)| (self.display_filter)(*space));
-
-        self.displayed_spaces = if let Some(sort_fn) = sort_fn {
-            let mut filtered_spaces = filtered_spaces_iter
-                .collect::<Vec<_>>();
-            filtered_spaces.sort_by(|(_, space_a), (_, space_b)| sort_fn(*space_a, *space_b));
-            filtered_spaces
-                .into_iter()
-                .map(|(space_id, _)| space_id.clone()).collect()
-        } else {
-            filtered_spaces_iter.map(|(space_id, _)| space_id.clone()).collect()
+    fn update_displayed_joined_spaces(&mut self, cx: &mut Cx, keywords: &str) {
+        self.is_filtered = !keywords.is_empty();
+        (self.display_filter, self.sort_fn) = match self.is_filtered {
+            false => (RoomDisplayFilter::default(), None),
+            true => RoomDisplayFilterBuilder::new()
+                .set_keywords(keywords.to_owned())
+                .set_filter_criteria(RoomFilterCriteria::All)
+                .build(),
         };
-
-        portal_list.set_first_id_and_scroll(0, 0.0);
+        self.regenerate_displayed_joined_spaces();
+        self.regenerate_invited_spaces(cx);
+        self.view.portal_list(cx, ids!(spaces_list)).set_first_id_and_scroll(0, 0.0);
         self.redraw(cx);
     }
 }

--- a/src/logout/logout_confirm_modal.rs
+++ b/src/logout/logout_confirm_modal.rs
@@ -39,7 +39,7 @@ script_mod! {
                 padding: 12,
                 draw_icon.svg: (ICON_LOGOUT)
                 icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
-                text: "Logout Now"
+                text: "Log out now"
             }
         }
     }
@@ -267,7 +267,7 @@ impl LogoutConfirmModal {
         self.final_success = None;
         self.set_message(cx, "Are you sure you want to logout?");
         confirm_button.set_enabled(cx, true);
-        confirm_button.set_text(cx, "Logout Now");
+        confirm_button.set_text(cx, "Log out now");
         cancel_button.set_visible(cx, true);
         cancel_button.set_enabled(cx, true);
         cancel_button.set_text(cx, "Cancel");

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -3047,6 +3047,7 @@ struct RoomListServiceRoomInfo {
     room_id: OwnedRoomId,
     state: RoomState,
     is_direct: bool,
+    is_space: bool,
     is_marked_unread: bool,
     is_tombstoned: bool,
     is_encrypted: bool,
@@ -3085,7 +3086,7 @@ impl RoomListServiceRoomInfo {
             async {
                 if room.state() != RoomState::Invited { return None; }
                 let invite = room.invite_details().await
-                    .inspect_err(|e| error!("Couldn't obtain who invited us to room {}: {e}", room.room_id()))
+                    .inspect_err(|e| warning!("Couldn't obtain who invited us to room {}: {e}", room.room_id()))
                     .ok()?;
                 let inviter = invite.inviter;
                 Some(InviterInfo {
@@ -3100,6 +3101,7 @@ impl RoomListServiceRoomInfo {
             room_id: room.room_id().to_owned(),
             state: room.state(),
             is_direct: is_direct.unwrap_or(false),
+            is_space: room.is_space(),
             is_marked_unread: room.is_marked_unread(),
             is_tombstoned: room.is_tombstoned(),
             is_encrypted: room.encryption_state().is_encrypted(),
@@ -3528,12 +3530,16 @@ async fn room_list_service_loop(room_list_service: Arc<RoomListService>) -> Resu
         all_rooms_list.entries_with_dynamic_adapters(usize::MAX);
 
     // By default, our rooms list should only show rooms that are:
-    // 1. not spaces (those are handled by the SpaceService),
+    // 1. not spaces, except invited ones (joined spaces are handled by the SpaceService,
+    //    which can only ever see spaces we've already joined),
     // 2. not left (clients don't typically show rooms that the user has already left),
     // 3. not outdated (don't show tombstoned rooms whose successor is already joined).
     room_list_dynamic_entries_controller.set_filter(Box::new(
         filters::new_filter_all(vec![
-            Box::new(filters::new_filter_not(Box::new(filters::new_filter_space()))),
+            Box::new(filters::new_filter_any(vec![
+                Box::new(filters::new_filter_not(Box::new(filters::new_filter_space()))),
+                Box::new(filters::new_filter_invite()),
+            ])),
             Box::new(filters::new_filter_non_left()),
             Box::new(filters::new_filter_deduplicate_versions()),
         ])
@@ -3870,6 +3876,15 @@ async fn update_room(
             });
         }
 
+        // An invited room will often arrive before we get its room creation event,
+        // so we can't always know whether it's a space up front; we have to check on every update.
+        if old_room.is_space != new_room.is_space {
+            enqueue_rooms_list_update(RoomsListUpdate::UpdateIsSpace {
+                room_id: new_room_id.clone(),
+                is_space: new_room.is_space,
+            });
+        }
+
         // If we know anything new about the inviter, send it to the rooms list.
         if old_room.inviter_info != new_room.inviter_info
             && let Some(inviter_info) = new_room.inviter_info.clone()
@@ -4015,6 +4030,9 @@ fn remove_room(room: &RoomListServiceRoomInfo) {
         RoomsListUpdate::RemoveRoom {
             room_id: room.room_id.clone(),
             new_state: room.state,
+            // Re-obtain whether this room is a space,
+            // since it may have changed since the last sync.
+            is_space: room.room.is_space(),
         }
     );
 }
@@ -4057,6 +4075,7 @@ async fn add_new_room(
                 invite_state: Default::default(),
                 is_selected: false,
                 is_direct: new_room.is_direct,
+                is_space: new_room.is_space,
             }));
             Cx::post_action(AppStateAction::RoomLoadedSuccessfully {
                 room_name_id,
@@ -4066,6 +4085,8 @@ async fn add_new_room(
             spawn_fetch_room_avatar(new_room);
             return Ok(());
         }
+        // Joined spaces are handled by the SpaceService, so don't handle them here.
+        RoomState::Joined if new_room.is_space => return Ok(()),
         RoomState::Joined => { } // Fall through to adding the joined room below.
     }
 

--- a/src/space_service_sync.rs
+++ b/src/space_service_sync.rs
@@ -67,11 +67,17 @@ pub enum SpaceRequest {
         space_id: OwnedRoomId,
         parent_chain: ParentChain,
     },
-    /// Get full details about a top-level space.
+    /// Get full details about any joined space.
     ///
-    /// This will result in a [`SpaceRoomListAction::TopLevelSpaceDetails`] action being emitted.
-    GetTopLevelSpaceDetails {
+    /// This will result in a [`SpaceRoomListAction::SpaceDetails`] action being emitted.
+    GetSpaceDetails {
         space_id: OwnedRoomId,
+    },
+    /// Determine which top-level space's dock a newly-joined space's lobby belongs in.
+    ///
+    /// This will result in a [`SpaceRoomListAction::JoinedSpaceAncestor`] action being emitted.
+    ResolveJoinedSpaceAncestor {
+        space_name_id: RoomNameId,
     },
 }
 
@@ -141,7 +147,7 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
     enqueue_rooms_list_update(RoomsListUpdate::SpaceRequestSender(space_request_sender.clone()));
 
     // Create the actual space service.
-    let space_service = SpaceService::new(client.clone()).await;
+    let space_service = Arc::new(SpaceService::new(client.clone()).await);
 
     // The set of async tasks that are handling room list requests for each top-level joined space,
     // along with a sender to send `SpaceRoomListRequest`s to those tasks.
@@ -183,7 +189,7 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
     // Get the set of top-level (root) spaces that the user has joined.
     let (initial_spaces, mut spaces_diff_stream) = space_service.subscribe_to_top_level_joined_spaces().await;
     for space in &initial_spaces {
-        add_new_space(space, &client).await;
+        add_new_space(space, &client);
     }
     let mut all_joined_spaces: Vector<SpaceRoom> = initial_spaces;
     if LOG_SPACE_SERVICE_DIFFS { log!("space_service: initial set: {all_joined_spaces:?}"); }
@@ -263,12 +269,54 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
                         error!("BUG: failed to send GetDetailedChildren request to space room list loop for space {space_id}");
                     }
                 }
-                SpaceRequest::GetTopLevelSpaceDetails { space_id } => {
-                    if let Some(space) = all_joined_spaces.iter().find(|s| s.room_id == space_id) {
-                        Cx::post_action(SpaceRoomListAction::TopLevelSpaceDetails(space.clone()));
+                SpaceRequest::GetSpaceDetails { space_id } => {
+                    let space_opt = match all_joined_spaces.iter().find(|s| s.room_id == space_id) {
+                        Some(space) => Some(space.clone()),
+                        None => space_service.get_space_room(&space_id).await,
+                    };
+                    if let Some(space) = space_opt {
+                        Cx::post_action(SpaceRoomListAction::SpaceDetails(space));
                     } else {
-                        error!("GetSpaceDetails: space {space_id} not found in all_joined_spaces");
+                        error!("GetSpaceDetails: space {space_id} is unknown to the space service");
                     }
+                }
+                SpaceRequest::ResolveJoinedSpaceAncestor { space_name_id } => {
+                    let space_service = Arc::clone(&space_service);
+                    let client = client.clone();
+                    // this is potentially a long-running operation, so spawn it in a new task.
+                    Handle::current().spawn(async move {
+                        if !client.get_room(space_name_id.room_id())
+                            .is_some_and(|r| r.state() == RoomState::Joined)
+                        {
+                            log!("Space {space_name_id:?} was not actually joined, ignoring it.");
+                            return;
+                        }
+                        // This rebuilds the space graph from scratch, so it works for any space,
+                        // even those that aren't in `all_joined_spaces` yet.
+                        let top_level_spaces = space_service.top_level_joined_spaces().await;
+                        let mut dock_space = None;
+                        let mut current_id = space_name_id.room_id().clone();
+                        let mut visited = HashSet::new();
+                        while visited.insert(current_id.clone()) {
+                            if let Some(ancestor) = top_level_spaces.iter().find(|s| s.room_id == current_id) {
+                                dock_space = Some(RoomNameId::new(
+                                    matrix_sdk::RoomDisplayName::Named(ancestor.display_name.clone()),
+                                    ancestor.room_id.clone(),
+                                ));
+                                break;
+                            }
+                            // A space can have multiple parents, so we just pick the first one.
+                            let Some(parent) = space_service.joined_parents_of_child(&current_id)
+                                .await
+                                .into_iter()
+                                .next()
+                            else {
+                                break;
+                            };
+                            current_id = parent.room_id;
+                        }
+                        Cx::post_action(SpaceRoomListAction::JoinedSpaceAncestor { space_name_id, dock_space });
+                    });
                 }
             }
         }
@@ -284,7 +332,7 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
                     VectorDiff::Append { values: new_spaces } => {
                         if LOG_SPACE_SERVICE_DIFFS { log!("space_service: diff Append {}", new_spaces.len()); }
                         for new_space in new_spaces {
-                            add_new_space(&new_space, &client).await;
+                            add_new_space(&new_space, &client);
                             all_joined_spaces.push_back(new_space);
                         }
                     }
@@ -295,12 +343,12 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
                     }
                     VectorDiff::PushFront { value: new_space } => {
                         if LOG_SPACE_SERVICE_DIFFS { log!("space_service: diff PushFront"); }
-                        add_new_space(&new_space, &client).await;
+                        add_new_space(&new_space, &client);
                         all_joined_spaces.push_front(new_space);
                     }
                     VectorDiff::PushBack { value: new_space } => {
                         if LOG_SPACE_SERVICE_DIFFS { log!("space_service: diff PushBack"); }
-                        add_new_space(&new_space, &client).await;
+                        add_new_space(&new_space, &client);
                         all_joined_spaces.push_back(new_space);
                     }
                     remove_diff @ VectorDiff::PopFront => {
@@ -329,7 +377,7 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
                     }
                     VectorDiff::Insert { index, value: new_space } => {
                         if LOG_SPACE_SERVICE_DIFFS { log!("space_service: diff Insert at {index}"); }
-                        add_new_space(&new_space, &client).await;
+                        add_new_space(&new_space, &client);
                         all_joined_spaces.insert(index, new_space);
                     }
                     VectorDiff::Set { index, value: changed_space } => {
@@ -376,7 +424,7 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
                         }
                         enqueue_spaces_list_update(SpacesListUpdate::ClearSpaces);
                         for new_space in &new_spaces {
-                            add_new_space(new_space, &client).await;
+                            add_new_space(new_space, &client);
                         }
                         all_joined_spaces = new_spaces;
                     }
@@ -423,17 +471,9 @@ pub async fn space_service_loop(client: Client) -> anyhow::Result<()> {
 }
 
 
-async fn add_new_space(space: &SpaceRoom, client: &Client) {
-    let space_avatar_opt = if let Some(url) = &space.avatar_url {
-        fetch_space_avatar(url.clone(), client)
-            .await
-            .inspect_err(|e| error!("Failed to fetch avatar for new space {:?} ({}): {e}", space.display_name, space.room_id))
-            .ok()
-    } else { None };
-    let space_avatar = space_avatar_opt.unwrap_or_else(
-        || utils::avatar_from_room_name(Some(&space.display_name))
-    );
-
+fn add_new_space(space: &SpaceRoom, client: &Client) {
+    // Start with a text avatar and fetch the real one in the background, just like with rooms.
+    let space_avatar = utils::avatar_from_room_name(Some(&space.display_name));
     let jsi = JoinedSpaceInfo {
         space_name_id: RoomNameId::new(
             matrix_sdk::RoomDisplayName::Named(space.display_name.clone()),
@@ -452,6 +492,23 @@ async fn add_new_space(space: &SpaceRoom, client: &Client) {
     // Robrix might be showing an out-of-date name, so broadcast the new name.
     Cx::post_action(AppStateAction::RoomNameUpdated(jsi.space_name_id.clone()));
     enqueue_spaces_list_update(SpacesListUpdate::AddJoinedSpace(jsi));
+
+    // now that we've enqueued the `AddJoinedSpace` update, we can fetch its avatar.
+    if let Some(url) = space.avatar_url.clone() {
+        // Limit concurrent avatar fetches, just like in other cases.
+        static SPACE_AVATAR_FETCH_LIMIT: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(8);
+        let space_id = space.room_id.clone();
+        let space_display_name = space.display_name.clone();
+        let client2 = client.clone();
+        Handle::current().spawn(async move {
+            let Ok(_permit) = SPACE_AVATAR_FETCH_LIMIT.acquire().await else { return };
+            let Ok(avatar) = fetch_space_avatar(url, &client2)
+                .await
+                .inspect_err(|e| error!("Failed to fetch avatar for new space {space_display_name:?} ({space_id}): {e}"))
+                else { return };
+            enqueue_spaces_list_update(SpacesListUpdate::UpdateSpaceAvatar { space_id, avatar });
+        });
+    }
 }
 
 
@@ -545,12 +602,12 @@ async fn update_space(
                 }
                 Some(RoomState::Joined) => {
                     log!("update_space(): adding new Joined space: {:?} ({new_space_id})", new_space.display_name);
-                    add_new_space(new_space, client).await;
+                    add_new_space(new_space, client);
                     return;
                 }
                 Some(RoomState::Invited) => {
                     log!("update_space(): adding new Invited space: {:?} ({new_space_id})", new_space.display_name);
-                    add_new_space(new_space, client).await;
+                    add_new_space(new_space, client);
                     return;
                 }
                 Some(RoomState::Knocked) => {
@@ -654,7 +711,7 @@ async fn update_space(
             old_space.room_id, new_space_id,
         );
         remove_space(old_space);
-        add_new_space(new_space, client).await;
+        add_new_space(new_space, client);
     }
 }
 
@@ -899,10 +956,19 @@ pub enum SpaceRoomListAction {
         parent_chain: ParentChain,
         children: Vector<SpaceRoom>,
     },
-    /// Summary details about a single top-level space.
+    /// Summary details about a single joined space.
     ///
-    /// This is sent in response to a [`SpaceRequest::GetTopLevelSpaceDetails`] request.
-    TopLevelSpaceDetails(SpaceRoom),
+    /// This is sent in response to a [`SpaceRequest::GetSpaceDetails`] request.
+    SpaceDetails(SpaceRoom),
+    /// Which top-level space's dock a newly-joined space should be shown in
+    ///
+    /// This is sent in response to a [`SpaceRequest::ResolveJoinedSpaceAncestor`] request.
+    JoinedSpaceAncestor {
+        space_name_id: RoomNameId,
+        /// The top-level ancestor whose dock should host the lobby, which is
+        /// `space_name_id` itself when that space is top-level.
+        dock_space: Option<RoomNameId>,
+    },
     /// The result of a [`SpaceRequest::LeaveSpace`].
     LeaveSpaceResult {
         space_name_id: RoomNameId,
@@ -940,9 +1006,15 @@ impl std::fmt::Debug for SpaceRoomListAction {
                     .field("num_children", &children.len())
                     .finish()
             }
-            SpaceRoomListAction::TopLevelSpaceDetails(space) => {
-                f.debug_tuple("SpaceRoomListAction::TopLevelSpaceDetails")
+            SpaceRoomListAction::SpaceDetails(space) => {
+                f.debug_tuple("SpaceRoomListAction::SpaceDetails")
                     .field(space)
+                    .finish()
+            }
+            SpaceRoomListAction::JoinedSpaceAncestor { space_name_id, dock_space } => {
+                f.debug_struct("SpaceRoomListAction::JoinedSpaceAncestor")
+                    .field("space_name_id", space_name_id)
+                    .field("dock_space", dock_space)
                     .finish()
             }
             SpaceRoomListAction::LeaveSpaceResult { space_name_id, result } => {


### PR DESCRIPTION
Invited spaces were previously not shown at all... oops.

Now we show them both in the RoomsList's Invites section, and within
the spaces bar as a special entry.

There's lots of other infra added to ensure that the joined space
(after you accept the invite) is shown within the proper parent space,
or more specifically a top-level joined space that is an ancestor of
the newly-joined one. Key poitns here:
* The rooms list service filter now includes invited spaces.
* Spaces bar entries now have an unread badge on the top right, which is
  currently only used for invites but can be used for mentions in the future.
* IN the mobile view mode, upgrading an invite screen to a joined one was
  apparently broken, now it works as it used to.
* When adding a new space, we fetch the avatar asynchronously so that
  it doesn't hold up the whole space service sync loop.
* the Spaces Bar now maintains a consistent ordering via `IndexMap`.

Closes #1048