### PR TITLE
Show an error banner if a failed message is blocking a room's send queue

### DIFF
--- a/src/block_user_modal.rs
+++ b/src/block_user_modal.rs
@@ -26,7 +26,7 @@ script_mod! {
 
         buttons_view := ModalButtonsRow {
             cancel_button := RobrixNeutralIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon.svg: (ICON_CLOSE)

--- a/src/home/failed_send_banner.rs
+++ b/src/home/failed_send_banner.rs
@@ -1,0 +1,163 @@
+//! A banner above the message composer, shown while a failed message
+//! is blocking everything queued behind it in this room.
+
+use std::cell::RefCell;
+use std::sync::Arc;
+
+use makepad_widgets::*;
+use matrix_sdk_ui::timeline::TimelineEventItemId;
+
+use crate::app::ConfirmDeleteAction;
+use crate::home::send_status_indicator::{is_send_error_retryable, stringify_send_error};
+use crate::shared::confirmation_modal::ConfirmationModalContent;
+use crate::sliding_sync::{MatrixRequest, TimelineKind, submit_async_request};
+
+script_mod! {
+    use mod.prelude.widgets.*
+    use mod.widgets.*
+
+    mod.widgets.FailedSendBanner = set_type_default() do #(FailedSendBanner::register_widget(vm)) {
+        ..mod.widgets.RoundedView
+
+        visible: false
+        width: Fill,
+        height: Fit,
+        flow: Down,
+        spacing: 10,
+        margin: Inset{left: 4, right: 4, bottom: 4},
+        padding: Inset{left: 12.0, top: 10.0, bottom: 10.0, right: 10.0}
+
+        show_bg: true
+        draw_bg +: {
+            color: (COLOR_PRIMARY)
+            border_radius: 5.0
+            border_color: #E34B4F
+            border_size: 2.0
+        }
+
+        reason_label := Label {
+            width: Fill,
+            height: Fit,
+            padding: Inset{ top: 1, left: 1, right: 1, bottom: 0 }
+            flow: Flow.Right { wrap: true },
+            max_lines: 2,
+            draw_text +: {
+                color: (COLOR_FG_DANGER_RED),
+                text_style: REGULAR_TEXT {font_size: 10}
+            }
+            text: ""
+        }
+
+        button_row := View {
+            width: Fill,
+            height: Fit,
+            flow: Flow.Right { wrap: true },
+            spacing: 10,
+
+            retry_button := RobrixIconButton {
+                padding: 10,
+                draw_icon.svg: (ICON_SEND)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -1, right: -1}}
+                text: "Retry"
+            }
+
+            cancel_send_button := RobrixNegativeIconButton {
+                padding: 10,
+                draw_icon.svg: (ICON_FORBIDDEN)
+                icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -1, right: -1, top: -1}}
+                text: "Cancel Send"
+            }
+        }
+    }
+}
+
+/// The message that failed to send and is holding up this room's send queue.
+#[derive(Clone)]
+pub struct BlockedSend {
+    pub timeline_kind: TimelineKind,
+    pub timeline_event_id: TimelineEventItemId,
+    pub error: Arc<matrix_sdk::Error>,
+}
+
+#[derive(Script, ScriptHook, Widget)]
+pub struct FailedSendBanner {
+    #[deref] view: View,
+    #[rust] blocked: Option<BlockedSend>,
+}
+
+impl Widget for FailedSendBanner {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        if let Event::Actions(actions) = event
+            && let Some(blocked) = &self.blocked
+        {
+            if self.button(cx, ids!(button_row.retry_button)).clicked(actions) {
+                submit_async_request(MatrixRequest::RetrySend {
+                    timeline_kind: blocked.timeline_kind.clone(),
+                    timeline_event_id: blocked.timeline_event_id.clone(),
+                });
+            }
+            // Cancelling throws away what the user wrote, so make them confirm it.
+            if self.button(cx, ids!(button_row.cancel_send_button)).clicked(actions) {
+                let timeline_kind = blocked.timeline_kind.clone();
+                let timeline_event_id = blocked.timeline_event_id.clone();
+                let content = ConfirmationModalContent {
+                    title_text: "Cancel sending this message?".into(),
+                    body_text: "It won't be sent, and what you wrote will be discarded.".into(),
+                    accept_button_text: Some("Cancel Send".into()),
+                    cancel_button_text: Some("Keep It".into()),
+                    on_accept_clicked: Some(Box::new(move |_cx| {
+                        submit_async_request(MatrixRequest::RedactMessage {
+                            timeline_kind,
+                            timeline_event_id,
+                            reason: None,
+                        });
+                    })),
+                    ..Default::default()
+                };
+                cx.action(ConfirmDeleteAction::Show(RefCell::new(Some(content))));
+            }
+        }
+        self.view.handle_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.view.draw_walk(cx, scope, walk)
+    }
+}
+
+impl FailedSendBanner {
+    fn show_or_hide(&mut self, cx: &mut Cx, blocked: Option<BlockedSend>) {
+        // This runs on every timeline update, so don't touch the UI unless something changed.
+        let is_same = match (&self.blocked, &blocked) {
+            (None, None) => true,
+            (Some(shown), Some(new)) => shown.timeline_event_id == new.timeline_event_id
+                && Arc::ptr_eq(&shown.error, &new.error),
+            _ => false,
+        };
+        if is_same { return }
+
+        let Some(blocked) = blocked else {
+            self.blocked = None;
+            self.view.set_visible(cx, false);
+            self.redraw(cx);
+            return;
+        };
+        self.view.label(cx, ids!(reason_label)).set_text(
+            cx,
+            &format!("Couldn't send an earlier message: {}", stringify_send_error(&blocked.error)),
+        );
+        self.view.button(cx, ids!(button_row.retry_button))
+            .set_visible(cx, is_send_error_retryable(&blocked.error));
+        self.blocked = Some(blocked);
+        self.view.set_visible(cx, true);
+        self.redraw(cx);
+    }
+}
+
+impl FailedSendBannerRef {
+    /// See [`FailedSendBanner::show_or_hide()`].
+    pub fn show_or_hide(&self, cx: &mut Cx, blocked: Option<BlockedSend>) {
+        let Some(mut inner) = self.borrow_mut() else { return };
+        inner.show_or_hide(cx, blocked);
+    }
+}

--- a/src/home/invite_modal.rs
+++ b/src/home/invite_modal.rs
@@ -30,7 +30,7 @@ script_mod! {
 
         buttons_view := ModalButtonsRow {
             cancel_button := RobrixNeutralIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 12,
                 draw_icon.svg: (ICON_FORBIDDEN)
@@ -39,7 +39,7 @@ script_mod! {
             }
 
             confirm_button := RobrixPositiveIconButton {
-                width: 120
+                width: Fit{min: FitBound.Abs(120.0)}
                 align: Align{x: 0.5, y: 0.5}
                 padding: 12,
                 draw_icon.svg: (ICON_ADD_USER)
@@ -49,7 +49,7 @@ script_mod! {
 
             okay_button := RobrixIconButton {
                 visible: false
-                width: 120
+                width: Fit{min: FitBound.Abs(120.0)}
                 align: Align{x: 0.5, y: 0.5}
                 padding: 12,
                 draw_icon.svg: (ICON_CHECKMARK)

--- a/src/home/mod.rs
+++ b/src/home/mod.rs
@@ -4,6 +4,7 @@ pub mod add_room;
 pub mod edited_indicator;
 pub mod editing_pane;
 pub mod event_source_modal;
+pub mod failed_send_banner;
 pub mod home_screen;
 pub mod invite_modal;
 pub mod invite_screen;
@@ -52,6 +53,7 @@ pub fn script_mod(vm: &mut ScriptVm) {
     invite_modal::script_mod(vm);
     invite_screen::script_mod(vm);
     tombstone_footer::script_mod(vm);
+    failed_send_banner::script_mod(vm);
     room_screen::script_mod(vm);
     rooms_sidebar::script_mod(vm);
     welcome_screen::script_mod(vm);

--- a/src/home/room_screen.rs
+++ b/src/home/room_screen.rs
@@ -39,6 +39,7 @@ use crate::{
 };
 use crate::home::event_reaction_list::ReactionListWidgetRefExt;
 use crate::home::room_read_receipt::AvatarRowWidgetRefExt;
+use crate::home::failed_send_banner::{BlockedSend, FailedSendBannerWidgetExt};
 use crate::home::send_status_indicator::{self, SendStatusIndicatorAction, SendStatusIndicatorRef, SendStatusIndicatorWidgetExt};
 use crate::room::room_input_bar::RoomInputBarWidgetExt;
 use crate::settings::app_preferences::{AppPreferencesGlobal, MarkAsReadBehavior, preferred_receipt_type};
@@ -718,6 +719,9 @@ script_mod! {
 
                 // Below that, display a typing notice when other users in the room are typing.
                 typing_notice := TypingNotice { }
+
+                // Below that, warn about a failed message that is holding up this room's send queue.
+                failed_send_banner := FailedSendBanner { }
 
                 room_input_bar := RoomInputBar { }
             }
@@ -2256,6 +2260,18 @@ impl RoomScreen {
                 own_send_indices(&tl.items, tl.kind.thread_root_event_id().is_none());
         }
 
+        let blocked_send = tl.index_of_first_own_failed
+            .and_then(|i| tl.items.get(i))
+            .and_then(|item| item.as_event())
+            .and_then(|event| match event.send_state() {
+                Some(EventSendState::SendingFailed { error, .. }) => Some(BlockedSend {
+                    timeline_kind: tl.kind.clone(),
+                    timeline_event_id: event.identifier(),
+                    error: error.clone(),
+                }),
+                _ => None,
+            });
+
         if should_continue_backwards_pagination {
             tl.is_paginating = true;
             submit_async_request(MatrixRequest::PaginateTimeline {
@@ -2268,6 +2284,9 @@ impl RoomScreen {
         if done_loading {
             top_space.set_visible(cx, false);
         }
+
+        self.view.failed_send_banner(cx, ids!(failed_send_banner))
+            .show_or_hide(cx, blocked_send);
 
         if let Some(users) = typing_users {
             self.view

--- a/src/join_leave_room_modal.rs
+++ b/src/join_leave_room_modal.rs
@@ -24,7 +24,7 @@ script_mod! {
 
         buttons_view := ModalButtonsRow {
             cancel_button := RobrixNegativeIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon.svg: (ICON_FORBIDDEN)
@@ -33,7 +33,7 @@ script_mod! {
             }
 
             accept_button := RobrixPositiveIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon.svg: (ICON_CHECKMARK)

--- a/src/logout/logout_confirm_modal.rs
+++ b/src/logout/logout_confirm_modal.rs
@@ -25,7 +25,7 @@ script_mod! {
 
         buttons_view := ModalButtonsRow {
             cancel_button := RobrixNeutralIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 12,
                 draw_icon.svg: (ICON_FORBIDDEN)
@@ -34,7 +34,7 @@ script_mod! {
             }
 
             confirm_button := RobrixNegativeIconButton {
-                width: 120
+                width: Fit{min: FitBound.Abs(120.0)}
                 align: Align{x: 0.5, y: 0.5}
                 padding: 12,
                 draw_icon.svg: (ICON_LOGOUT)

--- a/src/shared/confirmation_modal.rs
+++ b/src/shared/confirmation_modal.rs
@@ -20,7 +20,7 @@ script_mod! {
 
         buttons_view := ModalButtonsRow {
             cancel_button := RobrixNeutralIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 icon_walk: Walk{width: 0, height: 0, margin: 0}
@@ -28,7 +28,7 @@ script_mod! {
             }
 
             accept_button := RobrixPositiveIconButton {
-                width: 120
+                width: Fit{min: FitBound.Abs(120.0)}
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 icon_walk: Walk{width: 0, height: 0, margin: 0}
@@ -57,14 +57,14 @@ script_mod! {
     mod.widgets.NegativeConfirmationModal = mod.widgets.ConfirmationModal {
         buttons_view +: {
             cancel_button := RobrixNeutralIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon +: { svg: (ICON_FORBIDDEN) }
                 icon_walk: Walk{width: 16, height: 16, margin: Inset{left: -2, right: -1}}
             }
             accept_button := RobrixNegativeIconButton {
-                width: 120,
+                width: Fit{min: FitBound.Abs(120.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon +: { svg: (ICON_TRASH) }

--- a/src/sliding_sync.rs
+++ b/src/sliding_sync.rs
@@ -4396,6 +4396,7 @@ const SEND_QUEUE_RETRY_DELAY: Duration = Duration::from_secs(5);
 /// What a queued send request was for.
 enum LocalSendKind {
     Message,
+    ThreadMessage,
     Attachment,
     Edit,
     Reaction { key: String },
@@ -4432,6 +4433,7 @@ fn handle_send_queue_subscriber(client: Client) -> JoinHandle<()> {
                                 LocalEchoContent::Event { serialized_event, .. } => match serialized_event.deserialize() {
                                     Ok(AnyMessageLikeEventContent::RoomMessage(msg)) => match msg.msgtype {
                                         _ if matches!(msg.relates_to, Some(Relation::Replacement(_))) => LocalSendKind::Edit,
+                                        _ if matches!(msg.relates_to, Some(Relation::Thread(_))) => LocalSendKind::ThreadMessage,
                                         MessageType::Image(_) | MessageType::Video(_)
                                         | MessageType::File(_) | MessageType::Audio(_) => LocalSendKind::Attachment,
                                         _ => LocalSendKind::Message,
@@ -4482,6 +4484,7 @@ fn handle_send_queue_subscriber(client: Client) -> JoinHandle<()> {
                             let desc = stringify_send_error(&error);
                             let msg = match kinds.get(&transaction_id) {
                                 Some(LocalSendKind::Message) => format!("Couldn't send a message in {room_name}: {desc}\n\nOpen the message's menu to edit, retry, or cancel it. Future messages won't send until you do."),
+                                Some(LocalSendKind::ThreadMessage) => format!("Couldn't send a thread reply in {room_name}: {desc}\n\nOpen that thread to retry or cancel it. Future messages won't send until you do."),
                                 Some(LocalSendKind::Attachment) => format!("Couldn't send an attachment in {room_name}: {desc}\n\nOpen the message's menu to retry or cancel it. Future messages won't send until you do."),
                                 Some(LocalSendKind::Edit) => format!("Couldn't send your edit in {room_name}: {desc}\n\nYour edit was discarded."),
                                 Some(LocalSendKind::Reaction { key }) => format!("Couldn't send your {key} reaction in {room_name}: {desc}"),

--- a/src/tsp/create_did_modal.rs
+++ b/src/tsp/create_did_modal.rs
@@ -171,7 +171,7 @@ script_mod! {
 
         buttons_view := ModalButtonsRow {
             cancel_button := RobrixNegativeIconButton {
-                width: 100,
+                width: Fit{min: FitBound.Abs(100.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon.svg: (ICON_FORBIDDEN)
@@ -180,7 +180,7 @@ script_mod! {
             }
 
             accept_button := RobrixPositiveIconButton {
-                width: 140
+                width: Fit{min: FitBound.Abs(140.0)}
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon.svg: (ICON_CHECKMARK)

--- a/src/tsp/create_wallet_modal.rs
+++ b/src/tsp/create_wallet_modal.rs
@@ -118,7 +118,7 @@ script_mod! {
 
         buttons_view := ModalButtonsRow {
             cancel_button := RobrixNegativeIconButton {
-                width: 100,
+                width: Fit{min: FitBound.Abs(100.0)},
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon.svg: (ICON_FORBIDDEN)
@@ -127,7 +127,7 @@ script_mod! {
             }
 
             accept_button := RobrixPositiveIconButton {
-                width: 140
+                width: Fit{min: FitBound.Abs(140.0)}
                 align: Align{x: 0.5, y: 0.5}
                 padding: 15,
                 draw_icon.svg: (ICON_CHECKMARK)


### PR DESCRIPTION
This appears above the room or thread timeline's input bar.

This is now required because the new Matrix SDK version sends messages strictly in the order they were enqueued in (which is good), but means that one stuck message will hold up everything else queued up to send after it.