### PR TITLE
Show blocked users in settings, allow reject invite + block action

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The following table shows which host systems can currently be used to build Robr
 
 ## Known issues
  - Matrix-specific links (`https://matrix.to/...`) aren't fully handled in-app yet.
- - Ignoring/unignoring a user clears all timelines  (see: https://github.com/matrix-org/matrix-rust-sdk/issues/1703); the timeline will be re-filled gradually via back pagination, but the viewport position is not maintained.
 
 
 > [!IMPORTANT]
@@ -204,7 +203,7 @@ These are generally sorted in order of priority. If you're interested in helping
 - [x] SSO, other 3rd-party auth providers login screen: https://github.com/project-robius/robrix/issues/114
 - [x] Client logout, with server-side logout and app state reset: https://github.com/project-robius/robrix/pull/432
 - [x] Side panel showing detailed user profile info (click on their Avatar)
-- [x] Ignore and unignore users (see known issues)
+- [x] Ignore (block) and unignore (unblock) users
 - [x] Display read receipts besides messages: https://github.com/project-robius/robrix/pull/162
 - [x] Mention users within a room (or the whole `@room`): https://github.com/project-robius/robrix/issues/452
 - [x] Dedicated view of direct messages (DMs): https://github.com/project-robius/robrix/issues/139

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,7 @@ use makepad_widgets::*;
 use matrix_sdk::{RoomState, ruma::{OwnedEventId, OwnedRoomId, OwnedUserId, RoomId}};
 use serde::{Deserialize, Serialize};
 use crate::{
+    block_user_modal::{BlockUserModalAction, BlockUserModalWidgetRefExt},
     avatar_cache::clear_avatar_cache, room_preview_cache::clear_room_preview_cache, home::{
         event_source_modal::{EventSourceModalAction, EventSourceModalWidgetRefExt}, invite_modal::{InviteModalAction, InviteModalWidgetRefExt}, main_desktop_ui::MainDesktopUiAction, navigation_tab_bar::{NavigationBarAction, SelectedTab}, new_message_context_menu::NewMessageContextMenuWidgetRefExt, room_context_menu::RoomContextMenuWidgetRefExt, room_screen::{InviteAction, MessageAction, clear_timeline_states, invalidate_single_timeline_state}, rooms_list::{RoomsListAction, RoomsListRef, RoomsListUpdate, clear_all_invited_rooms, enqueue_rooms_list_update}
     }, join_leave_room_modal::{
@@ -127,6 +128,11 @@ script_mod! {
                         // A modal to confirm any deletion/removal action.
                         delete_confirmation_modal := Modal {
                             content := NegativeConfirmationModal {}
+                        }
+
+                        // A modal to confirm blocking or unblocking a user.
+                        block_user_modal := Modal {
+                            content := BlockUserModal {}
                         }
 
                         // A modal to preview and confirm file uploads.
@@ -451,6 +457,21 @@ impl MatchEvent for App {
                 _ => {}
             }
 
+            // Handle actions needed to open/close the block user modal.
+            match action.downcast_ref() {
+                Some(BlockUserModalAction::Open(request)) => {
+                    self.ui.block_user_modal(cx, ids!(block_user_modal.content))
+                        .set_info(cx, request.clone());
+                    self.ui.modal(cx, ids!(block_user_modal)).open(cx);
+                    continue;
+                }
+                Some(BlockUserModalAction::Close) => {
+                    self.ui.modal(cx, ids!(block_user_modal)).close(cx);
+                    continue;
+                }
+                _ => {}
+            }
+
             // Handle actions needed to open/close the join/leave room modal.
             match action.downcast_ref() {
                 Some(JoinLeaveRoomModalAction::Open { kind, show_tip }) => {
@@ -697,6 +718,7 @@ impl AppMain for App {
         crate::home::upload_progress::script_mod(vm);
         crate::room::script_mod(vm);
         crate::join_leave_room_modal::script_mod(vm);
+        crate::block_user_modal::script_mod(vm);
         crate::verification_modal::script_mod(vm);
         crate::profile::script_mod(vm);
         crate::home::script_mod(vm);

--- a/src/block_user_modal.rs
+++ b/src/block_user_modal.rs
@@ -1,0 +1,201 @@
+//! A confirmation modal for blocking or unblocking a user.
+
+use makepad_widgets::*;
+use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId};
+use crate::{home::rooms_list::{InviteState, set_invite_state}, sliding_sync::{MatrixRequest, submit_async_request}};
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+
+    mod.widgets.BlockUserModal = set_type_default() do #(BlockUserModal::register_widget(vm)) {
+        ..mod.widgets.SmallModal
+
+        title := ModalTitle {}
+
+        body := ModalBody {}
+
+        ModalBody {
+            margin: Inset{top: 15}
+            draw_text +: {
+                color: (COLOR_FG_DANGER_RED)
+            }
+            text: "Changing your blocked users will reload all room timelines from scratch. You may lose your viewing position in each room."
+        }
+
+        buttons_view := ModalButtonsRow {
+            cancel_button := RobrixNeutralIconButton {
+                width: 120,
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_CLOSE)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Cancel"
+            }
+
+            block_button := RobrixNegativeIconButton {
+                // Grows past 120 for the longer "Reject & Block" label.
+                width: Fit{min: FitBound.Abs(120)},
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Block"
+            }
+
+            unblock_button := RobrixPositiveIconButton {
+                visible: false,
+                width: Fit{min: FitBound.Abs(120)},
+                align: Align{x: 0.5, y: 0.5}
+                padding: 15,
+                draw_icon.svg: (ICON_CHECKMARK)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+                text: "Unblock"
+            }
+        }
+    }
+}
+
+/// A pending block/unblock action that the user must confirm.
+#[derive(Clone, Debug)]
+#[doc(alias("ignore", "unignore"))]
+pub struct BlockUserRequest {
+    pub user_id: OwnedUserId,
+    /// Shown in the prompt instead of the user ID, if known.
+    pub display_name: Option<String>,
+    /// Whether to block (`true`) or unblock (`false`) the user.
+    pub block: bool,
+    /// Also reject this user's pending invite to this room, if set.
+    pub reject_invite_to: Option<OwnedRoomId>,
+}
+impl BlockUserRequest {
+    /// Returns the name to show in the prompt, falling back to the user ID.
+    pub fn displayable_name(&self) -> &str {
+        self.display_name
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| self.user_id.as_str())
+    }
+}
+
+/// Actions handled by the parent widget of the [`BlockUserModal`].
+#[derive(Clone, Debug)]
+pub enum BlockUserModalAction {
+    /// The modal should be opened by its parent widget to confirm the given request.
+    Open(BlockUserRequest),
+    /// The user confirmed the request; the block, and any invite rejection, has been submitted.
+    Confirmed(BlockUserRequest),
+    /// The modal requested its parent widget to close it.
+    Close,
+}
+
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct BlockUserModal {
+    #[deref] view: View,
+    #[rust] request: Option<BlockUserRequest>,
+}
+
+impl Widget for BlockUserModal {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl WidgetMatchEvent for BlockUserModal {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        let cancel_clicked = self.view.button(cx, ids!(cancel_button)).clicked(actions);
+        if cancel_clicked
+            || actions.iter().any(|a| matches!(a.downcast_ref(), Some(ModalAction::Dismissed)))
+        {
+            self.request = None;
+            // Dismissing by clicking outside already closes the modal, and emitting
+            // `Close` for it would cause an infinite action loop.
+            if cancel_clicked {
+                cx.action(BlockUserModalAction::Close);
+            }
+            return;
+        }
+
+        let confirmed = self.view.button(cx, ids!(block_button)).clicked(actions)
+            || self.view.button(cx, ids!(unblock_button)).clicked(actions);
+        if !confirmed { return }
+        let Some(request) = self.request.take() else { return };
+
+        submit_async_request(MatrixRequest::BlockUser {
+            user_id: request.user_id.clone(),
+            block: request.block,
+        });
+        if let Some(room_id) = request.reject_invite_to.as_ref() {
+            submit_async_request(MatrixRequest::LeaveRoom { room_id: room_id.clone() });
+            set_invite_state(cx, room_id, InviteState::WaitingForLeaveResult);
+        }
+        cx.action(BlockUserModalAction::Confirmed(request));
+        cx.action(BlockUserModalAction::Close);
+    }
+}
+
+impl BlockUserModal {
+    fn set_info(&mut self, cx: &mut Cx, request: BlockUserRequest) {
+        let name = request.displayable_name();
+        let (title, body, confirm_text) = if request.reject_invite_to.is_some() {
+            (
+                "Reject this invite and block?",
+                format!(
+                    "Are you sure you want to reject this invite and block {name}?\n\n\
+                    You won't see any messages or invites from them in any room."
+                ),
+                "Reject & Block",
+            )
+        } else if request.block {
+            (
+                "Block this user?",
+                format!(
+                    "Are you sure you want to block {name}?\n\n\
+                    You won't see any messages or invites from them in any room."
+                ),
+                "Block",
+            )
+        } else {
+            (
+                "Unblock this user?",
+                format!(
+                    "Are you sure you want to unblock {name}?\n\n\
+                    You'll start seeing their messages and invites again."
+                ),
+                "Unblock",
+            )
+        };
+
+        self.view.label(cx, ids!(title)).set_text(cx, title);
+        self.view.label(cx, ids!(body)).set_text(cx, &body);
+
+        let block_button = self.view.button(cx, ids!(block_button));
+        block_button.set_visible(cx, request.block);
+        block_button.set_text(cx, confirm_text);
+        block_button.reset_hover(cx);
+
+        let unblock_button = self.view.button(cx, ids!(unblock_button));
+        unblock_button.set_visible(cx, !request.block);
+        unblock_button.set_text(cx, confirm_text);
+        unblock_button.reset_hover(cx);
+
+        self.view.button(cx, ids!(cancel_button)).reset_hover(cx);
+        self.request = Some(request);
+        self.redraw(cx);
+    }
+}
+
+impl BlockUserModalRef {
+    /// See [`BlockUserModal::set_info()`].
+    pub fn set_info(&self, cx: &mut Cx, request: BlockUserRequest) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.set_info(cx, request);
+    }
+}

--- a/src/home/invite_screen.rs
+++ b/src/home/invite_screen.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 use makepad_widgets::*;
 use matrix_sdk::{RoomState, ruma::OwnedRoomId};
 
-use crate::{app::AppStateAction, avatar_cache::{self, AvatarCacheEntry}, home::rooms_list::RoomsListRef, join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, room::{BasicRoomDetails, FetchedRoomAvatar}, shared::{avatar::AvatarWidgetRefExt, restore_status_view::RestoreStatusViewWidgetExt}, sliding_sync::{submit_async_request, MatrixRequest}, utils::{self, RoomNameId}};
+use crate::{app::AppStateAction, avatar_cache::{self, AvatarCacheEntry}, block_user_modal::{BlockUserModalAction, BlockUserRequest}, home::rooms_list::RoomsListRef, join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, room::{BasicRoomDetails, FetchedRoomAvatar}, shared::{avatar::AvatarWidgetRefExt, restore_status_view::RestoreStatusViewWidgetExt}, sliding_sync::{is_user_blocked, submit_async_request, MatrixRequest}, utils::{self, RoomNameId}};
 
 use super::rooms_list::{AcceptedInviteKind, InviteState, InviterInfo, RoomsListAction, get_invited_rooms, set_invite_state};
 
@@ -169,6 +169,17 @@ script_mod! {
                 icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
                 text: "Join Room"
             }
+        }
+
+        // Put this on its own row with a bit of vertical space above it
+        reject_and_block_button := RobrixNegativeIconButton {
+            visible: false,
+            align: Align{x: 0.5, y: 0.5}
+            margin: Inset{top: 25}
+            padding: 15,
+            draw_icon.svg: (ICON_FORBIDDEN)
+            icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1} }
+            text: "Reject & Block Sender"
         }
 
         completion_label := Label {
@@ -332,6 +343,17 @@ impl Widget for InviteScreen {
                     });
                 }
             }
+            // Blocking is a serious action, don't allow bypassing the confirmation modal
+            if let Some(inviter) = info.inviter.as_ref()
+                && self.view.button(cx, ids!(reject_and_block_button)).clicked(actions)
+            {
+                cx.action(BlockUserModalAction::Open(BlockUserRequest {
+                    user_id: inviter.user_id.clone(),
+                    display_name: inviter.display_name.clone(),
+                    block: true,
+                    reject_invite_to: Some(info.room_id().clone()),
+                }));
+            }
             if let Some(modifiers) = self.view.button(cx, ids!(accept_button)).clicked_modifiers(actions) {
                 if modifiers.shift {
                     submit_async_request(MatrixRequest::JoinRoom {
@@ -372,6 +394,13 @@ impl Widget for InviteScreen {
                         continue;
                     }
                     _ => {}
+                }
+
+                if let Some(BlockUserModalAction::Confirmed(request)) = action.downcast_ref() {
+                    if request.reject_invite_to.as_ref() == Some(info.room_id()) {
+                        self.invite_state = InviteState::WaitingForLeaveResult;
+                    }
+                    continue;
                 }
 
                 if let Some(JoinLeaveRoomModalAction::Close { room_id, .. }) = action.downcast_ref() {
@@ -480,35 +509,45 @@ impl Widget for InviteScreen {
         // Third, set the buttons' text based on the invite state.
         let cancel_button = self.view.button(cx, ids!(cancel_button));
         let accept_button = self.view.button(cx, ids!(accept_button));
+        let reject_and_block_button = self.view.button(cx, ids!(reject_and_block_button));
+        reject_and_block_button.set_visible(
+            cx,
+            info.inviter.as_ref().is_some_and(|i| !is_user_blocked(&i.user_id)),
+        );
         let join_text = match self.is_space { true => "Join Space", false => "Join Room" };
         match self.invite_state {
             InviteState::WaitingOnUserInput => {
                 cancel_button.set_enabled(cx, true);
                 accept_button.set_enabled(cx, true);
+                reject_and_block_button.set_enabled(cx, true);
                 cancel_button.set_text(cx, "Reject Invite");
                 accept_button.set_text(cx, join_text);
             }
             InviteState::WaitingForJoinResult => {
                 cancel_button.set_enabled(cx, false);
                 accept_button.set_enabled(cx, false);
+                reject_and_block_button.set_enabled(cx, false);
                 cancel_button.set_text(cx, "Reject Invite");
                 accept_button.set_text(cx, "Joining...");
             }
             InviteState::WaitingForLeaveResult => {
                 cancel_button.set_enabled(cx, false);
                 accept_button.set_enabled(cx, false);
+                reject_and_block_button.set_enabled(cx, false);
                 cancel_button.set_text(cx, "Rejecting...");
                 accept_button.set_text(cx, join_text);
             }
             InviteState::WaitingForJoinedRoom => {
                 cancel_button.set_enabled(cx, false);
                 accept_button.set_enabled(cx, false);
+                reject_and_block_button.set_enabled(cx, false);
                 cancel_button.set_text(cx, "Reject Invite");
                 accept_button.set_text(cx, "Joined!");
             }
             InviteState::RoomLeft => {
                 cancel_button.set_visible(cx, false);
                 accept_button.set_visible(cx, false);
+                reject_and_block_button.set_visible(cx, false);
                 self.view.label(cx, ids!(completion_label)).set_text(
                     cx,
                     "Invite successfully rejected. You may close this invite.",
@@ -579,6 +618,7 @@ impl InviteScreen {
         let accept_button = self.view.button(cx, ids!(accept_button));
         accept_button.set_visible(cx, true);
         accept_button.reset_hover(cx);
+        self.view.button(cx, ids!(reject_and_block_button)).reset_hover(cx);
         self.view.label(cx, ids!(completion_label)).set_text(cx, "");
         self.room_name_id = None;
         self.info = None;

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -1843,7 +1843,7 @@ impl RoomScreen {
                         jump_to_bottom_button.update_visibility(cx, true);
                     }
                     //
-                    // TODO: after an (un)ignore user event, all timelines are cleared. Handle that here.
+                    // TODO: after a user is (un)blocked, all timelines are cleared. Handle that here.
                     //
                     else {
                         // warning!("!!! Couldn't find new event with matching ID for ANY event currently visible in the portal list");

--- a/src/home/rooms_list.rs
+++ b/src/home/rooms_list.rs
@@ -33,6 +33,7 @@ use crate::{
         FetchedRoomAvatar,
         room_display_filter::{RoomDisplayFilter, RoomDisplayFilterBuilder, RoomFilterCriteria, SortFn},
     },
+    sliding_sync::BlockedUsersUpdated,
     shared::{
         collapsible_header::{CollapsibleHeaderAction, CollapsibleHeaderWidgetRefExt, HeaderCategory},
         jump_to_bottom_button::UnreadMessageCount,
@@ -172,12 +173,10 @@ pub enum RoomsListUpdate {
     AddJoinedRoom(JoinedRoomInfo),
     /// Clear all rooms in the list of all rooms.
     ClearRooms,
-    /// Update the latest event content and timestamp for the given room.
+    /// Update the preview of the latest event for the given room.
     UpdateLatestEvent {
         room_id: OwnedRoomId,
-        timestamp: MilliSecondsSinceUnixEpoch,
-        /// The Html-formatted text preview of the latest message.
-        latest_message_text: String,
+        latest: LatestEventPreview,
     },
     /// Update the number of unread messages and mentions for the given room.
     UpdateNumUnreadMessages {
@@ -321,6 +320,21 @@ impl ActionDefaultRef for RoomsListAction {
 }
 
 
+/// A preview of a room's latest event, as shown in its entry in the rooms list.
+#[derive(Debug)]
+pub struct LatestEventPreview {
+    /// The Html-formatted preview text, which includes the sender's display name.
+    pub text: String,
+    pub sender: Option<OwnedUserId>,
+    pub timestamp: MilliSecondsSinceUnixEpoch,
+}
+impl LatestEventPreview {
+    /// Returns whether this preview was sent by any of the given users.
+    pub fn was_sent_by_any(&self, users: &[OwnedUserId]) -> bool {
+        self.sender.as_ref().is_some_and(|s| users.contains(s))
+    }
+}
+
 /// UI-related info about a joined room.
 ///
 /// This includes info needed display a preview of that room in the RoomsList
@@ -343,8 +357,8 @@ pub struct JoinedRoomInfo {
     /// This includes things like is_favourite, is_low_priority,
     /// whether the room is a server notice room, etc.
     pub tags: Tags,
-    /// The timestamp and Html text content of the latest message in this room.
-    pub latest: Option<(MilliSecondsSinceUnixEpoch, String)>,
+    /// A preview of the latest message in this room.
+    pub latest: Option<LatestEventPreview>,
     /// The avatar for this room: either an array of bytes holding the avatar image
     /// or a string holding the first Unicode character of the room name.
     pub room_avatar: FetchedRoomAvatar,
@@ -835,9 +849,9 @@ impl RoomsList {
                     // Broadcast this to an already-open InviteScreen that might be showing this room.
                     cx.action(InviteScreenAction::InviterInfoUpdated { room_id, inviter_info });
                 }
-                RoomsListUpdate::UpdateLatestEvent { room_id, timestamp, latest_message_text } => {
+                RoomsListUpdate::UpdateLatestEvent { room_id, latest } => {
                     if let Some(room) = self.all_joined_rooms.get_mut(&room_id) {
-                        room.latest = Some((timestamp, latest_message_text));
+                        room.latest = Some(latest);
                     } else {
                         error!("Error: couldn't find room {room_id} to update latest event");
                     }
@@ -1649,6 +1663,17 @@ impl Widget for RoomsList {
 
                 if let Some(AppStateAction::FocusNone) = action.downcast_ref() {
                     self.set_current_active_room(cx, None);
+                    continue;
+                }
+
+                // If we just blocked a user, we don't want to show any message previews from them.
+                if let Some(BlockedUsersUpdated(blocked_users)) = action.downcast_ref() {
+                    for room in self.all_joined_rooms.values_mut() {
+                        if room.latest.as_ref().is_some_and(|l| l.was_sent_by_any(blocked_users)) {
+                            room.latest = None;
+                        }
+                    }
+                    self.redraw(cx);
                     continue;
                 }
 

--- a/src/home/rooms_list_entry.rs
+++ b/src/home/rooms_list_entry.rs
@@ -418,9 +418,9 @@ impl RoomsListEntryContent {
         self.view.label(cx, ids!(room_name)).set_text(cx, &room_info.room_name_id.display());
         let timestamp = self.view.label(cx, ids!(timestamp));
         let latest_message = self.view.html_or_plaintext(cx, ids!(latest_message));
-        if let Some((ts, msg)) = room_info.latest.as_ref() {
-            timestamp.set_text(cx, relative_format(*ts).as_deref().unwrap_or(""));
-            latest_message.show_html(cx, msg);
+        if let Some(latest) = room_info.latest.as_ref() {
+            timestamp.set_text(cx, relative_format(latest.timestamp).as_deref().unwrap_or(""));
+            latest_message.show_html(cx, &latest.text);
         } else {
             timestamp.set_text(cx, "");
             latest_message.show_plaintext(cx, "[No recent messages]");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ pub mod profile;
 mod verification_modal;
 /// A modal/dialog popup for joining/leaving rooms, including confirming invite accept/reject.
 mod join_leave_room_modal;
+/// A modal/dialog popup for confirming that a user should be blocked or unblocked.
+pub mod block_user_modal;
 /// Shared UI components.
 pub mod shared;
 /// Generating text previews of timeline events/messages.

--- a/src/profile/user_profile.rs
+++ b/src/profile/user_profile.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, ops::{Deref, DerefMut}};
 use makepad_widgets::*;
 use matrix_sdk::{room::{RoomMember, RoomMemberRole}, ruma::{events::room::member::MembershipState, OwnedRoomId, OwnedUserId}};
 use crate::{
-    avatar_cache, shared::{avatar::{AvatarState, AvatarWidgetExt}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, current_user_id, is_user_ignored, submit_async_request}, utils
+    avatar_cache, block_user_modal::{BlockUserModalAction, BlockUserRequest}, shared::{avatar::{AvatarState, AvatarWidgetExt}, popup_list::{PopupKind, enqueue_popup_notification}}, sliding_sync::{MatrixRequest, current_user_id, is_user_blocked, submit_async_request}, utils
 };
 use super::user_profile_cache;
 
@@ -205,12 +205,12 @@ script_mod! {
                 text: "Jump to Read Receipt"
             }
 
-            ignore_user_button := RobrixNegativeIconButton {
+            block_user_button := RobrixNegativeIconButton {
                 padding: Inset{top: 10, bottom: 10, left: 12, right: 15}
                 margin: 0,
                 draw_icon.svg: (ICON_FORBIDDEN)
                 icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -0.5} }
-                text: "Ignore (Block) User"
+                text: "Block User"
             }
         }
 
@@ -391,6 +391,9 @@ impl Widget for UserProfileSlidingPane {
             self.redraw(cx);
             return;
         }
+        // While the pane is sliding out, don't handle any events/hits,
+        // as those hits are likely intended for a different widget.
+        if self.is_animating_out { return; }
 
         let area = self.view.area();
 
@@ -506,23 +509,19 @@ impl Widget for UserProfileSlidingPane {
                 return;
             }
 
-            // The `ignore_user_button` require room membership info.
-            if let Some(room_member) = info.room_member.as_ref() {
-                if self.button(cx, ids!(ignore_user_button)).clicked(actions) {
-                    // `room_member.is_ignored()` doesn't auto-update or sync, it's just a "snapshot",
-                    // so we can't rely on it until a full homeserver sync occurs.
-                    // Thus we just track the ignore state ourselves.
-                    let is_ignored = is_user_ignored(room_member.user_id());
-                    submit_async_request(MatrixRequest::IgnoreUser {
-                        ignore: !is_ignored,
-                        user_id: info.user_id.clone(),
-                        room_id: info.room_id.clone(),
-                    });
-                    log!("Submitting request to {}ignore user {}.",
-                        if is_ignored { "un" } else { "" },
-                        info.user_id,
-                    );
-                }
+            if !self.is_animating_out && self.button(cx, ids!(block_user_button)).clicked(actions) {
+                let request = BlockUserRequest {
+                    user_id: info.user_id.clone(),
+                    display_name: info.username.clone(),
+                    block: !is_user_blocked(&info.user_id),
+                    reject_invite_to: None,
+                };
+                // Hide the pane immediately to make room for the confirmation modal
+                self.is_animating_out = true;
+                cx.revert_key_focus();
+                self.animator_play(cx, ids!(panel.hide));
+                cx.action(BlockUserModalAction::Open(request));
+                self.redraw(cx);
             }
         }
     }
@@ -573,24 +572,23 @@ impl Widget for UserProfileSlidingPane {
         //    since you cannot direct message yourself.
         // * `copy_link_to_user_button` is always enabled with the same text.
         // * `jump_to_read_receipt_button` is always shown with the same text.
-        // * `ignore_user_button` is hidden if the user is not a member of the room,
-        //    or if the user is the same as the account user, since you cannot ignore yourself.
-        //    * The button text changes to "Unignore" if the user is already ignored.
+        // * `block_user_button` is hidden if the user is the same as the account user,
+        //    since you cannot block yourself.
+        //    * The button text changes to "Unblock" if the user is already blocked.
         let is_pane_showing_current_account = info.room_member.as_ref()
             .map(|rm| rm.is_account_user())
             .unwrap_or_else(|| current_user_id().is_some_and(|uid| uid == info.user_id));
 
         self.button(cx, ids!(direct_message_button)).set_visible(cx, !is_pane_showing_current_account);
 
-        let ignore_user_button = self.button(cx, ids!(ignore_user_button));
-        ignore_user_button.set_visible(cx, !is_pane_showing_current_account && info.room_member.is_some());
+        let block_user_button = self.button(cx, ids!(block_user_button));
+        block_user_button.set_visible(cx, !is_pane_showing_current_account);
         // Unfortunately the Matrix SDK's RoomMember type does not properly track
-        // the `ignored` state of a user, so we have to maintain it separately.
-        let is_ignored = info.room_member.as_ref()
-            .is_some_and(|rm| is_user_ignored(rm.user_id()));
-        ignore_user_button.set_text(
+        // the blocked state of a user, so we have to maintain it separately.
+        let is_blocked = is_user_blocked(&info.user_id);
+        block_user_button.set_text(
             cx,
-            if is_ignored { "Unignore (Unblock) User" } else { "Ignore (Block) User" }
+            if is_blocked { "Unblock User" } else { "Block User" }
         );
 
         self.view.draw_walk(cx, scope, walk)
@@ -664,7 +662,7 @@ impl UserProfileSlidingPane {
         self.view.button(cx, ids!(direct_message_button)).reset_hover(cx);
         self.view.button(cx, ids!(copy_link_to_user_button)).reset_hover(cx);
         self.view.button(cx, ids!(jump_to_read_receipt_button)).reset_hover(cx);
-        self.view.button(cx, ids!(ignore_user_button)).reset_hover(cx);
+        self.view.button(cx, ids!(block_user_button)).reset_hover(cx);
         self.redraw(cx);
     }
 }

--- a/src/room/room_input_bar.rs
+++ b/src/room/room_input_bar.rs
@@ -24,7 +24,7 @@ use matrix_sdk::room::reply::{EnforceThread, Reply};
 use ruma::events::room::message::AddMentions;
 use matrix_sdk_ui::timeline::{EmbeddedEvent, EventTimelineItem, TimelineEventItemId};
 use ruma::{events::room::message::{LocationMessageEventContent, MessageType, ReplyWithinThread, RoomMessageEventContent}, OwnedEventId, OwnedRoomId, OwnedTransactionId};
-use crate::{home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt, EditingPaneWidgetRefExt}, location_preview::{LocationPreviewWidgetExt, LocationPreviewWidgetRefExt}, room_screen::{MessageAction, populate_preview_of_timeline_item}, rooms_list::RoomsListRef, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}, upload_progress::{UploadProgressViewWidgetRefExt, UploadState}}, join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, location::init_location_subscriber, profile::user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId}, room::BasicRoomDetails, settings::app_preferences::{AppPreferencesAction, AppPreferencesGlobal}, shared::{avatar::{AvatarState, AvatarWidgetRefExt}, file_upload_modal::{AttachmentUpload, FileUploadAttemptId, PendingUpload, handle_picked_file, handle_picker_launch_errors}, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::{MentionableTextInputWidgetExt, MentionableTextInputWidgetRefExt, MentionableTextInputState}, popup_list::{PopupKind, enqueue_popup_notification}, room_input_popup_menu::RoomInputPopupMenuAction, slash_commands::{SlashCommandAction, SlashCommandOutcome}, styles::*}, sliding_sync::{MatrixRequest, TimelineKind, UserPowerLevels, submit_async_request}, utils};
+use crate::{block_user_modal::{BlockUserModalAction, BlockUserRequest}, home::{editing_pane::{EditingPaneState, EditingPaneWidgetExt, EditingPaneWidgetRefExt}, location_preview::{LocationPreviewWidgetExt, LocationPreviewWidgetRefExt}, room_screen::{MessageAction, populate_preview_of_timeline_item}, rooms_list::RoomsListRef, tombstone_footer::{SuccessorRoomDetails, TombstoneFooterWidgetExt}, upload_progress::{UploadProgressViewWidgetRefExt, UploadState}}, join_leave_room_modal::{JoinLeaveModalKind, JoinLeaveRoomModalAction}, location::init_location_subscriber, profile::user_profile::{ShowUserProfileAction, UserProfile, UserProfileAndRoomId}, room::BasicRoomDetails, settings::app_preferences::{AppPreferencesAction, AppPreferencesGlobal}, shared::{avatar::{AvatarState, AvatarWidgetRefExt}, file_upload_modal::{AttachmentUpload, FileUploadAttemptId, PendingUpload, handle_picked_file, handle_picker_launch_errors}, html_or_plaintext::HtmlOrPlaintextWidgetRefExt, mentionable_text_input::{MentionableTextInputWidgetExt, MentionableTextInputWidgetRefExt, MentionableTextInputState}, popup_list::{PopupKind, enqueue_popup_notification}, room_input_popup_menu::RoomInputPopupMenuAction, slash_commands::{SlashCommandAction, SlashCommandOutcome}, styles::*}, sliding_sync::{MatrixRequest, TimelineKind, UserPowerLevels, submit_async_request}, utils};
 use crate::room::reply_preview::CollapsiblePreviewWidgetRefExt;
 
 script_mod! {
@@ -526,12 +526,13 @@ impl RoomInputBar {
                     }),
                 )
             }
-            SlashCommandAction::IgnoreUser { user_id, ignore } => {
-                submit_async_request(MatrixRequest::IgnoreUser {
-                    ignore,
+            SlashCommandAction::BlockUser { user_id, block } => {
+                cx.action(BlockUserModalAction::Open(BlockUserRequest {
                     user_id,
-                    room_id: room_id.clone(),
-                })
+                    display_name: None,
+                    block,
+                    reject_invite_to: None,
+                }))
             }
             SlashCommandAction::SetDisplayName(new_display_name) => {
                 submit_async_request(MatrixRequest::SetDisplayName {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -3,12 +3,14 @@ use makepad_widgets::ScriptVm;
 pub mod settings_screen;
 pub mod account_settings;
 pub mod app_settings;
+pub mod privacy_settings;
 pub mod about_settings;
 pub mod app_preferences;
 
 pub fn script_mod(vm: &mut ScriptVm) {
     account_settings::script_mod(vm);
     app_settings::script_mod(vm);
+    privacy_settings::script_mod(vm);
     about_settings::script_mod(vm);
     settings_screen::script_mod(vm);
 }

--- a/src/settings/privacy_settings.rs
+++ b/src/settings/privacy_settings.rs
@@ -1,0 +1,204 @@
+//! Privacy-related settings within the SettingsScreen.
+//!
+//! Currently this just includes the list of blocked/ignored users.
+
+use makepad_widgets::*;
+use matrix_sdk::ruma::OwnedUserId;
+
+use crate::{
+    block_user_modal::{BlockUserModalAction, BlockUserRequest},
+    sliding_sync::{BlockedUsersUpdated, get_blocked_users},
+};
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    // A single blocked user in the blocked users list.
+    mod.widgets.BlockedUserEntry = #(BlockedUserEntry::register_widget(vm)) {
+        width: Fill, height: Fit
+        flow: Down
+
+        View {
+            width: Fill, height: Fit
+            flow: Right,
+            padding: 10,
+            spacing: 10,
+            align: Align{y: 0.5}
+
+            unblock_button := RobrixPositiveIconButton {
+                height: mod.widgets.SETTINGS_BUTTON_HEIGHT,
+                padding: Inset{left: 12, right: 15}
+                icon_walk: Walk{width: 0, height: 0}
+                spacing: 0
+                text: "Unblock"
+            }
+
+            user_id := Label {
+                width: Fill, height: Fit
+                flow: Flow.Right{wrap: true},
+                max_lines: 2,
+                text_overflow: Ellipsis,
+                draw_text +: {
+                    color: (MESSAGE_TEXT_COLOR),
+                    text_style: theme.font_bold { font_size: 12 },
+                }
+            }
+        }
+
+        LineH { padding: 10, margin: Inset{left: 5, right: 5} }
+    }
+
+    mod.widgets.PrivacySettings = #(PrivacySettings::register_widget(vm)) {
+        width: Fill, height: Fit
+        flow: Down
+
+        LineH { width: 425, padding: 10, margin: Inset{top: 20, bottom: 5} }
+
+        TitleLabel {
+            text: "Privacy Settings"
+        }
+
+        SubsectionLabel {
+            text: "Blocked Users"
+        }
+
+        mod.widgets.SettingsSectionDescription {
+            body: "<ul><li>You won't see any messages or invites from a blocked user, in any room.</li></ul>"
+        }
+
+        no_blocked_users_label := View {
+            width: Fill, height: Fit
+            Label {
+                width: Fill, height: Fit
+                margin: Inset{top: 10, bottom: 8, left: 13, right: 10},
+                flow: Flow.Right{wrap: true},
+                draw_text +: {
+                    color: (COLOR_TEXT_WARNING_NOT_FOUND),
+                    text_style: MESSAGE_TEXT_STYLE { font_size: 11 },
+                }
+                text: "You haven't blocked anyone."
+            }
+        }
+
+        RoundedView {
+            width: Fill, height: Fit
+            margin: 5,
+
+            show_bg: true,
+            draw_bg +: {
+                color: #F6F8F9
+                border_radius: 4.0
+            }
+
+            blocked_users_list := FlatList {
+                width: Fill,
+                height: Fit,
+                spacing: 0.0
+                flow: Down,
+
+                grab_key_focus: true,
+                drag_scrolling: true,
+                scroll_bars: ScrollBars { show_scroll_x: false, show_scroll_y: false },
+
+                blocked_user_entry := mod.widgets.BlockedUserEntry { }
+            }
+        }
+    }
+}
+
+
+/// A single blocked user shown in the list of blocked users.
+///
+/// Note that this intentionally excludes the blocked users' display names
+/// and avatars, and they may be offensive and our current user won't want to see them.
+#[derive(Script, ScriptHook, Widget)]
+pub struct BlockedUserEntry {
+    #[deref] view: View,
+    #[rust] user_id: Option<OwnedUserId>,
+}
+
+impl Widget for BlockedUserEntry {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+
+        let Some(user_id) = self.user_id.as_ref() else { return };
+        let Event::Actions(actions) = event else { return };
+        if self.view.button(cx, ids!(unblock_button)).clicked(actions) {
+            cx.action(BlockUserModalAction::Open(BlockUserRequest {
+                user_id: user_id.clone(),
+                display_name: None,
+                block: false,
+                reject_invite_to: None,
+            }));
+        }
+        if actions.iter().any(|a| matches!(a.downcast_ref(), Some(BlockUserModalAction::Close))) {
+            self.view.button(cx, ids!(unblock_button)).reset_hover(cx);
+        }
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let user_id = scope.props.get::<OwnedUserId>().unwrap();
+        self.view.label(cx, ids!(user_id)).set_text(cx, user_id.as_str());
+        if self.user_id.as_ref() != Some(user_id) {
+            self.user_id = Some(user_id.clone());
+        }
+
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+
+/// The privacy settings section, which lists the users blocked by this account.
+#[derive(Script, ScriptHook, Widget)]
+pub struct PrivacySettings {
+    #[deref] view: View,
+
+    /// The blocked users known to this widget, or `None` if they haven't been loaded yet.
+    #[rust] blocked_users: Option<Vec<OwnedUserId>>,
+}
+
+impl Widget for PrivacySettings {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if let Event::Actions(actions) = event {
+            for action in actions {
+                if let Some(BlockedUsersUpdated(blocked_users)) = action.downcast_ref() {
+                    self.blocked_users = Some(blocked_users.clone());
+                    self.view.redraw(cx);
+                }
+            }
+        }
+        self.view.handle_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let blocked_users = &*self.blocked_users.get_or_insert_with(get_blocked_users);
+        self.view.view(cx, ids!(no_blocked_users_label)).set_visible(cx, blocked_users.is_empty());
+
+        while let Some(subview) = self.view.draw_walk(cx, scope, walk).step() {
+            // Here, we only need to handle drawing the blocked users list.
+            let flat_list_ref = subview.as_flat_list();
+            let Some(mut list) = flat_list_ref.borrow_mut() else {
+                error!("!!! PrivacySettings::draw_walk(): BUG: expected a FlatList widget, but got something else");
+                continue;
+            };
+            for user_id in blocked_users {
+                if let Some(item) = list.item(cx, LiveId::from_str(user_id.as_str()), id!(blocked_user_entry)) {
+                    item.draw_all(cx, &mut Scope::with_props(user_id));
+                }
+            }
+            // Drop the entries for any users who were unblocked and removed from this list.
+            list.items.retain_visible();
+        }
+        DrawStep::done()
+    }
+}
+
+impl PrivacySettingsRef {
+    /// Reloads the list of blocked users shown by this section.
+    pub fn populate(&self, cx: &mut Cx) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.blocked_users = Some(get_blocked_users());
+        inner.redraw(cx);
+    }
+}

--- a/src/settings/settings_screen.rs
+++ b/src/settings/settings_screen.rs
@@ -1,7 +1,7 @@
 
 use makepad_widgets::*;
 
-use crate::{app::AppState, home::navigation_tab_bar::{NavigationBarAction, SelectedTab, get_own_profile}, profile::user_profile::UserProfile, settings::{PopulateMode, account_settings::AccountSettingsWidgetExt, app_settings::AppSettingsWidgetExt}};
+use crate::{app::AppState, home::navigation_tab_bar::{NavigationBarAction, SelectedTab, get_own_profile}, profile::user_profile::UserProfile, settings::{PopulateMode, account_settings::AccountSettingsWidgetExt, app_settings::AppSettingsWidgetExt, privacy_settings::PrivacySettingsWidgetExt}};
 
 script_mod! {
     use mod.prelude.widgets.*
@@ -58,6 +58,9 @@ script_mod! {
 
                 // The Robrix app settings section.
                 app_settings := AppSettings {}
+
+                // The privacy settings section.
+                privacy_settings := PrivacySettings {}
 
                 // The TSP wallet settings section.
                 tsp_settings_screen := TspSettingsScreen {}
@@ -210,6 +213,7 @@ impl SettingsScreen {
             PopulateMode::Initial => {
                 self.view.account_settings(cx, ids!(account_settings)).populate(cx, profile);
                 self.view.app_settings(cx, ids!(app_settings)).populate(cx, &app_state.app_prefs);
+                self.view.privacy_settings(cx, ids!(privacy_settings)).populate(cx);
             }
             PopulateMode::AfterReapply => {
                 self.view.account_settings(cx, ids!(account_settings)).restore_after_reapply(cx);

--- a/src/shared/slash_commands.rs
+++ b/src/shared/slash_commands.rs
@@ -105,16 +105,16 @@ pub static SLASH_COMMANDS: &[SlashCommand] = &[
         usage: "/whois <user-id>",
     },
     SlashCommand {
-        name: "ignore",
-        aliases: &["block"],
-        description: "Hide/block all messages from a user",
-        usage: "/ignore <user-id>",
+        name: "block",
+        aliases: &["ignore"],
+        description: "Hide all messages and invites from a user",
+        usage: "/block <user-id>",
     },
     SlashCommand {
-        name: "unignore",
-        aliases: &["unblock"],
-        description: "Stop hiding/blocking a user's messages",
-        usage: "/unignore <user-id>",
+        name: "unblock",
+        aliases: &["unignore"],
+        description: "Stop hiding a user's messages and invites",
+        usage: "/unblock <user-id>",
     },
     SlashCommand {
         name: "nick",
@@ -175,10 +175,11 @@ pub enum SlashCommandAction {
     OpenDirectMessage(OwnedUserId),
     /// Show the given user's profile pane.
     ShowUserProfile(OwnedUserId),
-    /// Ignore (`true`) or unignore (`false`) the given user.
-    IgnoreUser {
+    /// Block (`true`) or unblock (`false`) the given user.
+    #[doc(alias("ignore", "unignore"))]
+    BlockUser {
         user_id: OwnedUserId,
-        ignore: bool,
+        block: bool,
     },
     /// Set the current user's display name across all rooms.
     SetDisplayName(String),
@@ -227,7 +228,7 @@ pub fn parse_input(text: &str) -> SlashCommandOutcome {
     }
 
     // Commands focused on a single user all take one argument, so parse it once.
-    if let "dm" | "invite" | "whois" | "ignore" | "unignore" = command.name {
+    if let "dm" | "invite" | "whois" | "block" | "unblock" = command.name {
         let Some(user_id) = parse_user_id(arg) else {
             return SlashCommandOutcome::Error(format!(
                 "\"{arg}\" isn't a valid user ID; it should look like @user:server.org"
@@ -237,8 +238,8 @@ pub fn parse_input(text: &str) -> SlashCommandOutcome {
             "dm" => SlashCommandAction::OpenDirectMessage(user_id),
             "invite" => SlashCommandAction::InviteUser(user_id),
             "whois" => SlashCommandAction::ShowUserProfile(user_id),
-            "ignore" => SlashCommandAction::IgnoreUser { user_id, ignore: true },
-            _ => SlashCommandAction::IgnoreUser { user_id, ignore: false },
+            "block" => SlashCommandAction::BlockUser { user_id, block: true },
+            _ => SlashCommandAction::BlockUser { user_id, block: false },
         });
     }
 
@@ -548,12 +549,12 @@ mod tests_slash_commands {
         assert!(matches!(action("/msg @bob:server.org"), SlashCommandAction::OpenDirectMessage(_)));
         assert!(matches!(action("/query @bob:server.org"), SlashCommandAction::OpenDirectMessage(_)));
         assert!(matches!(
-            action("/block @bob:server.org"),
-            SlashCommandAction::IgnoreUser { ignore: true, .. },
+            action("/ignore @bob:server.org"),
+            SlashCommandAction::BlockUser { block: true, .. },
         ));
         assert!(matches!(
-            action("/unblock @bob:server.org"),
-            SlashCommandAction::IgnoreUser { ignore: false, .. },
+            action("/unignore @bob:server.org"),
+            SlashCommandAction::BlockUser { block: false, .. },
         ));
     }
 
@@ -706,18 +707,18 @@ mod tests_slash_commands {
     #[test]
     fn user_commands_require_a_full_user_id() {
         assert!(error("/invite bob").contains("@user:server.org"));
-        assert!(error("/ignore @bob").contains("@user:server.org"));
+        assert!(error("/block @bob").contains("@user:server.org"));
 
         let user_id = UserId::parse("@bob:server.org").unwrap();
         assert!(matches!(action("/invite @bob:server.org"), SlashCommandAction::InviteUser(u) if u == user_id));
         assert!(matches!(action("/whois @bob:server.org"), SlashCommandAction::ShowUserProfile(u) if u == user_id));
         assert!(matches!(
-            action("/ignore @bob:server.org"),
-            SlashCommandAction::IgnoreUser { ignore: true, .. },
+            action("/block @bob:server.org"),
+            SlashCommandAction::BlockUser { block: true, .. },
         ));
         assert!(matches!(
-            action("/unignore @bob:server.org"),
-            SlashCommandAction::IgnoreUser { ignore: false, .. },
+            action("/unblock @bob:server.org"),
+            SlashCommandAction::BlockUser { block: false, .. },
         ));
     }
 

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -37,7 +37,7 @@ use std::io;
 use hashbrown::{HashMap, HashSet};
 use crate::{
     app::AppStateAction, app_data_dir, cache_dir, avatar_cache::AvatarUpdate, event_preview::{BeforeText, TextPreview, text_preview_of_raw_timeline_event, text_preview_of_timeline_item}, home::{
-        add_room::KnockResultAction, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::LinkPreviewData, room_screen::{InviteResultAction, TimelineUpdate, index_of_event}, rooms_list::{self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, RoomsListUpdate, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, send_status_indicator::stringify_send_error, tombstone_footer::SuccessorRoomDetails
+        add_room::KnockResultAction, invite_screen::{JoinRoomResultAction, LeaveRoomResultAction}, link_preview::LinkPreviewData, room_screen::{InviteResultAction, TimelineUpdate, index_of_event}, rooms_list::{self, InvitedRoomInfo, InviterInfo, JoinedRoomInfo, LatestEventPreview, RoomsListUpdate, enqueue_rooms_list_update}, rooms_list_header::RoomsListHeaderAction, send_status_indicator::stringify_send_error, tombstone_footer::SuccessorRoomDetails
     }, login::login_screen::LoginAction, logout::{logout_confirm_modal::LogoutAction, logout_state_machine::{LogoutConfig, is_logout_in_progress, logout_with_state_machine}}, media_cache::{MediaCacheEntry, MediaCacheEntryRef}, persistence::{self, ClientSessionPersisted, load_app_state}, profile::{
         user_profile::UserProfile,
         user_profile_cache::{UserProfileUpdate, enqueue_user_profile_update},
@@ -360,6 +360,12 @@ pub enum AccountDataAction {
     AccountManagementUrlFetched(AccountManagementUrl),
 }
 
+/// An action broadcast when the account's list of blocked users changes.
+///
+/// Contains the new list, sorted by user ID.
+#[derive(Clone, Debug)]
+pub struct BlockedUsersUpdated(pub Vec<OwnedUserId>);
+
 /// Actions emitted in response to a [`MatrixRequest::OpenOrCreateDirectMessage`].
 #[derive(Debug)]
 pub enum DirectMessageRoomAction {
@@ -612,13 +618,12 @@ pub enum MatrixRequest {
         /// * If `true` (default is false), the link will include an action hint to join the room.
         join_on_click: bool,
     },
-    /// Request to ignore/block or unignore/unblock a user.
-    IgnoreUser {
+    /// Request to block or unblock a user.
+    #[doc(alias("ignore", "unignore"))]
+    BlockUser {
         user_id: OwnedUserId,
-        /// Whether to ignore (`true`) or unignore (`false`) the user.
-        ignore: bool,
-        /// The room that the user was (un)ignored in, so we can re-paginate it.
-        room_id: OwnedRoomId,
+        /// Whether to block (`true`) or unblock (`false`) the user.
+        block: bool,
     },
     /// Request to set or remove the avatar of the current user's account.
     SetAvatar {
@@ -1870,61 +1875,34 @@ async fn matrix_worker_task(
                 });
             }
 
-            MatrixRequest::IgnoreUser { ignore, user_id, room_id } => {
+            MatrixRequest::BlockUser { block, user_id } => {
                 let Some(client) = get_client() else { continue };
-                let _ignore_task = Handle::current().spawn(async move {
-                    log!("Sending request to {}ignore user: {user_id}...", if ignore { "" } else { "un" });
-                    let ignore_result = if ignore {
+                let _block_task = Handle::current().spawn(async move {
+                    log!("Sending request to {}block user: {user_id}...", if block { "" } else { "un" });
+                    let block_result = if block {
                         client.account().ignore_user(&user_id).await
                     } else {
                         client.account().unignore_user(&user_id).await
                     };
 
-                    if let Err(e) = ignore_result {
-                        error!("Failed to {}ignore user {user_id}: {e:?}", if ignore { "" } else { "un" });
+                    if let Err(e) = block_result {
+                        error!("Failed to {}block user {user_id}: {e:?}", if block { "" } else { "un" });
                         enqueue_popup_notification(
-                            format!("Couldn't {}ignore {user_id}. Error: {e}", if ignore { "" } else { "un" }),
+                            format!("Couldn't {}block {user_id}. Error: {e}", if block { "" } else { "un" }),
                             PopupKind::Error,
                             None,
                         );
                         return;
                     }
-                    log!("Successfully {}ignored user {user_id}.", if ignore { "" } else { "un" });
+                    log!("Successfully {}blocked user {user_id}.", if block { "" } else { "un" });
                     enqueue_popup_notification(
-                        format!("{} ignoring {user_id}.", if ignore { "Now" } else { "No longer" }),
+                        format!("{} blocking {user_id}.", if block { "Now" } else { "No longer" }),
                         PopupKind::Success,
                         Some(4.0),
                     );
-
-                    // We need to re-acquire the `RoomMember` object now that its state
-                    // has changed, i.e., the user has been (un)ignored.
-                    // We then need to send an update to replace the cached `RoomMember`
-                    // with the now-stale ignored state.
-                    if let Some(room) = client.get_room(&room_id) {
-                        if let Ok(Some(new_room_member)) = room.get_member(&user_id).await {
-                            log!("Enqueueing user profile update for user {user_id}, who is now {}ignored.",
-                                if new_room_member.is_ignored() { "" } else { "un" },
-                            );
-                            enqueue_user_profile_update(UserProfileUpdate::RoomMemberOnly {
-                                room_id: room_id.clone(),
-                                room_member: new_room_member,
-                            });
-                        }
-                    }
-
-                    // After successfully (un)ignoring a user, all timelines are fully cleared by the Matrix SDK.
-                    // Therefore, we need to re-fetch all timelines for all rooms,
-                    // and currently the only way to actually accomplish this is via pagination.
-                    // See: <https://github.com/matrix-org/matrix-rust-sdk/issues/1703#issuecomment-2250297923>
-                    //
-                    // Note that here we only proactively re-paginate the *current* room
-                    // (the one being viewed by the user when this ignore request was issued),
-                    // and all other rooms will be re-paginated in `handle_ignore_user_list_subscriber()`.`
-                    submit_async_request(MatrixRequest::PaginateTimeline {
-                        timeline_kind: TimelineKind::MainRoom { room_id },
-                        num_events: 50,
-                        direction: PaginationDirection::Backwards,
-                    });
+                    // Upon the next sync, the blocked user list will be updated, which will cause
+                    // the matrix SDK to clear each timeline, at which point the visible timelines
+                    // will re-paginate themselves.
                 });
             }
 
@@ -3076,19 +3054,23 @@ pub fn stop_sync_service_for_shutdown(timeout: Duration) -> Result<(), Elapsed> 
     result
 }
 
-/// The list of users that the current user has chosen to ignore.
+/// The list of users that the current user has chosen to block.
 /// Ideally we shouldn't have to maintain this list ourselves,
-/// but the Matrix SDK doesn't currently properly maintain the list of ignored users.
-static IGNORED_USERS: Mutex<HashSet<OwnedUserId, ConstHasher>> = Mutex::new(HashSet::with_hasher(BuildHasherDefault::new()));
+/// but the Matrix SDK doesn't currently properly maintain the list of blocked users.
+static BLOCKED_USERS: Mutex<HashSet<OwnedUserId, ConstHasher>> = Mutex::new(HashSet::with_hasher(BuildHasherDefault::new()));
 
-/// Returns a deep clone of the current list of ignored users.
-pub fn get_ignored_users() -> HashSet<OwnedUserId, ConstHasher> {
-    IGNORED_USERS.lock().unwrap().clone()
+/// Returns a sorted list of the currently blocked users.
+#[doc(alias("ignored"))]
+pub fn get_blocked_users() -> Vec<OwnedUserId> {
+    let mut users: Vec<_> = BLOCKED_USERS.lock().unwrap().iter().cloned().collect();
+    users.sort_unstable();
+    users
 }
 
-/// Returns whether the given user ID is currently being ignored.
-pub fn is_user_ignored(user_id: &UserId) -> bool {
-    IGNORED_USERS.lock().unwrap().contains(user_id)
+/// Returns whether the given user ID is currently blocked.
+#[doc(alias("ignored"))]
+pub fn is_user_blocked(user_id: &UserId) -> bool {
+    BLOCKED_USERS.lock().unwrap().contains(user_id)
 }
 
 
@@ -3415,8 +3397,8 @@ async fn start_matrix_client_login_and_sync(rt: Handle) {
         // Listen for changes to our verification status and incoming verification requests.
         subscriber_task_handles.push(add_verification_event_handlers_and_sync_client(client.clone()));
 
-        // Listen for updates to the ignored user list.
-        subscriber_task_handles.push(handle_ignore_user_list_subscriber(client.clone()));
+        // Listen for updates to the blocked user list.
+        subscriber_task_handles.push(handle_blocked_user_list_subscriber(client.clone()));
 
         // Listen for session changes, e.g., when the access token becomes invalid.
         subscriber_task_handles.push(handle_session_changes(client.clone()));
@@ -4277,10 +4259,10 @@ async fn add_new_room(
     Ok(())
 }
 
-#[allow(unused)]
-async fn current_ignore_user_list(client: &Client) -> Option<HashSet<OwnedUserId>> {
+/// Reads the account-wide list of blocked users from the account data in the local store.
+async fn current_blocked_user_list(client: &Client) -> Option<HashSet<OwnedUserId, ConstHasher>> {
     use matrix_sdk::ruma::events::ignored_user_list::IgnoredUserListEventContent;
-    let ignored_users = client.account()
+    let blocked_users = client.account()
         .account_data::<IgnoredUserListEventContent>()
         .await
         .ok()??
@@ -4290,45 +4272,39 @@ async fn current_ignore_user_list(client: &Client) -> Option<HashSet<OwnedUserId
         .into_keys()
         .collect();
 
-    Some(ignored_users)
+    Some(blocked_users)
 }
 
+/// Replaces the list of blocked users, emitting a [`BlockedUsersUpdated`] action if it changed.
+fn set_blocked_users(new_list: HashSet<OwnedUserId, ConstHasher>) {
+    let mut blocked_users = BLOCKED_USERS.lock().unwrap();
+    if *blocked_users == new_list {
+        return;
+    }
+    *blocked_users = new_list;
+    drop(blocked_users);
+    Cx::post_action(BlockedUsersUpdated(get_blocked_users()));
+}
+
+/// Listens for changes to the list of blocked users.
+///
 /// This function spawns a task that captures a strong `Client` ref,
 /// so the caller should abort+await it upon logout to ensure the Client gets dropped.
-fn handle_ignore_user_list_subscriber(client: Client) -> JoinHandle<()> {
+fn handle_blocked_user_list_subscriber(client: Client) -> JoinHandle<()> {
     let mut subscriber = client.subscribe_to_ignore_user_list_changes();
-    log!("Initial ignored-user list is: {:?}", subscriber.get());
     Handle::current().spawn(async move {
-        let mut first_update = true;
-        while let Some(ignore_list) = subscriber.next().await {
-            log!("Received an updated ignored-user list: {ignore_list:?}");
-            let ignored_users_new = ignore_list
+        if let Some(initial_list) = current_blocked_user_list(&client).await {
+            log!("Initial blocked-user list is: {initial_list:?}");
+            set_blocked_users(initial_list);
+        }
+
+        while let Some(blocked_list) = subscriber.next().await {
+            log!("Received an updated blocked-user list: {blocked_list:?}");
+            let blocked_users_new = blocked_list
                 .into_iter()
                 .filter_map(|u| OwnedUserId::try_from(u).ok())
                 .collect::<HashSet<_, ConstHasher>>();
-
-            // TODO: when we support persistent state, don't forget to update `IGNORED_USERS` upon app boot.
-            let mut ignored_users_old = IGNORED_USERS.lock().unwrap();
-            let has_changed = *ignored_users_old != ignored_users_new;
-            *ignored_users_old = ignored_users_new;
-
-            if has_changed && !first_update {
-                // After successfully (un)ignoring a user, all timelines are fully cleared by the Matrix SDK.
-                // Therefore, we need to re-fetch all timelines for all rooms,
-                // and currently the only way to actually accomplish this is via pagination.
-                // See: <https://github.com/matrix-org/matrix-rust-sdk/issues/1703#issuecomment-2250297923>
-                for joined_room in client.joined_rooms() {
-                    submit_async_request(MatrixRequest::PaginateTimeline {
-                        timeline_kind: TimelineKind::MainRoom {
-                            room_id: joined_room.room_id().to_owned(),
-                        },
-                        num_events: 50,
-                        direction: PaginationDirection::Backwards,
-                    });
-                }
-            }
-
-            first_update = false;
+            set_blocked_users(blocked_users_new);
         }
     })
 }
@@ -4884,7 +4860,7 @@ async fn text_preview_of_latest_thread_reply(
 async fn get_latest_event_details(
     latest_event_value: &LatestEventValue,
     client: &Client,
-) -> Option<(MilliSecondsSinceUnixEpoch, String)> {
+) -> Option<LatestEventPreview> {
     macro_rules! get_sender_username {
         ($profile:expr, $sender:expr, $is_own:expr) => {{
             match $profile {
@@ -4903,13 +4879,19 @@ async fn get_latest_event_details(
     match latest_event_value {
         LatestEventValue::None => None,
         LatestEventValue::Remote { timestamp, sender, is_own, profile, content } => {
+            // Don't show previews for a message sent by a blocked user.
+            // The SDK usually won't give us these, but a cached latest event instance
+            // could still be in use by the UI, so this is just an extra precaution.
+            if is_user_blocked(sender) {
+                return None;
+            }
             let sender_username = get_sender_username!(profile, sender, *is_own);
-            let latest_message_text = text_preview_of_timeline_item(
+            let text = text_preview_of_timeline_item(
                 content,
                 sender,
                 &sender_username,
             ).format_with(&sender_username, true);
-            Some((*timestamp, latest_message_text))
+            Some(LatestEventPreview { timestamp: *timestamp, text, sender: Some(sender.clone()) })
         }
         LatestEventValue::Local { timestamp, sender, profile, content, state: _ } => {
             // TODO: use the `state` enum to augment the preview text with more details.
@@ -4917,15 +4899,19 @@ async fn get_latest_event_details(
             //                "<span color="red">Failed to send {msg}</span>"
             let is_own = current_user_id().is_some_and(|id| &id == sender);
             let sender_username = get_sender_username!(profile, sender, is_own);
-            let latest_message_text = text_preview_of_timeline_item(
+            let text = text_preview_of_timeline_item(
                 content,
                 sender,
                 &sender_username,
             ).format_with(&sender_username, true);
-            Some((*timestamp, latest_message_text))
+            Some(LatestEventPreview { timestamp: *timestamp, text, sender: Some(sender.clone()) })
         }
         LatestEventValue::RemoteInvite { timestamp, .. } => {
-            Some((*timestamp, String::from("You were invited to this room.")))
+            Some(LatestEventPreview {
+                timestamp: *timestamp,
+                text: String::from("You were invited to this room."),
+                sender: None,
+            })
         }
     }    
 }
@@ -4935,14 +4921,13 @@ async fn get_latest_event_details(
 /// This function sends a `RoomsListUpdate::UpdateLatestEvent`
 /// to update the latest event in the RoomsListEntry for the given room.
 async fn update_latest_event(room: &Room) {
-    if let Some((timestamp, latest_message_text)) = get_latest_event_details(
+    if let Some(latest) = get_latest_event_details(
         &room.latest_event().await,
         &room.client(),
     ).await {
         enqueue_rooms_list_update(RoomsListUpdate::UpdateLatestEvent {
             room_id: room.room_id().to_owned(),
-            timestamp,
-            latest_message_text,
+            latest,
         });
     }
 }
@@ -5908,7 +5893,7 @@ pub async fn clear_app_state(config: &LogoutConfig) -> Result<()> {
     CLIENT.lock().unwrap().take();
     SYNC_SERVICE.lock().unwrap().take();
     SYNC_SERVICE_ASSUMED_RUNNING.store(false, Ordering::Release);
-    IGNORED_USERS.lock().unwrap().clear();
+    set_blocked_users(HashSet::default());
     ALL_JOINED_ROOMS.lock().unwrap().clear();
     OWN_DISPLAY_NAME.lock().unwrap().take();
     LOGOUT_NOTIFY.notify_one();


### PR DESCRIPTION
This completes everything surrounding blocked (ignored) users. We also always show a confirmation modal now for blocking and unblocking a user, since it's a more serious action.

Use the term "block" everywhere instead of "ignore", as it's more common.

There's a new privacy settings screen, which currenlty only shows the list of blocked users, with an option to unblock each one.

The invite screen now offers a "Reject and block user" button, like in other clients.

We also make it much more efficient to re-paginate rooms after a user is blocked or unblocked (since all their timelines get wiped by the SDK). There are other improvements here too, like clearing out message previews sent by blocked users.

Closes #1020